### PR TITLE
Make OSM tile server configurable.

### DIFF
--- a/openstreetmap/README
+++ b/openstreetmap/README
@@ -1,0 +1,30 @@
+ ____ OpenStreetMap Plugin ____
+by Mike Macgirvin
+   Klaus Weidenbach
+
+This addon allows you to use OpenStreetMap for displaying locations.
+
+___ Requirements ___
+
+To use this plugin you need a tile Server that provides the maps.
+OpenStreetMap data is free for everyone to use. Their tile servers are not.
+Please take a look at their "Tile Usage Policy":
+http://wiki.openstreetmap.org/wiki/Tile_usage_policy
+You can run your own tile server or choose one from their list of public
+tile servers: http://wiki.openstreetmap.org/wiki/TMS
+Support the OpenStreetMap community and share the load.
+
+___ Configuration ___
+
+Open the .htconfig.php file and add "openstreetmap" to the list of activated
+addons.
+    $a->config['system']['addon'] = "openstreetmap, ..."
+
+You have to add two configuration variables for the addon:
+    $a->config['openstreetmap']['tmsserver'] = 'http://www.openstreetmap.org/';
+    $a->config['openstreetmap']['zoom'] = '18';
+
+The *tmsserver* points to the tile server you want to use. Use the full URL,
+with protocol (http/s) and trailing slash. You can configure the default zoom
+level on the map with *zoom*. 1 will show the whole world and 18 is the highest
+zoom level available.

--- a/openstreetmap/admin.tpl
+++ b/openstreetmap/admin.tpl
@@ -1,0 +1,3 @@
+{{ inc field_input.tpl with $field=$tmsserver }}{{ endinc }}
+{{ inc field_input.tpl with $field=$zoom }}{{ endinc }}
+<div class="submit"><input type="submit" name="page_site" value="$submit" /></div>


### PR DESCRIPTION
This patch makes it possible to configure the tile server used for serving the OpenStreetMap maps.
Add README with hints about the Tile Usage Policy (http://wiki.openstreetmap.org/wiki/Tile_usage_policy). A list of public available tile servers can be found here: http://wiki.openstreetmap.org/wiki/TMS
You can also configure the default zoom level.
