### PR TITLE
Bugfix: deactivating Real-Time Updates when updating the plugin

### DIFF
--- a/facebook/facebook.php
+++ b/facebook/facebook.php
@@ -46,6 +46,12 @@
  * authenticate to your site to establish identity. We will address this 
  * in a future release.
  */
+ 
+ /** TODO
+ * - Implement a method for the administrator to delete all configuration data the plugin has created,
+ *   e.g. the app_access_token
+ * - Implement a configuration option to set the polling interval system-wide
+ */
 
 define('FACEBOOK_MAXPOSTLEN', 420);
 
@@ -57,8 +63,6 @@ function facebook_install() {
 	register_hook('connector_settings',  'addon/facebook/facebook.php', 'facebook_plugin_settings');
 	register_hook('cron',             'addon/facebook/facebook.php', 'facebook_cron');
 	register_hook('queue_predeliver', 'addon/facebook/facebook.php', 'fb_queue_hook');
-	
-	if (get_config('facebook', 'realtime_active') == 1) facebook_subscription_add_users(); // Restore settings, if the plugin was installed before
 }
 
 
@@ -73,9 +77,6 @@ function facebook_uninstall() {
 	// hook moved
 	unregister_hook('post_local_end',  'addon/facebook/facebook.php', 'facebook_post_hook');
 	unregister_hook('plugin_settings',  'addon/facebook/facebook.php', 'facebook_plugin_settings');
-	
-	if (get_config('facebook', 'realtime_active') == 1) facebook_subscription_del_users();
-	del_config('facebook', 'app_access_token');
 }
 
 


### PR DESCRIPTION
The lines in the uninstall-hook deactivated the plugin not only when uninstalling it, but also when updating it. Yes, I know that's documented behavior - I didn't RTFM carfully enough :)
Some more error handling.
