### PR TITLE
Add Gravatar plugin.

### DIFF
--- a/gravatar/README.md
+++ b/gravatar/README.md
@@ -1,0 +1,42 @@
+# Gravatar Plugin
+by [Klaus Weidenbach](http://friendica.dszdw.net/profile/klaus)
+
+This addon allows you to look up an avatar image for new users and contacts at [Gravatar](http://www.gravatar.com). This will be used if there have not been found any other avatar images yet for example through OpenID.
+
+Gravatar is a popular, but centralized and proprietary service where people can store an avatar image for their email-addresses. It is widely used on many pages, for example to display an avatar for comment functions, profile pages, etc.
+
+* * *
+
+# Configuration
+## Default Avatar Image
+If no avatar was found for an email Gravatar can create some pseudo-random generated avatars based on an email hash. You can choose between these presets:
+
+* __Gravatar__: default static Gravatar logo
+* __MM__: (mystery-man) a static image
+* __Identicon__: a generated geometric pattern based on email hash
+* __Monsterid__: a generated 'monster' with different colors, faces, etc. based on email hash
+* __Wavatar__: faces with different features and backgrounds based on email hash
+* __Retro__: 8-bit arcade-styled pixelated faces based on email hash
+
+See examples at [Gravatar][1].
+## Avatar Rating
+Gravatar lets users self-rate their images to be used at appropriate audiences. Choose which are appropriate for your friendica site:
+
+* __g__: suitable for display on all wesites with any audience type
+* __pg__: may contain rude gestures, provocatively dressed individuals, the lesser swear words, or mild violence
+* __r__: may contain such things as harsh profanity, intense violence, nudity, or hard drug use
+* __x__: may contain hardcore sexual imagery or extremely disurbing violence
+
+See more information at [Gravatar][1].
+
+## Alternative Configuration
+Open the .htconfig.php file and add "gravatar" to the list of activated addons:
+
+        $a->config['system']['addon'] = "..., gravatar";
+
+You can add two configuration variables for the addon:
+
+        $a->config['gravatar']['default_avatar'] = "identicon";
+        $a->config['gravatar']['rating'] = "g";
+
+[1]: http://www.gravatar.com/site/implement/images/ "See documentation at Gravatar for more information"

--- a/gravatar/admin.tpl
+++ b/gravatar/admin.tpl
@@ -1,0 +1,3 @@
+{{ inc field_select.tpl with $field=$default_avatar}}{{ endinc }}
+{{ inc field_select.tpl with $field=$rating }}{{ endinc }}
+<div class="submit"><input type="submit" value="$submit" /></div>

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Name: Gravatar Support
+ * Description: If there is no avatar image for a new user or contact this plugin will look for one at Gravatar.
+ * Version: 1.0
+ * Author: Klaus Weidenbach <http://friendica.dszdw.net/profile/klaus>
+ */
+
+/**
+ * Installs the plugin hook
+ */
+function gravatar_install() {
+	register_hook('avatar_lookup', 'addon/gravatar/gravatar.php', 'gravatar_lookup');
+
+	logger("installed gravatar");
+}
+
+/**
+ * Removes the plugin hook
+ */
+function gravatar_uninstall() {
+	unregister_hook('avatar_lookup', 'addon/gravatar/gravatar.php', 'gravatar_lookup');
+
+	logger("uninstalled gravatar");
+}
+
+/**
+ * Looks up the avatar at gravatar.com and returns the URL.
+ *
+ * @param $a array
+ * @param &$b array
+ */
+function gravatar_lookup($a, &$b) {
+	$default_avatar = get_config('gravatar', 'default_img');
+	$rating = get_config('gravatar', 'rating');
+
+	// setting default value if nothing configured
+	if(! $default_avatar)
+		$default_avatar = 'identicon'; // pseudo-random geometric pattern based on email hash
+	if(! $rating)
+		$rating = 'g'; // suitable for display on all websites with any audience type
+
+	$hash = md5(trim(strtolower($b['email'])));
+
+	$url = 'http://www.gravatar.com/avatar/' .$hash .'.jpg';
+	$url .= '?s=' .$b['size'] .'&r=' .$rating;
+	if ($default_avatar != "gravatar")
+		$url .= '&d=' .$default_avatar;
+
+	$b['url'] = $url;
+}
+
+/**
+ * Display admin settings for this addon
+ */
+function gravatar_plugin_admin (&$a, &$o) {
+	$t = file_get_contents( dirname(__file__)."/admin.tpl");
+
+	$default_avatar = get_config('gravatar', 'default_img');
+	$rating = get_config('gravatar', 'rating');
+
+	// set default values for first configuration
+	if(! $default_avatar)
+		$default_avatar = 'identicon'; // pseudo-random geometric pattern based on email hash
+	if(! $rating)
+		$rating = 'g'; // suitable for display on all websites with any audience type
+
+	// Available options for the select boxes
+	$default_avatars = array(
+		'gravatar' => 'Gravatar',
+		'mm' => 'MM',
+		'identicon' => 'Identicon',
+		'monsterid' => 'Monsterid',
+		'wavatar' => 'Wavatar',
+		'retro' => 'Retro'
+	);
+	$ratings = array(
+		'g' => 'g',
+		'pg' => 'pg',
+		'r' => 'r',
+		'x' => 'x'
+	);
+
+	$o = '<input type="hidden" name="form_security_token" value="' .get_form_security_token("gravatarsave") .'">';
+	$o .= replace_macros( $t, array(
+		'$submit' => t('Submit'),
+		'$default_avatar' => array('avatar', t('Default avatar image'), $default_avatar, t('Select default avatar image if none was found at Gravatar. See README'), $default_avatars),
+		'$rating' => array('rating', t('Rating of images'), $rating, t('Select the appropriate avatar rating for your site. See README'), $ratings),
+	));
+}
+
+/**
+ * Save admin settings
+ */
+function gravatar_plugin_admin_post (&$a) {
+	check_form_security_token('gravatarsave');
+
+	$default_avatar = ((x($_POST, 'avatar')) ? notags(trim($_POST['avatar'])) : 'identicon');
+	$rating = ((x($_POST, 'rating')) ? notags(trim($_POST['rating'])) : 'g');
+	set_config('gravatar', 'default_img', $default_avatar);
+	set_config('gravatar', 'rating', $rating);
+	info( t('Gravatar settings updated.') .EOL);
+}
+?>


### PR DESCRIPTION
This plugin provides the default Gravatar lookup feature that has been in friendica's core before.
In addition it lets you choose the default avatar image type and select the allowed image rating.
Please review this patch together with the friendica core patch submited some minutes ago.
Thank you very much for your feedback.
