### PR TITLE
Added App::get_cached_avatar_image usage for displaying "Latest users" avatar thumbs in left sidebar of Community home page. 

### DIFF
--- a/communityhome/communityhome.php
+++ b/communityhome/communityhome.php
@@ -55,7 +55,7 @@ function communityhome_home(&$a, &$o){
 			$entry = replace_macros($tpl,array(
 				'$id' => $rr['id'],
 				'$profile-link' => $profile_link,
-				'$photo' => $rr[$photo],
+				'$photo' => $a->get_cached_avatar_image($rr[$photo]),
 				'$alt-text' => $rr['name'],
 			));
 			$aside['$lastusers_items'][] = $entry;


### PR DESCRIPTION
Requires: FRIENDICA_VERSION 3.0.1380+

App::get_cached_avatar_image provides shared profile image access and reduced sql queries/load.
