### PR TITLE
return 0 from get_body_length before loading the body to DomDocument if body is empty

### DIFF
--- a/showmore/showmore.php
+++ b/showmore/showmore.php
@@ -77,7 +77,7 @@ function get_body_length($body) {
 	// We need to get rid of hidden tags (display: none)
 
 	// Get rid of the warning. It would be better to have some valid html as input
-	$dom = DomDocument::loadHTML($body);
+	$dom = @DomDocument::loadHTML($body);
 	$xpath = new DOMXPath($dom);
 
 	/*


### PR DESCRIPTION
Fixes http://bugs.friendica.com/view.php?id=463
