### PR TITLE
twitter/statusnet mirroring: misspelled variable

### DIFF
--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -812,7 +812,7 @@ function statusnet_fetchtimeline($a, $uid) {
 		if ($post->id > $lastid)
 			$lastid = $post->id;
 
-		if ($firsttime)
+		if ($first_time)
 			continue;
 
 		if (is_object($post->retweeted_status))

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -616,7 +616,7 @@ function twitter_fetchtimeline($a, $uid) {
 		if ($post->id_str > $lastid)
 			$lastid = $post->id_str;
 
-		if ($firsttime)
+		if ($first_time)
 			continue;
 
 		if (!strpos($post->source, $application_name)) {


### PR DESCRIPTION
The test for the first fetching of items didn't work because of a misspelled variable name ...
