### PR TITLE
gpluspost: Wrong table used and some beautifying

### DIFF
--- a/gpluspost/gpluspost.php
+++ b/gpluspost/gpluspost.php
@@ -283,9 +283,6 @@ function gpluspost_feeditem($pid, $uid) {
 		if ($msglink == "")
 			$msglink = $item["plink"];
 
-		if ($image != $msglink)
-			$html = trim(str_replace($msglink, "", $html));
-
 		// Fetching the title - or the first line
 		if ($item["title"] != "")
 			$title = $item["title"];
@@ -293,6 +290,11 @@ function gpluspost_feeditem($pid, $uid) {
 			$lines = explode("\n", $msg);
 			$title = $lines[0];
 		}
+
+		if ($image != $msglink)
+			$html = trim(str_replace($msglink, "", $html));
+
+		$title = trim(str_replace($msglink, "", $title));
 
 		if ($uid == 0)
 			$title = $item["author-name"].": ".$title;


### PR DESCRIPTION
I used the table "contacts" where "user" would have been correct :) Further there is now a recycle sign for repeated items and URLs in the title are removed when they point to the URL in the article.
