### PR TITLE
facebook, statusnet and twitter: Now shared messages are clearly marked ...

### DIFF
--- a/fbpost/fbpost.php
+++ b/fbpost/fbpost.php
@@ -570,25 +570,25 @@ function fbpost_post_hook(&$a,&$b) {
 				$body = preg_replace( '/'.$recycle.'\[url\=(\w+.*?)\](\w+.*?)\[\/url\]/i', "\n\t$2:\t", $body);
 
 				// share element
-				$body = preg_replace_callback("/\[share(.*?)\]\s?(.*?)\s?\[\/share\]/ism","fbpost_ShareAttributes", $body);
+				//$body = preg_replace_callback("/\[share(.*?)\]\s?(.*?)\s?\[\/share\]/ism","fbpost_ShareAttributes", $body);
 
-				$bodyparts = explode("\t", $body);
+				//$bodyparts = explode("\t", $body);
 				// Doesn't help with multiple repeats - the problem has to be solved later
-				if (sizeof($bodyparts) == 3) {
-					$html = bbcode($bodyparts[2], false, false);
-					$test = trim(html2plain($html, 0, true));
+				//if (sizeof($bodyparts) == 3) {
+				//	$html = bbcode($bodyparts[2], false, false);
+				//	$test = trim(html2plain($html, 0, true));
 
-					if (trim($bodyparts[0]) == "")
-						$body = trim($bodyparts[2]);
-					else if (trim($test) == "")
-						$body = trim($bodyparts[0]);
-					else
-						$body = trim($bodyparts[0])."\n\n".trim($bodyparts[1])."[quote]".trim($bodyparts[2])."[/quote]";
-				} else
+				//	if (trim($bodyparts[0]) == "")
+				//		$body = trim($bodyparts[2]);
+				//	else if (trim($test) == "")
+				//		$body = trim($bodyparts[0]);
+				//	else
+				//		$body = trim($bodyparts[0])."\n\n".trim($bodyparts[1])."[quote]".trim($bodyparts[2])."[/quote]";
+				//} else
 					$body = str_replace("\t", "", $body);
 
 				// At first convert the text to html
-				$html = bbcode($body, false, false);
+				$html = bbcode($body, false, false, 2);
 
 				// Then convert it to plain text
 				$msg = trim($b['title']." \n\n".html2plain($html, 0, true));

--- a/fromgplus/fromgplus.php
+++ b/fromgplus/fromgplus.php
@@ -124,11 +124,16 @@ function fromgplus_post($a, $uid, $source, $body, $location) {
 	$_REQUEST['body'] = $body;
 	$_REQUEST['location'] = $location;
 
-        logger('fromgplus: posting for user '.$uid);
+	if (($_REQUEST['title'] == "") AND ($_REQUEST['body'] == "")) {
+	        logger('fromgplus: empty post for user '.$uid." ".print_r($_REQUEST, true));
+		return;
+	}
 
 	require_once('mod/item.php');
 	//print_r($_REQUEST);
+        logger('fromgplus: posting for user '.$uid." ".print_r($_REQUEST, true));
 	item_post($a);
+        logger('fromgplus: done for user '.$uid);
 }
 
 function fromgplus_html2bbcode($html) {

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -491,10 +491,10 @@ function statusnet_shortenmsg($b, $max_char) {
 	$body = preg_replace( '/'.$recycle.'\[url\=(\w+.*?)\](\w+.*?)\[\/url\]/i', "\n", $body);
 
 	// remove the share element
-	$body = preg_replace("/\[share(.*?)\](.*?)\[\/share\]/ism","\n\n$2\n\n",$body);
+	//$body = preg_replace("/\[share(.*?)\](.*?)\[\/share\]/ism","\n\n$2\n\n",$body);
 
 	// At first convert the text to html
-	$html = bbcode($body, false, false);
+	$html = bbcode($body, false, false, 2);
 
 	// Then convert it to plain text
 	//$msg = trim($b['title']." \n\n".html2plain($html, 0, true));

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -357,10 +357,10 @@ function twitter_shortenmsg($b) {
 	$body = preg_replace( '/'.$recycle.'\[url\=(\w+.*?)\](\w+.*?)\[\/url\]/i', "\n", $body);
 
 	// remove the share element
-	$body = preg_replace("/\[share(.*?)\](.*?)\[\/share\]/ism","\n\n$2\n\n",$body);
+	//$body = preg_replace("/\[share(.*?)\](.*?)\[\/share\]/ism","\n\n$2\n\n",$body);
 
 	// At first convert the text to html
-	$html = bbcode($body, false, false);
+	$html = bbcode($body, false, false, 2);
 
 	// Then convert it to plain text
 	//$msg = trim($b['title']." \n\n".html2plain($html, 0, true));
@@ -628,13 +628,7 @@ function twitter_post_hook(&$a,&$b) {
                         $image = $msgarr["image"];
 
 		// and now tweet it :-)
-		if(strlen($msg) and ($image == "")) {
-			$result = $tweet->post('statuses/update', array('status' => $msg));
-			logger('twitter_post send, result: ' . print_r($result, true), LOGGER_DEBUG);
-			if ($result->error) {
-				logger('Send to Twitter failed: "' . $result->error . '"');
-			}
-		} else if(strlen($msg) and ($image != "")) {
+		if(strlen($msg) and ($image != "")) {
 			$img_str = fetch_url($image);
 
 			$tempfile = tempnam(get_config("system","temppath"), "cache");
@@ -649,7 +643,16 @@ function twitter_post_hook(&$a,&$b) {
 			logger('twitter_post_with_media send, result: ' . print_r($result, true), LOGGER_DEBUG);
 			if ($result->error) {
 				logger('Send to Twitter failed: "' . $result->error . '"');
+				// Workaround: Remove the picture link so that the post can be reposted without it
+				$image = "";
 			}
+		}
+
+		if(strlen($msg) and ($image == "")) {
+			$result = $tweet->post('statuses/update', array('status' => $msg));
+			logger('twitter_post send, result: ' . print_r($result, true), LOGGER_DEBUG);
+			if ($result->error)
+				logger('Send to Twitter failed: "' . $result->error . '"');
 		}
 	}
 }


### PR DESCRIPTION
...with the name of the original poster

twitter: When a post with a picture failes than the post is repeated without a picture
fromgplus: Under certain circumenstances "fromgplus" generates an empty post that is blocking the cron hook - so now messages are mirrored anymore.
