### PR TITLE
Fix: Unset $groupchats variable in jappixmini produces syntax error

### DIFF
--- a/jappixmini/jappixmini.php
+++ b/jappixmini/jappixmini.php
@@ -499,7 +499,7 @@ function jappixmini_script(&$a,&$s) {
     $r = q("SELECT `username` FROM `user` WHERE `uid`=$uid");
     $nickname = json_encode($r[0]["username"]);
     $groupchats = get_config('jappixmini','groupchats');
-    //if $groupchats has no value jappix_addon_start will have an sytax error
+    //if $groupchats has no value jappix_addon_start will produce a syntax error
     if(!isset($groupchats)){
     	$groupchats = "{}";
     }


### PR DESCRIPTION
If $groupchats was unset, I got a javascript syntax error. This commit fixes that.
