### PR TITLE
pumpio, statusnet, tumblr, twitter, wordpress: Changed the way, shares are displayed

### DIFF
--- a/fbpost/fbpost.php
+++ b/fbpost/fbpost.php
@@ -764,7 +764,10 @@ function fbpost_post_hook(&$a,&$b) {
 						);
 					}
 					else {
-						if(! $likes) {
+						// Only add to queue if its a toplevel post.
+						// Sometimes posts are accepted from facebook although it telling an error
+						// This leads to endless comment flooding.
+						if(! $likes AND $toplevel) {
 							$r = q("SELECT `id` FROM `contact` WHERE `uid` = %d AND `self`", intval($b['uid']));
 							if (count($r))
 								$a->contact = $r[0]["id"];

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -428,13 +428,13 @@ function pumpio_send(&$a,&$b) {
 		if ($title != '')
 			$title = "<h4>".$title."</h4>";
 
-		$content = bbcode($b['body'], false, false);
+		$content = bbcode($b['body'], false, false, 4);
 
 		// Enhance the way, videos are displayed
-		$content = preg_replace('/<a.*?href="(https?:\/\/www.youtube.com\/.*?)".*?>(.*?)<\/a>/ism',"\n[url]$1[/url]\n",$content);
-		$content = preg_replace('/<a.*?href="(https?:\/\/youtu.be\/.*?)".*?>(.*?)<\/a>/ism',"\n$1\n",$content);
-		$content = preg_replace('/<a.*?href="(https?:\/\/vimeo.com\/.*?)".*?>(.*?)<\/a>/ism',"\n$1\n",$content);
-		$content = preg_replace('/<a.*?href="(https?:\/\/player.vimeo.com\/.*?)".*?>(.*?)<\/a>/ism',"\n$1\n",$content);
+		$content = preg_replace('/<a href="(https?:\/\/www.youtube.com\/.*?)".*?>(.*?)<\/a>/ism',"\n[url]$1[/url]\n",$content);
+		$content = preg_replace('/<a href="(https?:\/\/youtu.be\/.*?)".*?>(.*?)<\/a>/ism',"\n$1\n",$content);
+		$content = preg_replace('/<a href="(https?:\/\/vimeo.com\/.*?)".*?>(.*?)<\/a>/ism',"\n$1\n",$content);
+		$content = preg_replace('/<a href="(https?:\/\/player.vimeo.com\/.*?)".*?>(.*?)<\/a>/ism',"\n$1\n",$content);
 
 		$URLSearchString = "^\[\]";
 		$content = preg_replace_callback("/\[url\]([$URLSearchString]*)\[\/url\]/ism",'tryoembed',$content);

--- a/rendertime/rendertime.php
+++ b/rendertime/rendertime.php
@@ -26,10 +26,8 @@ function rendertime_page_end(&$a, &$o) {
 
 	$duration = microtime(true)-$a->performance["start"];
 
-	if (!is_site_admin())
-		return
-
-	$o = $o.'<div class="renderinfo">'.sprintf(t("Performance: Database: %s, Network: %s, Rendering: %s, Parser: %s, I/O: %s, Other: %s, Total: %s"),
+	if (is_site_admin())
+		$o = $o.'<div class="renderinfo">'.sprintf(t("Performance: Database: %s, Network: %s, Rendering: %s, Parser: %s, I/O: %s, Other: %s, Total: %s"),
 						round($a->performance["database"], 3),
 						round($a->performance["network"], 3),
 						round($a->performance["rendering"], 3),

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -448,19 +448,21 @@ function short_link($url) {
 } };
 
 function statusnet_shortenmsg($b, $max_char) {
+	require_once("include/api.php");
 	require_once("include/bbcode.php");
 	require_once("include/html2plain.php");
 
 	// Looking for the first image
+	$cleaned_body = api_clean_plain_items($b['body']);
 	$image = '';
-	if(preg_match("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/is",$b['body'],$matches))
+	if(preg_match("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/is",$cleaned_body,$matches))
 		$image = $matches[3];
 
 	if ($image == '')
-		if(preg_match("/\[img\](.*?)\[\/img\]/is",$b['body'],$matches))
+		if(preg_match("/\[img\](.*?)\[\/img\]/is",$cleaned_body,$matches))
 			$image = $matches[1];
 
-	$multipleimages = (strpos($b['body'], "[img") != strrpos($b['body'], "[img"));
+	$multipleimages = (strpos($cleaned_body, "[img") != strrpos($cleaned_body, "[img"));
 
 	// When saved into the database the content is sent through htmlspecialchars
 	// That means that we have to decode all image-urls
@@ -500,7 +502,7 @@ function statusnet_shortenmsg($b, $max_char) {
 	//$body = preg_replace("/\[share(.*?)\](.*?)\[\/share\]/ism","\n\n$2\n\n",$body);
 
 	// At first convert the text to html
-	$html = bbcode($body, false, false, 2);
+	$html = bbcode(api_clean_plain_items($body), false, false, 2, true);
 
 	// Then convert it to plain text
 	//$msg = trim($b['title']." \n\n".html2plain($html, 0, true));

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -350,18 +350,18 @@ function tumblr_send(&$a,&$b) {
 			$params['embed'] = $link;
 			if ($title != '')
 				$params['caption'] = '<h1><a href="'.$link.'">'.$title.
-							"</a></h1><p>".bbcode($body, false, false)."</p>";
+							"</a></h1><p>".bbcode($body, false, false, 4)."</p>";
 			else
-				$params['caption'] = bbcode($body, false, false);
+				$params['caption'] = bbcode($body, false, false, 4);
 		} else if (($link != '') and !$video) {
 			$params['type'] = "link";
 			$params['title'] = $title;
 			$params['url'] = $link;
-			$params['description'] = bbcode($b["body"], false, false);
+			$params['description'] = bbcode($b["body"], false, false, 4);
 		} else {
 			$params['type'] = "text";
 			$params['title'] = $title;
-			$params['body'] = bbcode($b['body'], false, false);
+			$params['body'] = bbcode($b['body'], false, false, 4);
 		}
 
 		$consumer_key = get_config('tumblr','consumer_key');

--- a/wppost/wppost.php
+++ b/wppost/wppost.php
@@ -194,7 +194,10 @@ function wppost_send(&$a,&$b) {
 
 			// If no bookmark is found then take the first line
 			if ($wptitle == '') {
-				$title = html2plain(bbcode($b['body'], false, false), 0, true)."\n";
+				// Remove the share element before fetching the first line
+				$title = trim(preg_replace("/\[share.*?\](.*?)\[\/share\]/ism","\n$1\n",$b['body']));
+
+				$title = html2plain(bbcode($title, false, false), 0, true)."\n";
 				$pos = strpos($title, "\n");
 				$trailer = "";
 				if (($pos == 0) or ($pos > 100)) {
@@ -207,7 +210,7 @@ function wppost_send(&$a,&$b) {
 		}
 
 		$title = '<title>' . (($wptitle) ? $wptitle : t('Post from Friendica')) . '</title>';
-		$post = bbcode($b['body'], false, false);
+		$post = bbcode($b['body'], false, false, 4);
 
 		// If a link goes to youtube then remove the stuff around it. Wordpress detects youtube links and embeds it
 		$post = preg_replace('/<a.*?href="(https?:\/\/www.youtube.com\/.*?)".*?>(.*?)<\/a>/ism',"\n$1\n",$post);


### PR DESCRIPTION
Shared items are now displayed in a more compact format.

For twitter and statusnet the messages now don't contain information from shared items anymore (since that sometimes lead to strange messages where your own message and the title made a strange context)

In twitter the system now looks for the entities (for urls) when importing tweets.
