### PR TITLE
statistics: A module to take part to the statistics at http://pods.jasonrobinson.me/

### DIFF
--- a/statistics_json/statistics_json.php
+++ b/statistics_json/statistics_json.php
@@ -71,7 +71,6 @@ function statistics_json_init() {
 
 	header("Content-Type: application/json");
 	echo json_encode($statistics);
-print_r($users);
 	logger("statistics_init: printed ".print_r($statistics, true));
 	killme();
 }


### PR DESCRIPTION
There is a statistics page at http://pods.jasonrobinson.me/ that collects some data from diaspora servers. This plugin returns all necessary data to be part of this collection.

It only returns aggregated data like the number of users and active users this month and during 6 months. It only counts users who wants to publish their profile.
