### PR TITLE
statistics: Network name and all posts

### DIFF
--- a/statistics_json/statistics_json.php
+++ b/statistics_json/statistics_json.php
@@ -91,7 +91,7 @@ function statistics_json_cron($a,$b) {
 			set_config('statistics_json','active_users_monthly', $active_users_monthly);
 	}
 
-	$posts = q("SELECT COUNT(*) AS local_posts FROM `item` WHERE `wall`");
+	$posts = q("SELECT COUNT(*) AS local_posts FROM `item` WHERE `wall` left(body, 6) != '[share'");
 
 	if (!is_array($posts))
 		$local_posts = -1;


### PR DESCRIPTION
I spoke with Jason from http://pods.jasonrobinson.me/ who asked me to add a network field. Additionally the counter now counts all posts - not only top posts.
