### PR TITLE
statistics: auto-registering the server.

### DIFF
--- a/statistics_json/statistics_json.php
+++ b/statistics_json/statistics_json.php
@@ -46,7 +46,7 @@ function statistics_json_cron($a,$b) {
 		$next = $last + (360 * 60);
 		if($next > time()) {
 			logger('statistics_json_cron: calculation intervall not reached');
-//			return;
+			return;
 		}
 	}
         logger('statistics_json_cron: cron_start');


### PR DESCRIPTION
When activated, the system will auto register itself. That means that the admin will only have to activate the addon - that's all. The developer of the statistics page told me that there were no problem even when the system would register itself multiple times.
