### PR TITLE
Re-enabling a once stopped mirroring now doesn't flood the timeline with old posts anymore.

### DIFF
--- a/fbpost/fbpost.php
+++ b/fbpost/fbpost.php
@@ -140,6 +140,9 @@ function fbpost_post(&$a) {
 		$value = ((x($_POST,'mirror_posts')) ? intval($_POST['mirror_posts']) : 0);
 		set_pconfig($uid,'facebook','mirror_posts', $value);
 
+		if (!$value)
+			del_pconfig($uid,'facebook','last_created');
+
 		$value = ((x($_POST,'suppress_view_on_friendica')) ? intval($_POST['suppress_view_on_friendica']) : 0);
 		set_pconfig($uid,'facebook','suppress_view_on_friendica', $value);
 

--- a/fromgplus/fromgplus.php
+++ b/fromgplus/fromgplus.php
@@ -71,6 +71,10 @@ function fromgplus_addon_settings_post(&$a,&$b) {
 		set_pconfig(local_user(),'fromgplus','account',trim($_POST['fromgplus-account']));
 		$enable = ((x($_POST,'fromgplus-enable')) ? intval($_POST['fromgplus-enable']) : 0);
 		set_pconfig(local_user(),'fromgplus','enable', $enable);
+
+		if (!$enable)
+			del_pconfig(local_user(),'fromgplus','lastdate');
+
 		info( t('Google+ Import Settings saved.') . EOL);
 	}
 }

--- a/gpluspost/gpluspost.php
+++ b/gpluspost/gpluspost.php
@@ -182,6 +182,9 @@ function gpluspost_settings_post(&$a,&$b) {
 			set_pconfig(local_user(),'fromgplus','account',trim($_POST['fromgplus-account']));
 			$enable = ((x($_POST,'fromgplus-enable')) ? intval($_POST['fromgplus-enable']) : 0);
 			set_pconfig(local_user(),'fromgplus','enable', $enable);
+
+			if (!$enable)
+				del_pconfig(local_user(),'fromgplus','lastdate');
 		}
 	}
 }

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -326,7 +326,7 @@ function pumpio_settings_post(&$a,&$b) {
 			set_pconfig(local_user(),'pumpio','post_by_default',intval($_POST['pumpio_bydefault']));
 
 			if (!$_POST['pumpio_mirror'])
-				set_pconfig(local_user(),'pumpio','lastdate', $lastdate);
+				del_pconfig(local_user(),'pumpio','lastdate');
 
 			//header("Location: ".$a->get_baseurl()."/pumpio/connect");
 		}

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -250,6 +250,10 @@ function statusnet_settings_post ($a,$post) {
 		set_pconfig(local_user(), 'statusnet', 'mirror_posts', intval($_POST['statusnet-mirror']));
 		set_pconfig(local_user(), 'statusnet', 'import', intval($_POST['statusnet-import']));
 		set_pconfig(local_user(), 'statusnet', 'create_user', intval($_POST['statusnet-create_user']));
+
+		if (!intval($_POST['statusnet-mirror']))
+			del_pconfig(local_user(),'statusnet','lastid');
+
 		info( t('StatusNet settings updated.') . EOL);
 	}}}}
 }

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -194,7 +194,11 @@ function twitter_settings_post ($a,$post) {
 		set_pconfig(local_user(), 'twitter', 'mirror_posts', intval($_POST['twitter-mirror']));
 		set_pconfig(local_user(), 'twitter', 'import', intval($_POST['twitter-import']));
 		set_pconfig(local_user(), 'twitter', 'create_user', intval($_POST['twitter-create_user']));
-                info( t('Twitter settings updated.') . EOL);
+
+                if (!intval($_POST['twitter-mirror']))
+                        del_pconfig(local_user(),'twitter','lastid');
+
+                info(t('Twitter settings updated.') . EOL);
 	}}
 }
 function twitter_settings(&$a,&$s) {


### PR DESCRIPTION
There was a problem when mirroring was once enabled, then stopped, then reenabled. The problem was that the system tried to fetch all postings from the time the mirroring once stopped. This is now changed.
