### PR TITLE
Use the original application name when mirroring posts

### DIFF
--- a/fbsync/fbsync.php
+++ b/fbsync/fbsync.php
@@ -216,6 +216,7 @@ function fbsync_createpost($a, $uid, $self, $contacts, $applications, $post, $cr
 	$access_token = get_pconfig($uid,'facebook','access_token');
 
 	require_once("include/oembed.php");
+	require_once("include/network.php");
 
 	// check if it was already imported
 	$r = q("SELECT * FROM `item` WHERE `uid` = %d AND `uri` = '%s' LIMIT 1",
@@ -339,6 +340,7 @@ function fbsync_createpost($a, $uid, $self, $contacts, $applications, $post, $cr
 	$type = "";
 
 	if (isset($post->attachment->name) and isset($post->attachment->href)) {
+		$post->attachment->href = original_url($post->attachment->href);
 		$oembed_data = oembed_fetch_url($post->attachment->href);
 		$type = $oembed_data->type;
 		if ($type == "rich")
@@ -390,6 +392,8 @@ function fbsync_createpost($a, $uid, $self, $contacts, $applications, $post, $cr
 						logger('fbsync_createpost: error fetching fbid '.$media->photo->fbid.' '.print_r($data, true), LOGGER_DEBUG);
 				}
 			}
+
+			$preview = fbpost_cleanpicture($preview);
 
 			if (isset($media->href) AND ($preview != "") AND ($media->href != ""))
 				$content .= "\n".'[url='.$media->href.'][img]'.$preview.'[/img][/url]';

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -532,6 +532,9 @@ function statusnet_post_hook(&$a,&$b) {
 		return;
 
 	// if posts comes from statusnet don't send it back
+	if($b['extid'] == NETWORK_STATUSNET)
+		return;
+
 	if($b['app'] == "StatusNet")
 		return;
 
@@ -829,7 +832,9 @@ function statusnet_fetchtimeline($a, $uid) {
 			$_REQUEST["type"] = "wall";
 			$_REQUEST["api_source"] = true;
 			$_REQUEST["profile_uid"] = $uid;
-			$_REQUEST["source"] = "StatusNet";
+			//$_REQUEST["source"] = "StatusNet";
+			$_REQUEST["source"] = $post->source;
+			$_REQUEST["extid"] = NETWORK_STATUSNET;
 
 			//$_REQUEST["date"] = $post->created_at;
 

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -438,6 +438,9 @@ function twitter_post_hook(&$a,&$b) {
 		return;
 
 	// if post comes from twitter don't send it back
+	if($b['extid'] == NETWORK_TWITTER)
+		return;
+
 	if($b['app'] == "Twitter")
 		return;
 
@@ -743,7 +746,9 @@ function twitter_fetchtimeline($a, $uid) {
 			$_REQUEST["type"] = "wall";
 			$_REQUEST["api_source"] = true;
 			$_REQUEST["profile_uid"] = $uid;
-			$_REQUEST["source"] = "Twitter";
+			//$_REQUEST["source"] = "Twitter";
+			$_REQUEST["source"] = $post->source;
+			$_REQUEST["extid"] = NETWORK_TWITTER;
 
 			//$_REQUEST["date"] = $post->created_at;
 


### PR DESCRIPTION
This change will only work with version 3.3.1. By now the original application name (instead of "Twitter" or "Facebook" will be used when mirroring posts.
