### PR TITLE
GNU Social, Pump.io, Twitter: Improved check for duplicated posts

### DIFF
--- a/convpath/convpath.php
+++ b/convpath/convpath.php
@@ -4,7 +4,7 @@
  * Description: Converts all internal paths according to the current scheme (http or https)
  * Version: 1.0
  * Author: Michael Vogel <https://pirati.ca/profile/heluecht>
- * 
+ * Status: Unsupported
  */
 
 function convpath_install() {

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -731,7 +731,7 @@ function pumpio_fetchtimeline(&$a, $uid) {
 					if ($receiver->id == "http://activityschema.org/collection/public")
 						$public = true;
 
-			if ($public AND !strstr($post->generator->displayName, $application_name)) {
+			if ($public AND !stristr($post->generator->displayName, $application_name)) {
 				require_once('include/html2bbcode.php');
 
 				$_SESSION["authenticated"] = true;

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -838,7 +838,7 @@ function statusnet_fetchtimeline($a, $uid) {
 		if ($post->in_reply_to_status_id != "")
 			continue;
 
-		if (!strpos($post->source, $application_name)) {
+		if (!stristr($post->source, $application_name)) {
 			$_SESSION["authenticated"] = true;
 			$_SESSION["uid"] = $uid;
 

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -751,7 +751,7 @@ function twitter_fetchtimeline($a, $uid) {
 		if ($first_time)
 			continue;
 
-		if (!strpos($post->source, $application_name)) {
+		if (!stristr($post->source, $application_name)) {
 			$_SESSION["authenticated"] = true;
 			$_SESSION["uid"] = $uid;
 


### PR DESCRIPTION
Hopefully this reduces the problem of mirrored posts that were originally posted from friendica.

Additionally I set "convpath" to unsupported since it is obsolete through the ssl settings we added in 3.3.2.