### PR TITLE
pumpio-Bugfix: Comments had a wrong network value in some cases

### DIFF
--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -1130,6 +1130,7 @@ function pumpio_dopost(&$a, $client, $uid, $self, $post, $own_id, $threadcomplet
 				$public = true;
 
 	$postarray = array();
+        $postarray['network'] = NETWORK_PUMPIO;
 	$postarray['gravity'] = 0;
 	$postarray['uid'] = $uid;
 	$postarray['wall'] = 0;


### PR DESCRIPTION
When comments were imported from pumpio they hadn't had "pumpio" as network source.