### PR TITLE
Improved loop detection for Google+, Pump.io, Twitter and GNU Social

### DIFF
--- a/fromgplus/fromgplus.php
+++ b/fromgplus/fromgplus.php
@@ -416,6 +416,7 @@ function fromgplus_fetch($a, $uid) {
 	$reversed = array_reverse($activities->items);
 
 	foreach($reversed as $item) {
+
 		if (strtotime($item->published) <= $initiallastdate)
 			continue;
 
@@ -431,14 +432,11 @@ function fromgplus_fetch($a, $uid) {
 		if ($first_time)
 			continue;
 
-		if ($item->access->description == "Public")
-
-			// Loop prevention - ignore postings from HootSuite
-			if ($item->provider->title == "HootSuite")
-				continue;
+		if ($item->access->description == "Public") {
 
 			// Loop prevention through the special blank from the googleplus connector
-			if (strstr($item->object->content, $blank))
+			//if (strstr($item->object->content, $blank))
+			if (strrpos($item->object->content, $blank) >= strlen($item->object->content) - 5)
 				continue;
 
 			switch($item->object->objectType) {
@@ -454,8 +452,8 @@ function fromgplus_fetch($a, $uid) {
 					else
 						$location = "";
 
-					fromgplus_post($a, $uid, "Google+", $post, $location);
-					//fromgplus_post($a, $uid, $item->provider->title, $post, $location);
+					//fromgplus_post($a, $uid, "Google+", $post, $location);
+					fromgplus_post($a, $uid, $item->provider->title, $post, $location);
 
 					break;
 
@@ -488,10 +486,11 @@ function fromgplus_fetch($a, $uid) {
 					else
 						$location = "";
 
-					fromgplus_post($a, $uid, "Google+", $post, $location);
-					//fromgplus_post($a, $uid, $item->provider->title, $post, $location);
+					//fromgplus_post($a, $uid, "Google+", $post, $location);
+					fromgplus_post($a, $uid, $item->provider->title, $post, $location);
 					break;
 			}
+		}
 	}
 	if ($lastdate != 0)
 		set_pconfig($uid,'fromgplus','lastdate', $lastdate);

--- a/gpluspost/gpluspost.php
+++ b/gpluspost/gpluspost.php
@@ -230,7 +230,7 @@ function gpluspost_send(&$a,&$b) {
 		return;
 
 	// if post comes from Google+ don't send it back
-	if (!get_pconfig($b["uid"],'gpluspost','no_loop_prevention') and ($b['app'] == "Google+"))
+	if (!get_pconfig($b["uid"],'gpluspost','no_loop_prevention') and (($b['app'] == "Google+") OR ($b["extid"] == NETWORK_GPLUS)))
 		return;
 
 	if (!gpluspost_nextscripts()) {

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -433,9 +433,6 @@ function pumpio_send(&$a,&$b) {
 
 		$title = trim($b['title']);
 
-		//if ($title != '')
-		//	$title = "<h4>".$title."</h4>";
-
 		$content = bbcode($b['body'], false, false, 4);
 
 		// Enhance the way, videos are displayed
@@ -502,6 +499,10 @@ function pumpio_send(&$a,&$b) {
 		$success = $client->CallAPI($url, 'POST', $params, array('FailOnAccessError'=>true, 'RequestContentType'=>'application/json'), $user);
 
 		if($success) {
+
+			if ($user->generator->displayName)
+				set_pconfig($b["uid"], "pumpio", "application_name", $user->generator->displayName);
+
 			$post_id = $user->object->id;
 			logger('pumpio_send '.$username.': success '.$post_id);
 			if($post_id AND $iscomment) {
@@ -672,8 +673,12 @@ function pumpio_fetchtimeline(&$a, $uid) {
 	$hostname = get_pconfig($uid, 'pumpio','host');
 	$username = get_pconfig($uid, "pumpio", "user");
 
-	$application_name  = get_config('pumpio', 'application_name');
-
+	//  get the application name for the pump.io app
+	//  1st try personal config, then system config and fallback to the
+	//  hostname of the node if neither one is set.
+	$application_name  = get_pconfig( $uid, 'pumpio', 'application_name');
+	if ($application_name == "")
+		$application_name  = get_config('pumpio', 'application_name');
 	if ($application_name == "")
 		$application_name = $a->get_hostname();
 

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -191,7 +191,7 @@ function statusnet_settings_post ($a,$post) {
 					set_pconfig(local_user(), 'statusnet', 'consumerkey', $asn['consumerkey'] );
 					set_pconfig(local_user(), 'statusnet', 'consumersecret', $asn['consumersecret'] );
 					set_pconfig(local_user(), 'statusnet', 'baseapi', $asn['apiurl'] );
-					set_pconfig(local_user(), 'statusnet', 'application_name', $asn['applicationname'] );
+					//set_pconfig(local_user(), 'statusnet', 'application_name', $asn['applicationname'] );
 				} else {
 					notice( t('Please contact your site administrator.<br />The provided API URL is not valid.').EOL.$asn['apiurl'].EOL );
 				}
@@ -210,7 +210,7 @@ function statusnet_settings_post ($a,$post) {
 			set_pconfig(local_user(), 'statusnet', 'consumerkey', $_POST['statusnet-consumerkey']);
 			set_pconfig(local_user(), 'statusnet', 'consumersecret', $_POST['statusnet-consumersecret']);
 			set_pconfig(local_user(), 'statusnet', 'baseapi', $apibase );
-			set_pconfig(local_user(), 'statusnet', 'application_name', $_POST['statusnet-applicationname'] );
+			//set_pconfig(local_user(), 'statusnet', 'application_name', $_POST['statusnet-applicationname'] );
 		} else {
 			//  the API path is not correct, maybe missing trailing / ?
 			$apibase = $apibase . '/';
@@ -328,8 +328,8 @@ function statusnet_settings(&$a,&$s) {
 		$s .= '<label id="statusnet-baseapi-label" for="statusnet-baseapi">'. t("Base API Path \x28remember the trailing /\x29") .'</label>';
 		$s .= '<input id="statusnet-baseapi" type="text" name="statusnet-baseapi" size="35" /><br />';
 		$s .= '<div class="clear"></div>';
-		$s .= '<label id="statusnet-applicationname-label" for="statusnet-applicationname">'.t('StatusNet application name').'</label>';
-		$s .= '<input id="statusnet-applicationname" type="text" name="statusnet-applicationname" size="35" /><br />';
+		//$s .= '<label id="statusnet-applicationname-label" for="statusnet-applicationname">'.t('StatusNet application name').'</label>';
+		//$s .= '<input id="statusnet-applicationname" type="text" name="statusnet-applicationname" size="35" /><br />';
 		$s .= '<p></p><div class="clear"></div>';
 		$s .= '<div class="settings-submit-wrapper" ><input type="submit" name="statusnet-submit" class="settings-submit" value="' . t('Save Settings') . '" /></div>';
 		$s .= '</div>';
@@ -637,7 +637,7 @@ function statusnet_plugin_admin_post(&$a){
 		    $apiurl=$apiurl.'/';
 		$secret=trim($_POST['secret'][$id]);
 		$key=trim($_POST['key'][$id]);
-		$applicationname = ((x($_POST, 'applicationname')) ? notags(trim($_POST['applicationname'][$id])):'');
+		//$applicationname = ((x($_POST, 'applicationname')) ? notags(trim($_POST['applicationname'][$id])):'');
 		if ($sitename!="" &&
 			$apiurl!="" &&
 			$secret!="" &&
@@ -649,7 +649,7 @@ function statusnet_plugin_admin_post(&$a){
 					'apiurl' => $apiurl,
 					'consumersecret' => $secret,
 					'consumerkey' => $key,
-					'applicationname' => $applicationname
+					//'applicationname' => $applicationname
 				);
 		}
 	}
@@ -669,7 +669,7 @@ function statusnet_plugin_admin(&$a, &$o){
 				'apiurl' => Array("apiurl[$id]", "Api url", $s['apiurl'], t("Base API Path \x28remember the trailing /\x29") ),
 				'secret' => Array("secret[$id]", "Secret", $s['consumersecret'], ""),
 				'key' => Array("key[$id]", "Key", $s['consumerkey'], ""),
-				'applicationname' => Array("applicationname[$id]", "Application name", $s['applicationname'], ""),
+				//'applicationname' => Array("applicationname[$id]", "Application name", $s['applicationname'], ""),
 				'delete' => Array("delete[$id]", "Delete", False , "Check to delete this preset"),
 			);
 		}
@@ -681,7 +681,7 @@ function statusnet_plugin_admin(&$a, &$o){
 		'apiurl' => Array("apiurl[$id]", "Api url", "", t("Base API Path \x28remember the trailing /\x29") ),
 		'secret' => Array("secret[$id]", t("Consumer Secret"), "", ""),
 		'key' => Array("key[$id]", t("Consumer Key"), "", ""),
-		'applicationname' => Array("applicationname[$id]", t("Application name"), "", ""),
+		//'applicationname' => Array("applicationname[$id]", t("Application name"), "", ""),
 	);
 
 	$t = get_markup_template( "admin.tpl", "addon/statusnet/" );

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -606,6 +606,10 @@ function statusnet_post_hook(&$a,&$b) {
 			//$result = $dent->post('statuses/update', $postdata);
 			logger('statusnet_post send, result: ' . print_r($result, true).
 				"\nmessage: ".$msg, LOGGER_DEBUG."\nOriginal post: ".print_r($b, true)."\nPost Data: ".print_r($postdata, true));
+
+			if ($result->source)
+				set_pconfig($b["uid"], "statusnet", "application_name", strip_tags($result->source));
+
 			if ($result->error) {
 				logger('Send to StatusNet failed: "'.$result->error.'"');
 			} elseif ($iscomment) {

--- a/statusnet/templates/admin.tpl
+++ b/statusnet/templates/admin.tpl
@@ -3,7 +3,7 @@
 	{{include file="field_input.tpl" field=$s.apiurl}}
 	{{include file="field_input.tpl" field=$s.secret}}
 	{{include file="field_input.tpl" field=$s.key}}
-	{{include file="field_input.tpl" field=$s.applicationname}}
+	<!-- {{include file="field_input.tpl" field=$s.applicationname}} -->
 	{{if $s.delete}}
 		{{include file="field_checkbox.tpl" field=$s.delete}}
 		<hr>

--- a/twitter/templates/admin.tpl
+++ b/twitter/templates/admin.tpl
@@ -1,4 +1,4 @@
 {{include file="field_input.tpl" field=$consumerkey}}
 {{include file="field_input.tpl" field=$consumersecret}}
-{{include file="field_input.tpl" field=$applicationname}}
+<!-- {{include file="field_input.tpl" field=$applicationname}} -->
 <div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -572,7 +572,7 @@ function twitter_plugin_admin_post(&$a){
 	$applicationname = ((x($_POST, 'applicationname')) ? notags(trim($_POST['applicationname'])):'');
 	set_config('twitter','consumerkey',$consumerkey);
 	set_config('twitter','consumersecret',$consumersecret);
-	set_config('twitter','application_name',$applicationname);
+	//set_config('twitter','application_name',$applicationname);
 	info( t('Settings updated.'). EOL );
 }
 function twitter_plugin_admin(&$a, &$o){
@@ -583,7 +583,7 @@ function twitter_plugin_admin(&$a, &$o){
 								// name, label, value, help, [extra values]
 		'$consumerkey' => array('consumerkey', t('Consumer key'),  get_config('twitter', 'consumerkey' ), ''),
 		'$consumersecret' => array('consumersecret', t('Consumer secret'),  get_config('twitter', 'consumersecret' ), ''),
-		'$applicationname' => array('applicationname', t('Name of the Twitter Application'), get_config('twitter','application_name'),t('Set this to the exact name you gave the app on twitter.com/apps to avoid mirroring postings from ~friendica back to ~friendica'))
+		//'$applicationname' => array('applicationname', t('Name of the Twitter Application'), get_config('twitter','application_name'),t('Set this to the exact name you gave the app on twitter.com/apps to avoid mirroring postings from ~friendica back to ~friendica'))
 	));
 }
 

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -506,6 +506,10 @@ function twitter_post_hook(&$a,&$b) {
 			unlink($tempfile);
 
 			logger('twitter_post_with_media send, result: ' . print_r($result, true), LOGGER_DEBUG);
+
+			if ($result->source)
+				set_config("twitter", "application_name", strip_tags($result->source));
+
 			if ($result->errors OR $result->error) {
 				logger('Send to Twitter failed: "' . print_r($result->errors, true) . '"');
 
@@ -531,6 +535,10 @@ function twitter_post_hook(&$a,&$b) {
 
 			$result = $tweet->post($url, $post);
 			logger('twitter_post send, result: ' . print_r($result, true), LOGGER_DEBUG);
+
+			if ($result->source)
+				set_config("twitter", "application_name", strip_tags($result->source));
+
 			if ($result->errors) {
 				logger('Send to Twitter failed: "' . print_r($result->errors, true) . '"');
 


### PR DESCRIPTION
In the past the problem existed that a bad configuration of the connectors lead to the situation of a posting loop. This shouldn't now happen anymore for pump.io, GNU Social and Twitter. The system now fetches the application name from the last post and writes it in the configuration. This should now be bullet proof.

Google+ was a different problem. There the system sometimes detected a posting loop where there was none.