### PR TITLE
Facebook: Improved privacy detection, changed permissions

### DIFF
--- a/fbpost/README.md
+++ b/fbpost/README.md
@@ -1,18 +1,10 @@
-Installing the Friendica/Facebook connector
+#### Installing the Friendica/Facebook connector
 
-Detailed instructions how to use this plugin can be found at
-the [How to: Friendica's Facebook Connector](https://github.com/friendica/friendica/wiki/How-to:-Friendica%E2%80%99s-Facebook-connector) page.
+Please register a Facebook application at [developers.facebook.com](https://developers.facebook.com/apps/async/create/platform-setup/dialog/)
 
-Vidoes and embeds will not be posted if there is no other content. Links 
-and images will be converted to a format suitable for the Facebook API and 
-long posts truncated - with a link to view the full post. 
+Chose "Website" as platform. Next you have to let your application be reviewed. You need these permissions for that:
 
-Facebook contacts will not be able to view private photos, as they are not able to
-authenticate to your site to establish identity. We will address this 
-in a future release.
+publish_actions, publish_pages, user_posts, user_photos, user_status, user_videos, manage_pages
 
-This addon will only post your entries to your Facebook account but won't fetch
-content from there.
+After your application was reviewed, your users can post to Facebook.
 
-Info: please make sure that you understand all aspects due to Friendica's 
-default licence which is: [MIT License](https://github.com/friendica/friendica/blob/master/LICENSE)

--- a/fbpost/fbpost.php
+++ b/fbpost/fbpost.php
@@ -248,9 +248,10 @@ function fbpost_content(&$a) {
 		$o .= '<div id="fbpost-enable-wrapper">';
 
 		//read_stream,publish_stream,manage_pages,photo_upload,user_groups,offline_access
+		//export_stream,read_stream,publish_stream,manage_pages,photo_upload,user_groups,publish_actions,user_friends,share_item,video_upload,status_update
 
-		$o .= '<a href="https://www.facebook.com/dialog/oauth?client_id=' . $appid . '&redirect_uri=' 
-			. $a->get_baseurl() . '/fbpost/' . $a->user['nickname'] . '&scope=export_stream,read_stream,publish_stream,manage_pages,photo_upload,user_groups,publish_actions,user_friends,share_item,video_upload,status_update">' . t('Install Facebook Post connector for this account.') . '</a>';
+		$o .= '<a href="https://www.facebook.com/dialog/oauth?client_id=' . $appid . '&redirect_uri='
+			. $a->get_baseurl() . '/fbpost/' . $a->user['nickname'] . '&scope=publish_actions,publish_pages,user_posts,user_photos,user_status,user_videos,manage_pages">' . t('Install Facebook Post connector for this account.') . '</a>';
 		$o .= '</div>';
 	}
 
@@ -261,8 +262,10 @@ function fbpost_content(&$a) {
 
 		$o .= '<div id="fbpost-enable-wrapper">';
 
-		$o .= '<a href="https://www.facebook.com/dialog/oauth?client_id=' . $appid . '&redirect_uri=' 
-			. $a->get_baseurl() . '/fbpost/' . $a->user['nickname'] . '&scope=export_stream,read_stream,publish_stream,manage_pages,photo_upload,user_groups,publish_actions,user_friends,share_item,video_upload,status_update">' . t('Re-authenticate [This is necessary whenever your Facebook password is changed.]') . '</a>';
+		//export_stream,read_stream,publish_stream,manage_pages,photo_upload,user_groups,publish_actions,user_friends,share_item,video_upload,status_update
+
+		$o .= '<a href="https://www.facebook.com/dialog/oauth?client_id=' . $appid . '&redirect_uri='
+			. $a->get_baseurl() . '/fbpost/' . $a->user['nickname'] . '&scope=publish_actions,publish_pages,user_posts,user_photos,user_status,user_videos,manage_pages">' . t('Re-authenticate [This is necessary whenever your Facebook password is changed.]') . '</a>';
 		$o .= '</div>';
 
 		$o .= '<div id="fbpost-post-default-form">';

--- a/fbpost/fbpost.php
+++ b/fbpost/fbpost.php
@@ -991,10 +991,14 @@ function fbpost_fetchwall($a, $uid) {
 
 	$access_token = get_pconfig($uid,'facebook','access_token');
 	$post_to_page = get_pconfig($uid,'facebook','post_to_page');
+	$mirror_page = get_pconfig($uid,'facebook','mirror_page');
 	$lastcreated = get_pconfig($uid,'facebook','last_created');
 
 	if ((int)$post_to_page == 0)
 		$post_to_page = "me";
+
+	if ((int)$mirror_page != 0)
+		$post_to_page = $mirror_page;
 
 	$url = "https://graph.facebook.com/".$post_to_page."/feed?access_token=".$access_token;
 
@@ -1021,7 +1025,8 @@ function fbpost_fetchwall($a, $uid) {
 		if ($item->application->id == get_config('facebook','appid'))
 			continue;
 
-		if(isset($item->privacy) && ($item->privacy->value !== 'EVERYONE') && ($item->privacy->value !== ''))
+		//if(isset($item->privacy) && ($item->privacy->value !== 'EVERYONE') && ($item->privacy->value !== ''))
+		if((isset($item->privacy) && ($item->privacy->value !== 'EVERYONE')) OR !isset($item->privacy))
 			continue;
 
 		if (($post_to_page != $item->from->id) AND ((int)$post_to_page != 0))
@@ -1091,7 +1096,13 @@ function fbpost_fetchwall($a, $uid) {
 				$data = json_decode($feed);
 				if (isset($data->images)) {
 					$pagedata["images"][0]["src"] = $data->images[0]->source;
-					logger('fbpost_fetchwall: got fbid image '.$preview, LOGGER_DEBUG);
+					logger('got fbid image from images for '.$item->object_id, LOGGER_DEBUG);
+				} elseif (isset($data->source)) {
+					$pagedata["images"][0]["src"] = $data->source;
+					logger('got fbid image from source for '.$item->object_id, LOGGER_DEBUG);
+				} elseif (isset($data->picture)) {
+					$pagedata["images"][0]["src"] = $data->picture;
+					logger('got fbid image from picture for '.$item->object_id, LOGGER_DEBUG);
 				}
 			}
 


### PR DESCRIPTION
The issue https://github.com/friendica/friendica/issues/1416 reported a bug that postings from hidden groups were posted through the mirror function. I guess this was a problem inside of Facebook. But additionally the code was improved.

The permissions for the Facebook app was changed to make it compatible to Facebook's new requirements. These new permissions don't allow anymore the synchronization via "fbsync" since Facebook doesn't allow this after 30th of April anymore

