### PR TITLE
The function to post to Diaspora doesn't support newer versions

### DIFF
--- a/diaspora/diaspora.php
+++ b/diaspora/diaspora.php
@@ -5,6 +5,7 @@
  * Description: Post to Diaspora
  * Version: 0.1
  * Author: Michael Vogel <heluecht@pirati.ca>
+ * Status: Unsupported
  */
 
 function diaspora_install() {


### PR DESCRIPTION
So this addon is set to "unsupported"