### PR TITLE
Statusnet is now GNU Social

### DIFF
--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Name: StatusNet Connector
- * Description: Relay public postings to a connected StatusNet account
+ * Name: GNU Social Connector
+ * Description: Relay public postings to a connected GNU Social account
  * Version: 1.0.5
  * Author: Tobias Diekershoff <https://f.diekershoff.de/profile/tobias>
  * Author: Michael Vogel <https://pirati.ca/profile/heluecht>
@@ -35,7 +35,7 @@
 
 
 /***
- * We have to alter the TwitterOAuth class a little bit to work with any StatusNet
+ * We have to alter the TwitterOAuth class a little bit to work with any GNU Social
  * installation abroad. Basically it's only make the API path variable and be happy.
  *
  * Thank you guys for the Twitter compatible API!
@@ -119,7 +119,7 @@ function statusnet_install() {
 	register_hook('jot_networks',    'addon/statusnet/statusnet.php', 'statusnet_jot_nets');
 	register_hook('cron', 'addon/statusnet/statusnet.php', 'statusnet_cron');
 	register_hook('prepare_body', 'addon/statusnet/statusnet.php', 'statusnet_prepare_body');
-	logger("installed statusnet");
+	logger("installed GNU Social");
 }
 
 
@@ -148,20 +148,20 @@ function statusnet_jot_nets(&$a,&$b) {
 		$statusnet_defpost = get_pconfig(local_user(),'statusnet','post_by_default');
 		$selected = ((intval($statusnet_defpost) == 1) ? ' checked="checked" ' : '');
 		$b .= '<div class="profile-jot-net"><input type="checkbox" name="statusnet_enable"' . $selected . ' value="1" /> ' 
-			. t('Post to StatusNet') . '</div>';
+			. t('Post to GNU Social') . '</div>';
 	}
 }
 
 function statusnet_settings_post ($a,$post) {
 	if(! local_user())
 		return;
-	// don't check statusnet settings if statusnet submit button is not clicked
+	// don't check GNU Social settings if GNU Social submit button is not clicked
 	if (!x($_POST,'statusnet-submit'))
 		return;
 
 	if (isset($_POST['statusnet-disconnect'])) {
 		/***
-		 * if the statusnet-disconnect checkbox is set, clear the statusnet configuration
+		 * if the GNU Social-disconnect checkbox is set, clear the GNU Social configuration
 		 */
 		del_pconfig(local_user(), 'statusnet', 'consumerkey');
 		del_pconfig(local_user(), 'statusnet', 'consumersecret');
@@ -178,7 +178,7 @@ function statusnet_settings_post ($a,$post) {
 	} else {
 	if (isset($_POST['statusnet-preconf-apiurl'])) {
 		/***
-		 * If the user used one of the preconfigured StatusNet server credentials
+		 * If the user used one of the preconfigured GNU Social server credentials
 		 * use them. All the data are available in the global config.
 		 * Check the API Url never the less and blame the admin if it's not working ^^
 		 */
@@ -200,7 +200,7 @@ function statusnet_settings_post ($a,$post) {
 		goaway($a->get_baseurl().'/settings/connectors');
 	} else {
 	if (isset($_POST['statusnet-consumersecret'])) {
-		//  check if we can reach the API of the StatusNet server
+		//  check if we can reach the API of the GNU Social server
 		//  we'll check the API Version for that, if we don't get one we'll try to fix the path but will
 		//  resign quickly after this one try to fix the path ;-)
 		$apibase = $_POST['statusnet-baseapi'];
@@ -222,18 +222,18 @@ function statusnet_settings_post ($a,$post) {
 				set_pconfig(local_user(), 'statusnet', 'baseapi', $apibase );
 			} else {
 				//  still not the correct API base, let's do noting
-				notice( t('We could not contact the StatusNet API with the Path you entered.').EOL );
+				notice( t('We could not contact the GNU Social API with the Path you entered.').EOL );
 			}
 		}
 		goaway($a->get_baseurl().'/settings/connectors');
 	} else {
 	if (isset($_POST['statusnet-pin'])) {
-		//  if the user supplied us with a PIN from StatusNet, let the magic of OAuth happen
+		//  if the user supplied us with a PIN from GNU Social, let the magic of OAuth happen
 		$api     = get_pconfig(local_user(), 'statusnet', 'baseapi');
 		$ckey    = get_pconfig(local_user(), 'statusnet', 'consumerkey'  );
 		$csecret = get_pconfig(local_user(), 'statusnet', 'consumersecret' );
 		//  the token and secret for which the PIN was generated were hidden in the settings
-		//  form as token and token2, we need a new connection to StatusNet using these token
+		//  form as token and token2, we need a new connection to GNU Social using these token
 		//  and secret to request a Access Token with the PIN
 		$connection = new StatusNetOAuth($api, $ckey, $csecret, $_POST['statusnet-token'], $_POST['statusnet-token2']);
 		$token   = $connection->getAccessToken( $_POST['statusnet-pin'] );
@@ -256,7 +256,7 @@ function statusnet_settings_post ($a,$post) {
 		if (!intval($_POST['statusnet-mirror']))
 			del_pconfig(local_user(),'statusnet','lastid');
 
-		info( t('StatusNet settings updated.') . EOL);
+		info( t('GNU Social settings updated.') . EOL);
 	}}}}
 }
 function statusnet_settings(&$a,&$s) {
@@ -291,11 +291,11 @@ function statusnet_settings(&$a,&$s) {
 	$css = (($enabled) ? '' : '-disabled');
 
 	$s .= '<span id="settings_statusnet_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose(\'settings_statusnet_expanded\'); openClose(\'settings_statusnet_inflated\');">';
-	$s .= '<img class="connector'.$css.'" src="images/gnusocial.png" /><h3 class="connector">'. t('StatusNet Import/Export/Mirror').'</h3>';
+	$s .= '<img class="connector'.$css.'" src="images/gnusocial.png" /><h3 class="connector">'. t('GNU Social Import/Export/Mirror').'</h3>';
 	$s .= '</span>';
 	$s .= '<div id="settings_statusnet_expanded" class="settings-block" style="display: none;">';
 	$s .= '<span class="fakelink" onclick="openClose(\'settings_statusnet_expanded\'); openClose(\'settings_statusnet_inflated\');">';
-	$s .= '<img class="connector'.$css.'" src="images/gnusocial.png" /><h3 class="connector">'. t('StatusNet Import/Export/Mirror').'</h3>';
+	$s .= '<img class="connector'.$css.'" src="images/gnusocial.png" /><h3 class="connector">'. t('GNU Social Import/Export/Mirror').'</h3>';
 	$s .= '</span>';
 
 	if ( (!$ckey) && (!$csecret) ) {
@@ -304,14 +304,14 @@ function statusnet_settings(&$a,&$s) {
 		 */
 		$globalsn = get_config('statusnet', 'sites');
 		/***
-		 * lets check if we have one or more globally configured StatusNet
+		 * lets check if we have one or more globally configured GNU Social
 		 * server OAuth credentials in the configuration. If so offer them
 		 * with a little explanation to the user as choice - otherwise
 		 * ignore this option entirely.
 		 */
 		if (! $globalsn == null) {
-			$s .= '<h4>' . t('Globally Available StatusNet OAuthKeys') . '</h4>';
-			$s .= '<p>'. t("There are preconfigured OAuth key pairs for some StatusNet servers available. If you are using one of them, please use these credentials. If not feel free to connect to any other StatusNet instance \x28see below\x29.") .'</p>';
+			$s .= '<h4>' . t('Globally Available GNU Social OAuthKeys') . '</h4>';
+			$s .= '<p>'. t("There are preconfigured OAuth key pairs for some GNU Social servers available. If you are using one of them, please use these credentials. If not feel free to connect to any other GNU Social instance \x28see below\x29.") .'</p>';
 			$s .= '<div id="statusnet-preconf-wrapper">';
 			foreach ($globalsn as $asn) {
 				$s .= '<input type="radio" name="statusnet-preconf-apiurl" value="'. $asn['apiurl'] .'">'. $asn['sitename'] .'<br />';
@@ -320,7 +320,7 @@ function statusnet_settings(&$a,&$s) {
 			$s .= '<div class="settings-submit-wrapper" ><input type="submit" name="statusnet-submit" class="settings-submit" value="' . t('Save Settings') . '" /></div>';
 		}
 		$s .= '<h4>' . t('Provide your own OAuth Credentials') . '</h4>';
-		$s .= '<p>'. t('No consumer key pair for StatusNet found. Register your Friendica Account as an desktop client on your StatusNet account, copy the consumer key pair here and enter the API base root.<br />Before you register your own OAuth key pair ask the administrator if there is already a key pair for this Friendica installation at your favorited StatusNet installation.') .'</p>';
+		$s .= '<p>'. t('No consumer key pair for GNU Social found. Register your Friendica Account as an desktop client on your GNU Social account, copy the consumer key pair here and enter the API base root.<br />Before you register your own OAuth key pair ask the administrator if there is already a key pair for this Friendica installation at your favorited GNU Social installation.') .'</p>';
 		$s .= '<div id="statusnet-consumer-wrapper">';
 		$s .= '<label id="statusnet-consumerkey-label" for="statusnet-consumerkey">'. t('OAuth Consumer Key') .'</label>';
 		$s .= '<input id="statusnet-consumerkey" type="text" name="statusnet-consumerkey" size="35" /><br />';
@@ -331,7 +331,7 @@ function statusnet_settings(&$a,&$s) {
 		$s .= '<label id="statusnet-baseapi-label" for="statusnet-baseapi">'. t("Base API Path \x28remember the trailing /\x29") .'</label>';
 		$s .= '<input id="statusnet-baseapi" type="text" name="statusnet-baseapi" size="35" /><br />';
 		$s .= '<div class="clear"></div>';
-		//$s .= '<label id="statusnet-applicationname-label" for="statusnet-applicationname">'.t('StatusNet application name').'</label>';
+		//$s .= '<label id="statusnet-applicationname-label" for="statusnet-applicationname">'.t('GNU Socialapplication name').'</label>';
 		//$s .= '<input id="statusnet-applicationname" type="text" name="statusnet-applicationname" size="35" /><br />';
 		$s .= '<p></p><div class="clear"></div>';
 		$s .= '<div class="settings-submit-wrapper" ><input type="submit" name="statusnet-submit" class="settings-submit" value="' . t('Save Settings') . '" /></div>';
@@ -342,10 +342,10 @@ function statusnet_settings(&$a,&$s) {
 		 */
 		if ( (!$otoken) && (!$osecret) ) {
 			/***
-			 * the user has not yet connected the account to statusnet
+			 * the user has not yet connected the account to GNU Social
 			 * get a temporary OAuth key/secret pair and display a button with
 			 * which the user can request a PIN to connect the account to a
-			 * account at statusnet
+			 * account at GNU Social
 			 */
 			$connection = new StatusNetOAuth($api, $ckey, $csecret);
 			$request_token = $connection->getRequestToken('oob');
@@ -353,10 +353,10 @@ function statusnet_settings(&$a,&$s) {
 			/***
 			 *  make some nice form
 			 */
-			$s .= '<p>'. t('To connect to your StatusNet account click the button below to get a security code from StatusNet which you have to copy into the input box below and submit the form. Only your <strong>public</strong> posts will be posted to StatusNet.') .'</p>';
-			$s .= '<a href="'.$connection->getAuthorizeURL($token,False).'" target="_statusnet"><img src="addon/statusnet/signinwithstatusnet.png" alt="'. t('Log in with StatusNet') .'"></a>';
+			$s .= '<p>'. t('To connect to your GNU Social account click the button below to get a security code from GNU Social which you have to copy into the input box below and submit the form. Only your <strong>public</strong> posts will be posted to GNU Social.') .'</p>';
+			$s .= '<a href="'.$connection->getAuthorizeURL($token,False).'" target="_statusnet"><img src="addon/statusnet/signinwithstatusnet.png" alt="'. t('Log in with GNU Social') .'"></a>';
 			$s .= '<div id="statusnet-pin-wrapper">';
-			$s .= '<label id="statusnet-pin-label" for="statusnet-pin">'. t('Copy the security code from StatusNet here') .'</label>';
+			$s .= '<label id="statusnet-pin-label" for="statusnet-pin">'. t('Copy the security code from GNU Social here') .'</label>';
 			$s .= '<input id="statusnet-pin" type="text" name="statusnet-pin" />';
 			$s .= '<input id="statusnet-token" type="hidden" name="statusnet-token" value="'.$token.'" />';
 			$s .= '<input id="statusnet-token2" type="hidden" name="statusnet-token2" value="'.$request_token['oauth_token_secret'].'" />';
@@ -364,32 +364,32 @@ function statusnet_settings(&$a,&$s) {
 			$s .= '<div class="settings-submit-wrapper" ><input type="submit" name="statusnet-submit" class="settings-submit" value="' . t('Save Settings') . '" /></div>';
 			$s .= '<h4>'.t('Cancel Connection Process').'</h4>';
 			$s .= '<div id="statusnet-cancel-wrapper">';
-			$s .= '<p>'.t('Current StatusNet API is').': '.$api.'</p>';
-			$s .= '<label id="statusnet-cancel-label" for="statusnet-cancel">'. t('Cancel StatusNet Connection') . '</label>';
+			$s .= '<p>'.t('Current GNU Social API is').': '.$api.'</p>';
+			$s .= '<label id="statusnet-cancel-label" for="statusnet-cancel">'. t('Cancel GNU Social Connection') . '</label>';
 			$s .= '<input id="statusnet-cancel" type="checkbox" name="statusnet-disconnect" value="1" />';
 			$s .= '</div><div class="clear"></div>';
 			$s .= '<div class="settings-submit-wrapper" ><input type="submit" name="statusnet-submit" class="settings-submit" value="' . t('Save Settings') . '" /></div>';
 		} else {
 			/***
 			 *  we have an OAuth key / secret pair for the user
-			 *  so let's give a chance to disable the postings to statusnet
+			 *  so let's give a chance to disable the postings to GNU Social
 			 */
 			$connection = new StatusNetOAuth($api,$ckey,$csecret,$otoken,$osecret);
 			$details = $connection->get('account/verify_credentials');
 			$s .= '<div id="statusnet-info" ><img id="statusnet-avatar" src="'.$details->profile_image_url.'" /><p id="statusnet-info-block">'. t('Currently connected to: ') .'<a href="'.$details->statusnet_profile_url.'" target="_statusnet">'.$details->screen_name.'</a><br /><em>'.$details->description.'</em></p></div>';
-			$s .= '<p>'. t('If enabled all your <strong>public</strong> postings can be posted to the associated StatusNet account. You can choose to do so by default (here) or for every posting separately in the posting options when writing the entry.') .'</p>';
+			$s .= '<p>'. t('If enabled all your <strong>public</strong> postings can be posted to the associated GNU Social account. You can choose to do so by default (here) or for every posting separately in the posting options when writing the entry.') .'</p>';
 			if ($a->user['hidewall']) {
-			    $s .= '<p>'. t('<strong>Note</strong>: Due your privacy settings (<em>Hide your profile details from unknown viewers?</em>) the link potentially included in public postings relayed to StatusNet will lead the visitor to a blank page informing the visitor that the access to your profile has been restricted.') .'</p>';
+			    $s .= '<p>'. t('<strong>Note</strong>: Due your privacy settings (<em>Hide your profile details from unknown viewers?</em>) the link potentially included in public postings relayed to GNU Social will lead the visitor to a blank page informing the visitor that the access to your profile has been restricted.') .'</p>';
 			}
 			$s .= '<div id="statusnet-enable-wrapper">';
-			$s .= '<label id="statusnet-enable-label" for="statusnet-checkbox">'. t('Allow posting to StatusNet') .'</label>';
+			$s .= '<label id="statusnet-enable-label" for="statusnet-checkbox">'. t('Allow posting to GNU Social') .'</label>';
 			$s .= '<input id="statusnet-checkbox" type="checkbox" name="statusnet-enable" value="1" ' . $checked . '/>';
 			$s .= '<div class="clear"></div>';
-			$s .= '<label id="statusnet-default-label" for="statusnet-default">'. t('Send public postings to StatusNet by default') .'</label>';
+			$s .= '<label id="statusnet-default-label" for="statusnet-default">'. t('Send public postings to GNU Social by default') .'</label>';
 			$s .= '<input id="statusnet-default" type="checkbox" name="statusnet-default" value="1" ' . $defchecked . '/>';
 			$s .= '<div class="clear"></div>';
 
-			$s .= '<label id="statusnet-mirror-label" for="statusnet-mirror">'.t('Mirror all posts from statusnet that are no replies or repeated messages').'</label>';
+			$s .= '<label id="statusnet-mirror-label" for="statusnet-mirror">'.t('Mirror all posts from GNU Social that are no replies or repeated messages').'</label>';
 			$s .= '<input id="statusnet-mirror" type="checkbox" name="statusnet-mirror" value="1" '. $mirrorchecked . '/>';
 
 			$s .= '<div class="clear"></div>';
@@ -470,7 +470,7 @@ function statusnet_action($a, $uid, $pid, $action) {
 function statusnet_post_hook(&$a,&$b) {
 
 	/**
-	 * Post to statusnet
+	 * Post to GNU Social
 	 */
 
 	if (!get_pconfig($b["uid"],'statusnet','import')) {
@@ -484,11 +484,11 @@ function statusnet_post_hook(&$a,&$b) {
 	if($b['parent'] != $b['id']) {
 		logger("statusnet_post_hook: parameter ".print_r($b, true), LOGGER_DATA);
 
-		// Looking if its a reply to a statusnet post
+		// Looking if its a reply to a GNU Social post
 		$hostlength = strlen($hostname) + 2;
 		if ((substr($b["parent-uri"], 0, $hostlength) != $hostname."::") AND (substr($b["extid"], 0, $hostlength) != $hostname."::")
 			AND (substr($b["thr-parent"], 0, $hostlength) != $hostname."::")) {
-			logger("statusnet_post_hook: no statusnet post ".$b["parent"]);
+			logger("statusnet_post_hook: no GNU Social post ".$b["parent"]);
 			return;
 		}
 
@@ -541,14 +541,14 @@ function statusnet_post_hook(&$a,&$b) {
 	if($b['deleted'] || ($b['created'] !== $b['edited']))
 		return;
 
-	// if posts comes from statusnet don't send it back
+	// if posts comes from GNU Social don't send it back
 	if($b['extid'] == NETWORK_STATUSNET)
 		return;
 
 	if($b['app'] == "StatusNet")
 		return;
 
-	logger('statusnet post invoked');
+	logger('GNU Socialpost invoked');
 
 	load_pconfig($b['uid'], 'statusnet');
 
@@ -560,7 +560,7 @@ function statusnet_post_hook(&$a,&$b) {
 
 	if($ckey && $csecret && $otoken && $osecret) {
 
-		// If it's a repeated message from statusnet then do a native retweet and exit
+		// If it's a repeated message from GNU Social then do a native retweet and exit
 		if (statusnet_is_retweet($a, $b['uid'], $b['body']))
 			return;
 
@@ -621,7 +621,7 @@ function statusnet_post_hook(&$a,&$b) {
 				set_pconfig($b["uid"], "statusnet", "application_name", strip_tags($result->source));
 
 			if ($result->error) {
-				logger('Send to StatusNet failed: "'.$result->error.'"');
+				logger('Send to GNU Social failed: "'.$result->error.'"');
 			} elseif ($iscomment) {
 				logger('statusnet_post: Update extid '.$result->id." for post id ".$b['id']);
 				q("UPDATE `item` SET `extid` = '%s', `body` = '%s' WHERE `id` = %d",
@@ -1284,7 +1284,7 @@ function statusnet_checknotification($a, $uid, $own_url, $top_item, $postarray) 
 	if(!count($own_user))
 		return;
 
-	// Is it me from statusnet?
+	// Is it me from GNU Social?
 	if (link_compare($own_user[0]["url"], $postarray['author-link']))
 		return;
 
@@ -1357,7 +1357,7 @@ function statusnet_fetchhometimeline($a, $uid, $mode = 1) {
 	if(count($r)) {
 		$nick = $r[0]["nick"];
 	} else {
-		logger("statusnet_fetchhometimeline: Own statusnet contact not found for user ".$uid, LOGGER_DEBUG);
+		logger("statusnet_fetchhometimeline: Own GNU Social contact not found for user ".$uid, LOGGER_DEBUG);
 		return;
 	}
 
@@ -1647,7 +1647,7 @@ function statusnet_convertmsg($a, $body, $no_tags = false) {
 				$str_tags .= ',';
 
 			if ($mtch[1] == "#") {
-				// Replacing the hash tags that are directed to the statusnet server with internal links
+				// Replacing the hash tags that are directed to the GNU Social server with internal links
 				$snhash = "#[url=".$mtch[2]."]".$mtch[3]."[/url]";
 				$frdchash = '#[url='.$a->get_baseurl().'/search?tag='.rawurlencode($mtch[3]).']'.$mtch[3].'[/url]';
 				$body = str_replace($snhash, $frdchash, $body);
@@ -1656,7 +1656,7 @@ function statusnet_convertmsg($a, $body, $no_tags = false) {
 			} else
 				$str_tags .= "@[url=".$mtch[2]."]".$mtch[3]."[/url]";
 				// To-Do:
-				// There is a problem with links with to statusnet groups, so these links are stored with "@" like friendica groups
+				// There is a problem with links with to GNU Social groups, so these links are stored with "@" like friendica groups
 				//$str_tags .= $mtch[1]."[url=".$mtch[2]."]".$mtch[3]."[/url]";
 		}
 	}


### PR DESCRIPTION
We really should name a network by its current name. See issue https://github.com/friendica/friendica/issues/1744 - (although this refers to the homepage)