### PR TITLE
Langfilter

### DIFF
--- a/langfilter/LICENSE
+++ b/langfilter/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/langfilter/README.md
+++ b/langfilter/README.md
@@ -1,0 +1,40 @@
+Language Filter
+===============
+
+This addon allows users to define a list of languages in which postings shall
+be displayed. Postings in other languages will be collapsed, so the user can
+still read them if desired. When no language could be detected (this usually
+happens with short postings) the posting will be shown.
+
+It is based on the NSFW addon and filters the postings based on the language
+detected by Text_LanguageDetect package that is bundled with friendica.
+
+Please note, the language detection is not perfect. You should not trust it
+blindly and we will not be responsible for postings you don't see because
+they got wrongly hidden by this addon.
+
+Author
+======
+
+ * Tobias Diekershoff
+ 
+License
+=======
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/langfilter/lang/C/messages.po
+++ b/langfilter/lang/C/messages.po
@@ -1,0 +1,61 @@
+# ADDON langfilter
+# Copyright (C) 
+# This file is distributed under the same license as the Friendica langfilter addon package.
+# 
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-24 19:01+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: langfilter.php:43
+msgid "Language Filter"
+msgstr ""
+
+#: langfilter.php:44
+msgid ""
+"This addon tries to identify the language of a postings. If it does not "
+"match any language spoken by you (see below) the posting will be collapsed. "
+"Remember detecting the language is not perfect, especially with short "
+"postings."
+msgstr ""
+
+#: langfilter.php:45
+msgid "Use the language filter"
+msgstr ""
+
+#: langfilter.php:46
+msgid "Use /expression/ to provide regular expressions"
+msgstr ""
+
+#: langfilter.php:47
+msgid "I speak"
+msgstr ""
+
+#: langfilter.php:47
+msgid ""
+"List of abbreviations for languages you speak, comma seperated. For excample "
+"\"de,it\"."
+msgstr ""
+
+#: langfilter.php:48
+msgid "Save Settings"
+msgstr ""
+
+#: langfilter.php:67
+msgid "Language Filter Settings saved."
+msgstr ""
+
+#: langfilter.php:106
+#, php-format
+msgid "unspoken language %s - Click to open/close"
+msgstr ""

--- a/langfilter/lang/C/messages.po
+++ b/langfilter/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 19:01+0200\n"
+"POT-Creation-Date: 2015-07-24 19:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,28 +34,24 @@ msgid "Use the language filter"
 msgstr ""
 
 #: langfilter.php:46
-msgid "Use /expression/ to provide regular expressions"
-msgstr ""
-
-#: langfilter.php:47
 msgid "I speak"
 msgstr ""
 
-#: langfilter.php:47
+#: langfilter.php:46
 msgid ""
 "List of abbreviations for languages you speak, comma seperated. For excample "
 "\"de,it\"."
 msgstr ""
 
-#: langfilter.php:48
+#: langfilter.php:47
 msgid "Save Settings"
 msgstr ""
 
-#: langfilter.php:67
+#: langfilter.php:66
 msgid "Language Filter Settings saved."
 msgstr ""
 
-#: langfilter.php:106
+#: langfilter.php:105
 #, php-format
 msgid "unspoken language %s - Click to open/close"
 msgstr ""

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * Name: Language Filter
+ * Version: 0.1
+ * Description: Filters out postings in languages not spoken by the users
+ * Author: Tobias Diekershoff <https://f.diekershoff.de/u/tobias>
+ * License: MIT
+ */
+
+require_once('library/langdet/Text/LanguageDetect.php');
+
+/* Define the hooks we want to use
+ * that is, we have settings, we need to save the settings and we want
+ * to modify the content of a posting when friendica prepares it.
+ */
+function langfilter_install() {
+	register_hook('prepare_body',         'addon/langfilter/langfilter.php', 'langfilter_prepare_body', 10);
+	register_hook('plugin_settings',      'addon/langfilter/langfilter.php', 'langfilter_addon_settings');
+	register_hook('plugin_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
+}
+function langfilter_uninstall() {
+	unregister_hook('prepare_body',         'addon/langfilter/langfilter.php', 'langfilter_prepare_body');
+	unregister_hook('plugin_settings',      'addon/langfilter/langfilter.php', 'langfilter_addon_settings');
+	unregister_hook('plugin_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
+}
+
+/* The settings
+ * 1st check if somebody logged in is calling
+ * 2nd get the current settings
+ * 3rd parse a SMARTY3 template, replacing some translateable strings for the form
+ */
+function langfilter_addon_settings(&$a,&$s) {
+	if(! local_user())
+		return;
+
+	$enable_checked = (intval(get_pconfig(local_user(),'langfilter','disable')) ? '' : ' checked="checked" ');
+	$languages = get_pconfig(local_user(),'langfilter','languages');
+	if(! $languages)
+		$languages = 'en,de,fr,it,es';
+
+	$t = get_markup_template("settings.tpl", "addon/langfilter/" );
+	$s .= replace_macros ($t, array(
+	    '$title' => t("Language Filter"),
+	    '$intro' => t ('This addon tries to identify the language of a postings. If it does not match any language spoken by you (see below) the posting will be collapsed. Remember detecting the language is not perfect, especially with short postings.'),
+	    '$enabled' => array('langfilter_enable', t('Use the language filter'), $enable_checked, ''),
+	    '$regex' => t('Use /expression/ to provide regular expressions'),
+	    '$languages' => array('langfilter_languages', t('I speak'), $languages, t('List of abbreviations for languages you speak, comma seperated. For excample "de,it".') ),
+	    '$submit' => t('Save Settings'),
+	));
+
+	return;
+}
+/* Save the settings
+ * 1st check it's a logged in user calling
+ * 2nd check the langfilter form is to be saved
+ * 3rd save the settings to the DB for later usage
+ */
+function langfilter_addon_settings_post(&$a,&$b) {
+	if(! local_user())
+		return;
+
+	if($_POST['langfilter-settings-submit']) {
+		set_pconfig(local_user(),'langfilter','languages',trim($_POST['langfilter_languages']));
+		$enable = ((x($_POST,'langfilter_enable')) ? intval($_POST['langfilter_enable']) : 0);
+		$disable = 1-$enable;
+		set_pconfig(local_user(),'langfilter','disable', $disable);
+		info( t('Language Filter Settings saved.') . EOL);
+	}
+}
+/* Actually filter postings by their language
+ * 1st check if the user wants to filter postings
+ * 2nd get the user settings which languages shall be not filtered out
+ * 3rd determine the language of a posting
+ * 4th if the determined language does not fit to the spoken languages
+ *     of the user, then collapse the posting, but provide a link to
+ *     expand it again.
+ */
+function langfilter_prepare_body(&$a,&$b) {
+	if(get_pconfig(local_user(),'langfilter','disable'))
+		return;
+
+	if(local_user()) {
+		$langs = get_pconfig(local_user(),'langfilter','languages');
+	}
+	if($langs) {
+		$arr = explode(',',$langs);
+	} else {
+		return;
+	}
+
+	$found = false;
+    $l = new Text_LanguageDetect;
+    $l->_name_mode = 2;   // two letter codes
+    $l->_threshold = 600; // make it a bit harder to be confident with a lng
+                          // IOW make it more possible that lng is correct
+    $lng = $l->detectSimple($b['html']);
+    if ($lng==null)
+		return;
+    if (! in_array($lng, $arr))
+		$found = true;
+	if ($lng==null)
+		$found = false;
+
+	if($found) {
+		$rnd = random_string(8);
+		$b['html'] = '<div id="langfilter-wrap-' . $rnd . '" class="fakelink" onclick=openClose(\'langfilter-' . $rnd . '\'); >' . sprintf( t('unspoken language %s - Click to open/close'),$lng ) . '</div><div id="langfilter-' . $rnd . '" style="display: none; " >' . $b['html'] . '</div>';  
+	}
+}
+?>

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -43,7 +43,6 @@ function langfilter_addon_settings(&$a,&$s) {
 	    '$title' => t("Language Filter"),
 	    '$intro' => t ('This addon tries to identify the language of a postings. If it does not match any language spoken by you (see below) the posting will be collapsed. Remember detecting the language is not perfect, especially with short postings.'),
 	    '$enabled' => array('langfilter_enable', t('Use the language filter'), $enable_checked, ''),
-	    '$regex' => t('Use /expression/ to provide regular expressions'),
 	    '$languages' => array('langfilter_languages', t('I speak'), $languages, t('List of abbreviations for languages you speak, comma seperated. For excample "de,it".') ),
 	    '$submit' => t('Save Settings'),
 	));

--- a/langfilter/templates/settings.tpl
+++ b/langfilter/templates/settings.tpl
@@ -8,7 +8,6 @@
 
 	<div id="langfilter-wrapper">
 		<p>{{$intro}}</p>
-		<p>{{$regex}}</p>
 		{{include file="field_checkbox.tpl" field=$enabled}}
 		{{include file="field_input.tpl" field=$languages}}
 	</div>

--- a/langfilter/templates/settings.tpl
+++ b/langfilter/templates/settings.tpl
@@ -1,0 +1,18 @@
+<span id="settings_langfilter_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose('settings_langfilter_expanded'); openClose('settings_langfilter_inflated');">
+	<h3>{{$title}}</h3>
+</span>
+<div id="settings_langfilter_expanded" class="settings-block" style="display: none;">
+	<span class="fakelink" onclick="openClose('settings_langfilter_expanded'); openClose('settings_langfilter_inflated');">
+		<h3>{{$title}}</h3>
+	</span>
+
+	<div id="langfilter-wrapper">
+		<p>{{$intro}}</p>
+		<p>{{$regex}}</p>
+		{{include file="field_checkbox.tpl" field=$enabled}}
+		{{include file="field_input.tpl" field=$languages}}
+	</div>
+	<div class="settings-submit-wrapper" >
+		<input type="submit" id="langfilter-settings-submit" name="langfilter-settings-submit" class="settings-submit" value="{{$submit}}" />
+	</div>
+</div>	


### PR DESCRIPTION
This addon is based on the NSFW filter but collapses postings based on the detected language instead of a list of words.

not exactly what friendica/friendica#1778 describes as this is not a per contact setting, but it filters the postings in unspoken languages.