### PR TITLE
Cleanup implementation of langfilter_prepare_body, and fix a typo

### DIFF
--- a/langfilter/lang/C/messages.po
+++ b/langfilter/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-24 19:11+0200\n"
+"POT-Creation-Date: 2015-09-22 15:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: langfilter.php:43
+#: langfilter.php:44
 msgid "Language Filter"
 msgstr ""
 
-#: langfilter.php:44
+#: langfilter.php:45
 msgid ""
 "This addon tries to identify the language of a postings. If it does not "
 "match any language spoken by you (see below) the posting will be collapsed. "
@@ -29,29 +29,40 @@ msgid ""
 "postings."
 msgstr ""
 
-#: langfilter.php:45
+#: langfilter.php:46
 msgid "Use the language filter"
 msgstr ""
 
-#: langfilter.php:46
+#: langfilter.php:47
 msgid "I speak"
 msgstr ""
 
-#: langfilter.php:46
+#: langfilter.php:47
 msgid ""
-"List of abbreviations for languages you speak, comma seperated. For excample "
-"\"de,it\"."
+"List of abbreviations (iso2 codes) for languages you speak, comma separated. "
+"For example \"de,it\"."
 msgstr ""
 
-#: langfilter.php:47
+#: langfilter.php:48
+msgid "Minimum confidence in language detection"
+msgstr ""
+
+#: langfilter.php:48
+msgid ""
+"Minimum confidence in language detection being correct, from 0 to 100. Posts "
+"will not be filtered when the confidence of language detection is below this "
+"percent value."
+msgstr ""
+
+#: langfilter.php:49
 msgid "Save Settings"
 msgstr ""
 
-#: langfilter.php:66
+#: langfilter.php:73
 msgid "Language Filter Settings saved."
 msgstr ""
 
-#: langfilter.php:105
+#: langfilter.php:123
 #, php-format
 msgid "unspoken language %s - Click to open/close"
 msgstr ""

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -43,7 +43,7 @@ function langfilter_addon_settings(&$a,&$s) {
 	    '$title' => t("Language Filter"),
 	    '$intro' => t ('This addon tries to identify the language of a postings. If it does not match any language spoken by you (see below) the posting will be collapsed. Remember detecting the language is not perfect, especially with short postings.'),
 	    '$enabled' => array('langfilter_enable', t('Use the language filter'), $enable_checked, ''),
-	    '$languages' => array('langfilter_languages', t('I speak'), $languages, t('List of abbreviations (iso2 codes) for languages you speak, comma separated. For excample "de,it".') ),
+	    '$languages' => array('langfilter_languages', t('I speak'), $languages, t('List of abbreviations (iso2 codes) for languages you speak, comma separated. For example "de,it".') ),
 	    '$submit' => t('Save Settings'),
 	));
 
@@ -63,7 +63,8 @@ function langfilter_addon_settings_post(&$a,&$b) {
 		$enable = ((x($_POST,'langfilter_enable')) ? intval($_POST['langfilter_enable']) : 0);
 		$disable = 1-$enable;
 		set_pconfig(local_user(),'langfilter','disable', $disable);
-		set_pconfig(local_user(),'langfilter','minconfidence', $disable);
+		$confidence = ((x($_POST,'langfilter_minconfidence')) ? intval($_POST['langfilter_minconfidence']) : 0);
+		set_pconfig(local_user(),'langfilter','minconfidence', $confidence);
 		info( t('Language Filter Settings saved.') . EOL);
 	}
 }
@@ -89,6 +90,7 @@ function langfilter_prepare_body(&$a,&$b) {
     if( get_pconfig($logged_user,'langfilter','disable') ) return;
 
     $spoken_config = get_pconfig(local_user(),'langfilter','languages');
+    $minconfidence = get_pconfig(local_user(),'langfilter','minconfidence');
 
     # Don't filter if no spoken languages are configured 
     if ( ! $spoken_config ) return;
@@ -103,7 +105,8 @@ function langfilter_prepare_body(&$a,&$b) {
     $lang = $matches[1];
     $confidence = $matches[2];
 
-    # TODO: accept a confidence threshold in settings
+    # Do not filter if language detection confidence is too low
+    if ( $minconfidence && $confidence < $minconfidence ) return;
 
     $iso2 = Text_LanguageDetect_ISO639::nameToCode2($lang);
 

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -35,6 +35,7 @@ function langfilter_addon_settings(&$a,&$s) {
 
 	$enable_checked = (intval(get_pconfig(local_user(),'langfilter','disable')) ? '' : ' checked="checked" ');
 	$languages = get_pconfig(local_user(),'langfilter','languages');
+	$minconfidence = get_pconfig(local_user(),'langfilter','minconfidence')*100;
 	if(! $languages)
 		$languages = 'en,de,fr,it,es';
 
@@ -44,6 +45,7 @@ function langfilter_addon_settings(&$a,&$s) {
 	    '$intro' => t ('This addon tries to identify the language of a postings. If it does not match any language spoken by you (see below) the posting will be collapsed. Remember detecting the language is not perfect, especially with short postings.'),
 	    '$enabled' => array('langfilter_enable', t('Use the language filter'), $enable_checked, ''),
 	    '$languages' => array('langfilter_languages', t('I speak'), $languages, t('List of abbreviations (iso2 codes) for languages you speak, comma separated. For example "de,it".') ),
+	    '$minconfidence' => array('langfilter_minconfidence', t('Minimum confidence in language detection'), $minconfidence, t('Minimum confidence in language detection being correct, from 0 to 100. Posts will not be filtered when the confidence of language detection is below this percent value.') ),
 	    '$submit' => t('Save Settings'),
 	));
 
@@ -63,8 +65,11 @@ function langfilter_addon_settings_post(&$a,&$b) {
 		$enable = ((x($_POST,'langfilter_enable')) ? intval($_POST['langfilter_enable']) : 0);
 		$disable = 1-$enable;
 		set_pconfig(local_user(),'langfilter','disable', $disable);
-		$confidence = ((x($_POST,'langfilter_minconfidence')) ? intval($_POST['langfilter_minconfidence']) : 0);
-		set_pconfig(local_user(),'langfilter','minconfidence', $confidence);
+		$minconfidence = 0+$_POST['langfilter_minconfidence'];
+		if ( ! $minconfidence ) $minconfidence = 0;
+		else if ( $minconfidence < 0 ) $minconfidence = 0;
+		else if ( $minconfidence > 100 ) $minconfidence = 100;
+		set_pconfig(local_user(),'langfilter','minconfidence', $minconfidence/100.0);
 		info( t('Language Filter Settings saved.') . EOL);
 	}
 }

--- a/langfilter/templates/settings.tpl
+++ b/langfilter/templates/settings.tpl
@@ -10,6 +10,7 @@
 		<p>{{$intro}}</p>
 		{{include file="field_checkbox.tpl" field=$enabled}}
 		{{include file="field_input.tpl" field=$languages}}
+		{{include file="field_input.tpl" field=$minconfidence}}
 	</div>
 	<div class="settings-submit-wrapper" >
 		<input type="submit" id="langfilter-settings-submit" name="langfilter-settings-submit" class="settings-submit" value="{{$submit}}" />


### PR DESCRIPTION
I'd actually want to add a new setting to restrict filtering to posts for which the language guessers has a minimum confidence