### PR TITLE
Don't show the rendertime data and jappix in minimal mode.

### DIFF
--- a/jappixmini/jappixmini.php
+++ b/jappixmini/jappixmini.php
@@ -439,6 +439,9 @@ function jappixmini_script(&$a,&$s) {
 
     if(! local_user()) return;
 
+    if ($_GET["mode"] == "minimal")
+	return;
+
     $activate = get_pconfig(local_user(),'jappixmini','activate');
     $dontinsertchat = get_pconfig(local_user(), 'jappixmini','dontinsertchat');
     if (!$activate or $dontinsertchat) return;

--- a/rendertime/rendertime.php
+++ b/rendertime/rendertime.php
@@ -26,7 +26,7 @@ function rendertime_page_end(&$a, &$o) {
 
 	$duration = microtime(true)-$a->performance["start"];
 
-	if (is_site_admin())
+	if (is_site_admin() AND ($_GET["mode"] != "minimal"))
 		$o = $o.'<div class="renderinfo">'.sprintf(t("Performance: Database: %s, Network: %s, Rendering: %s, Parser: %s, I/O: %s, Other: %s, Total: %s"),
 						round($a->performance["database"], 3),
 						round($a->performance["network"], 3),


### PR DESCRIPTION
The minimal mode is used for example in the bookmarklet. It doesn't look nice if there would be a chat window there.