### PR TITLE
Only execute the sync if the pumpio plugin is enabled

### DIFF
--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -604,6 +604,12 @@ function pumpio_action(&$a, $uid, $uri, $action, $content = "") {
 }
 
 function pumpio_sync(&$a) {
+	$r = q("SELECT * FROM `addon` WHERE `installed` = 1 AND `name` = 'pumpio'",
+		$plugin);
+
+	if (!count($r))
+		return;
+
 	$last = get_config('pumpio','last_poll');
 
 	$poll_interval = intval(get_config('pumpio','poll_interval'));


### PR DESCRIPTION
The sync is now executed externally - so it has to be tested if the plugin is enabled.