### PR TITLE
make smileybutton part of the div profile-smiley-wrapper

### DIFF
--- a/smileybutton/smileybutton.php
+++ b/smileybutton/smileybutton.php
@@ -130,10 +130,9 @@ function show_button($a, &$b) {
 	$b = <<< EOT
 	<div id="profile-smiley-wrapper" style="display: block;" >
 		<img src="$image_url" class="smiley_button" onclick="toggle_smileybutton()" alt="smiley">
-	</div>
-
-	<div id="smileybutton" style="display:none;">
-	$s
+		<div id="smileybutton" style="display:none;">
+		$s
+		</div>
 	</div>
 
 	<script>


### PR DESCRIPTION
this is needed to make the smiley preview an inline-block (which is part of https://github.com/friendica/friendica/pull/2322)
The other themes are not affected by this.