### PR TITLE
encode the degree for the translation

### DIFF
--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -173,7 +173,7 @@ function curweather_plugin_settings(&$a,&$s) {
 		'$noappidtext' => $noappidtext,
 		'$info' => t('Enter either the name of your location or the zip code.'),
 		'$curweather_loc' => array( 'curweather_loc', t('Your Location'), $curweather_loc, t('Identifier of your location (name or zip code), e.g. <em>Berlin,DE</em> or <em>14476,DE</em>.') ),
-		'$curweather_units' => array( 'curweather_units', t('Units'), $curweather_units, t('select if the temperatur should be displayed in °C or °F'), array('metric'=>'°C', 'imperial'=>'°F')),
+		'$curweather_units' => array( 'curweather_units', t('Units'), $curweather_units, t('select if the temperatur should be displayed in &deg;C or &deg;F'), array('metric'=>'°C', 'imperial'=>'°F')),
 		'$enabled' => array( 'curweather_enable', t('Show weather data'), $enable, '')
 	    ));
 	return;

--- a/curweather/lang/C/messages.po
+++ b/curweather/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-13 18:46+0200\n"
+"POT-Creation-Date: 2016-03-12 08:10+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,114 +17,114 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: curweather.php:30
+#: curweather.php:31
 msgid "Error fetching weather data.\\nError was: "
 msgstr ""
 
-#: curweather.php:103 curweather.php:163
+#: curweather.php:111 curweather.php:172
 msgid "Current Weather"
 msgstr ""
 
-#: curweather.php:109
+#: curweather.php:118
 msgid "Relative Humidity"
 msgstr ""
 
-#: curweather.php:110
+#: curweather.php:119
 msgid "Pressure"
 msgstr ""
 
-#: curweather.php:111
+#: curweather.php:120
 msgid "Wind"
 msgstr ""
 
-#: curweather.php:112
+#: curweather.php:121
 msgid "Last Updated"
 msgstr ""
 
-#: curweather.php:113
+#: curweather.php:122
 msgid "Data by"
 msgstr ""
 
-#: curweather.php:114
+#: curweather.php:123
 msgid "Show on map"
 msgstr ""
 
-#: curweather.php:119
+#: curweather.php:128
 msgid "There was a problem accessing the weather data. But have a look"
 msgstr ""
 
-#: curweather.php:121
+#: curweather.php:130
 msgid "at OpenWeatherMap"
 msgstr ""
 
-#: curweather.php:137
+#: curweather.php:146
 msgid "Current Weather settings updated."
 msgstr ""
 
-#: curweather.php:152
+#: curweather.php:161
 msgid "No APPID found, please contact your admin to optain one."
 msgstr ""
 
-#: curweather.php:162 curweather.php:191
+#: curweather.php:171 curweather.php:200
 msgid "Save Settings"
 msgstr ""
 
-#: curweather.php:163
+#: curweather.php:172
 msgid "Settings"
 msgstr ""
 
-#: curweather.php:165
+#: curweather.php:174
 msgid "Enter either the name of your location or the zip code."
 msgstr ""
 
-#: curweather.php:166
+#: curweather.php:175
 msgid "Your Location"
 msgstr ""
 
-#: curweather.php:166
+#: curweather.php:175
 msgid ""
 "Identifier of your location (name or zip code), e.g. <em>Berlin,DE</em> or "
 "<em>14476,DE</em>."
 msgstr ""
 
-#: curweather.php:167
+#: curweather.php:176
 msgid "Units"
 msgstr ""
 
-#: curweather.php:167
-msgid "select if the temperatur should be displayed in °C or °F"
+#: curweather.php:176
+msgid "select if the temperatur should be displayed in &deg;C or &deg;F"
 msgstr ""
 
-#: curweather.php:168
+#: curweather.php:177
 msgid "Show weather data"
 msgstr ""
 
-#: curweather.php:181
+#: curweather.php:190
 msgid "Curweather settings saved."
 msgstr ""
 
-#: curweather.php:192
+#: curweather.php:201
 msgid "Caching Interval"
 msgstr ""
 
-#: curweather.php:192
+#: curweather.php:201
 msgid ""
 "For how long should the weather data be cached? Choose according your "
 "OpenWeatherMap account type."
 msgstr ""
 
-#: curweather.php:192
+#: curweather.php:201
 msgid "no cache"
 msgstr ""
 
-#: curweather.php:192
+#: curweather.php:201
 msgid "minutes"
 msgstr ""
 
-#: curweather.php:193
+#: curweather.php:202
 msgid "Your APPID"
 msgstr ""
 
-#: curweather.php:193
+#: curweather.php:202
 msgid "Your API key provided by OpenWeatherMap"
 msgstr ""


### PR DESCRIPTION
Strings containing the °C or °F are now &deg;C and &deg;F when passed to the translation function. Also the messages.po file for the addon was regenerated.

for friendica  ##2402