### PR TITLE
showmore: add css classes to elements

### DIFF
--- a/showmore/showmore.php
+++ b/showmore/showmore.php
@@ -121,9 +121,9 @@ function showmore_prepare_body(&$a,&$b) {
 
 	if($found) {
 		$rnd = random_string(8);
-		$b['html'] = '<span id="showmore-teaser-'.$rnd.'" style="display: block;">'.$shortened." ".
-				'<span id="showmore-wrap-'.$rnd.'" style="white-space:nowrap;" class="fakelink" onclick="openClose(\'showmore-'.$rnd.'\'); openClose(\'showmore-teaser-'.$rnd.'\');" >'.sprintf(t('show more')).'</span></span>'.
-				'<div id="showmore-'.$rnd.'" style="display: none;">'.$b['html'].'</div>';
+		$b['html'] = '<span id="showmore-teaser-'.$rnd.'" class="showmore-teaser" style="display: block;">'.$shortened." ".
+				'<span id="showmore-wrap-'.$rnd.'" style="white-space:nowrap;" class="showmore-wrap fakelink" onclick="openClose(\'showmore-'.$rnd.'\'); openClose(\'showmore-teaser-'.$rnd.'\');" >'.sprintf(t('show more')).'</span></span>'.
+				'<div id="showmore-'.$rnd.'" class="showmore-content" style="display: none;">'.$b['html'].'</div>';
 	}
 }
 


### PR DESCRIPTION
add some classes to the html elements of the showmore addon to have better possibilities for styling.

BTW
Since showmore can only appear once in one post/comment couldn't we use the item-id for `$rnd` instead of a random string?