### PR TITLE
only show address information when set

### DIFF
--- a/forumdirectory/templates/forumdirectory_item.tpl
+++ b/forumdirectory/templates/forumdirectory_item.tpl
@@ -20,9 +20,9 @@
 					<span class="city-state-zip">
 						{{if $profile.locality}}<span class="locality">{{$profile.locality}}</span>, {{/if}}
 						{{if $profile.region}}<span class="region">{{$profile.region}}</span>{{/if}}
-						{{if $profile.postal-code}}<span class="postal-code">{{$profile.postal-code}}</span>{{/if}}
+						{{if $profile['postal-code']}}<span class="postal-code">{{$profile['postal-code']}}</span>{{/if}}
 					</span>
-					{{if $profile.country-name}}<span class="country-name">{{$profile.country-name}}</span>{{/if}}
+					{{if $profile['country-name']}}<span class="country-name">{{$profile['country-name']}}</span>{{/if}}
 				</dd>
 				</dl>
 			{{/if}}

--- a/forumdirectory/templates/forumdirectory_item.tpl
+++ b/forumdirectory/templates/forumdirectory_item.tpl
@@ -18,9 +18,9 @@
 				<dd class="adr">
 					{{if $profile.address}}<div class="street-address">{{$profile.address}}</div>{{/if}}
 					<span class="city-state-zip">
-						<span class="locality">{{$profile.locality}}</span>{{if $profile.locality}}, {{/if}}
-						<span class="region">{{$profile.region}}</span>
-						<span class="postal-code">{{$profile.postal-code}}</span>
+						{{if $profile.locality}}<span class="locality">{{$profile.locality}}</span>, {{/if}}
+						{{if $profile.region}}<span class="region">{{$profile.region}}</span>{{/if}}
+						{{if $profile.postal-code}}<span class="postal-code">{{$profile.postal-code}}</span>{{/if}}
 					</span>
 					{{if $profile.country-name}}<span class="country-name">{{$profile.country-name}}</span>{{/if}}
 				</dd>


### PR DESCRIPTION
regarding the 0 in the postal code from friendica/friendica#1494

* only show fields set
* `country-name` and `postal-code` need other notation because of the dash in the variable name