### PR TITLE
Add minimum post body length setting to language filter

### DIFF
--- a/langfilter/templates/settings.tpl
+++ b/langfilter/templates/settings.tpl
@@ -11,6 +11,7 @@
 		{{include file="field_checkbox.tpl" field=$enabled}}
 		{{include file="field_input.tpl" field=$languages}}
 		{{include file="field_input.tpl" field=$minconfidence}}
+		{{include file="field_input.tpl" field=$minlength}}
 	</div>
 	<div class="settings-submit-wrapper" >
 		<input type="submit" id="langfilter-settings-submit" name="langfilter-settings-submit" class="settings-submit" value="{{$submit}}" />


### PR DESCRIPTION
No more "lol" messages filtered (with filter message being longer than the actual message)

NOTE: implementation might be cleaned up but I'm out of time (specifically: the way defaults are handled, currently rewritten in many places)