### PR TITLE
Twitter: The sync process is split into several short processes

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -625,7 +625,12 @@ function twitter_cron($a,$b) {
 	if(count($r)) {
 		foreach($r as $rr) {
 			logger('twitter: fetching for user '.$rr['uid']);
-			twitter_fetchtimeline($a, $rr['uid']);
+
+			if (get_config("system", "worker")) {
+				proc_run(PRIORITY_MEDIUM, "addon/twitter/twitter_sync.php", 1, $rr['uid']);
+			} else {
+				twitter_fetchtimeline($a, $rr['uid']);
+			}
 		}
 	}
 
@@ -647,8 +652,12 @@ function twitter_cron($a,$b) {
 			}
 
 			logger('twitter: importing timeline from user '.$rr['uid']);
-			twitter_fetchhometimeline($a, $rr["uid"]);
 
+			if (get_config("system", "worker")) {
+				proc_run(PRIORITY_MEDIUM, "addon/twitter/twitter_sync.php", 2, $rr['uid']);
+			} else {
+				twitter_fetchhometimeline($a, $rr["uid"]);
+			}
 /*
 			// To-Do
 			// check for new contacts once a day

--- a/twitter/twitter_sync.php
+++ b/twitter/twitter_sync.php
@@ -1,0 +1,78 @@
+<?php
+if (!file_exists("boot.php") AND (sizeof($_SERVER["argv"]) != 0)) {
+	$directory = dirname($_SERVER["argv"][0]);
+
+	if (substr($directory, 0, 1) != "/")
+		$directory = $_SERVER["PWD"]."/".$directory;
+
+	$directory = realpath($directory."/..");
+
+	chdir($directory);
+}
+
+require_once("boot.php");
+
+
+function twitter_sync_run($argv, $argc){
+	global $a, $db;
+
+	if(is_null($a)) {
+		$a = new App;
+	}
+
+	if(is_null($db)) {
+		@include(".htconfig.php");
+		require_once("include/dba.php");
+		$db = new dba($db_host, $db_user, $db_pass, $db_data);
+		unset($db_host, $db_user, $db_pass, $db_data);
+	};
+
+	require_once("addon/twitter/twitter.php");
+	require_once("include/pidfile.php");
+
+	$maxsysload = intval(get_config('system','maxloadavg'));
+	if($maxsysload < 1)
+		$maxsysload = 50;
+	if(function_exists('sys_getloadavg')) {
+		$load = sys_getloadavg();
+		if(intval($load[0]) > $maxsysload) {
+			logger('system: load ' . $load[0] . ' too high. Twitter sync deferred to next scheduled run.');
+			return;
+		}
+	}
+
+	if ($argc < 3) {
+		return;
+	}
+
+	$mode = intval($argv[1]);
+	$uid = intval($argv[2]);
+
+	/// @todo Replace it with "App::is_already_running" in the next release
+	$lockpath = get_lockpath();
+	if ($lockpath != '') {
+		$pidfile = new pidfile($lockpath, 'twitter_sync-'.$mode.'-'.$uid);
+		if($pidfile->is_already_running()) {
+			logger("Already running");
+			if ($pidfile->running_time() > 9*60) {
+				$pidfile->kill();
+				logger("killed stale process");
+				// Calling a new instance
+				proc_run('php','addon/twitter/twitter_sync.php', $mode, $uid);
+			}
+			exit;
+		}
+	}
+
+	if ($mode == 1) {
+		twitter_fetchtimeline($a, $uid);
+	} elseif ($mode == 2) {
+		twitter_fetchhometimeline($a, $uid);
+	}
+}
+
+if (array_search(__file__,get_included_files())===0){
+	twitter_sync_run($_SERVER["argv"],$_SERVER["argc"]);
+	killme();
+}
+?>

--- a/twitter/twitter_sync.php
+++ b/twitter/twitter_sync.php
@@ -16,11 +16,11 @@ require_once("boot.php");
 function twitter_sync_run($argv, $argc){
 	global $a, $db;
 
-	if(is_null($a)) {
+	if (is_null($a)) {
 		$a = new App;
 	}
 
-	if(is_null($db)) {
+	if (is_null($db)) {
 		@include(".htconfig.php");
 		require_once("include/dba.php");
 		$db = new dba($db_host, $db_user, $db_pass, $db_data);
@@ -31,11 +31,12 @@ function twitter_sync_run($argv, $argc){
 	require_once("include/pidfile.php");
 
 	$maxsysload = intval(get_config('system','maxloadavg'));
-	if($maxsysload < 1)
+	if ($maxsysload < 1) {
 		$maxsysload = 50;
-	if(function_exists('sys_getloadavg')) {
+	}
+	if (function_exists('sys_getloadavg')) {
 		$load = sys_getloadavg();
-		if(intval($load[0]) > $maxsysload) {
+		if (intval($load[0]) > $maxsysload) {
 			logger('system: load ' . $load[0] . ' too high. Twitter sync deferred to next scheduled run.');
 			return;
 		}
@@ -52,7 +53,7 @@ function twitter_sync_run($argv, $argc){
 	$lockpath = get_lockpath();
 	if ($lockpath != '') {
 		$pidfile = new pidfile($lockpath, 'twitter_sync-'.$mode.'-'.$uid);
-		if($pidfile->is_already_running()) {
+		if ($pidfile->is_already_running()) {
 			logger("Already running");
 			if ($pidfile->running_time() > 9*60) {
 				$pidfile->kill();


### PR DESCRIPTION
When the worker is enabled the call for fetching the timeline and the mentions is split into multiple calls. This is done to shorten the process execution time - which is very important with the frontend worker.