### PR TITLE
Move app to src

### DIFF
--- a/pumpio/pumpio_sync.php
+++ b/pumpio/pumpio_sync.php
@@ -1,4 +1,7 @@
 <?php
+
+use Friendica\App;
+
 if (!file_exists("boot.php") AND (sizeof($_SERVER["argv"]) != 0)) {
 	$directory = dirname($_SERVER["argv"][0]);
 

--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -6,6 +6,8 @@
  * Author: Fabio Comuni <http://kirgroup.com/profile/fabrixxm>
  */
 
+use Friendica\App;
+
 require_once 'include/Emailer.php';
 
 /* because the fraking openpgp-php is in composer, require libs in composer

--- a/twitter/twitter_sync.php
+++ b/twitter/twitter_sync.php
@@ -1,4 +1,7 @@
 <?php
+
+use Friendica\App;
+
 if (!file_exists("boot.php") AND (sizeof($_SERVER["argv"]) != 0)) {
 	$directory = dirname($_SERVER["argv"][0]);
 


### PR DESCRIPTION
This PR updates addons to make them compatible with the release 3.5.2 of Friendica.

It all boils down to using namespaces to invoke the App class. Fortunately, very few addons do that and were disrupted on server running Friendica develop branch.

This PR should be merged after the 3.5.2 release.