### PR TITLE
Grouping parentheses instead of capturing parentheses

### DIFF
--- a/nsfw/README
+++ b/nsfw/README
@@ -53,13 +53,13 @@ interested in postings about christmas.
 ATTENTION:
 
 It is absolutely important, that you use grouping
-parantheses instead of capturing parantheses!!
+parentheses instead of capturing parentheses!!
 
-Grouping parantheses are:
+Grouping parentheses are:
 
 	(?: )
 
-If you use capturing parantheses, which are
+If you use capturing parentheses, which are
 
 	( )
 

--- a/nsfw/README
+++ b/nsfw/README
@@ -47,7 +47,25 @@ done with a single regex, which matches all of them:
 Another use case could be, that you are simply not
 interested in postings about christmas.
 
-	/christmas([-_ ]?(tree|time|eve|pudding))?/
+	/christmas([-_ ]?(?:tree|time|eve|pudding))?/
+
+
+ATTENTION:
+
+It is absolutely important, that you use grouping
+parantheses instead of capturing parantheses!!
+
+Grouping parantheses are:
+
+	(?: )
+
+If you use capturing parantheses, which are
+
+	( )
+
+it will produce errors and the regex won't work and
+at least your targets will not get collapsed.
+
 
 
 3)

--- a/nsfw/README
+++ b/nsfw/README
@@ -47,7 +47,7 @@ done with a single regex, which matches all of them:
 Another use case could be, that you are simply not
 interested in postings about christmas.
 
-	/christmas([-_ ]?(?:tree|time|eve|pudding))?/
+	/christmas(?:[-_ ]?(?:tree|time|eve|pudding))?/
 
 
 ATTENTION:


### PR DESCRIPTION
As already mentioned in the README file, the usage of of capturing parathese produces errors, so it's important to use grouping parantheses there instead.