### PR TITLE
use more PConfig::delete

### DIFF
--- a/fromgplus/fromgplus.php
+++ b/fromgplus/fromgplus.php
@@ -86,7 +86,7 @@ function fromgplus_addon_settings_post(&$a,&$b) {
 		PConfig::set(local_user(),'fromgplus', 'keywords', $keywords);
 
 		if (!$enable)
-			del_pconfig(local_user(),'fromgplus','lastdate');
+			PConfig::delete(local_user(),'fromgplus','lastdate');
 
 		info( t('Google+ Import Settings saved.') . EOL);
 	}

--- a/ifttt/ifttt.php
+++ b/ifttt/ifttt.php
@@ -77,7 +77,7 @@ function ifttt_settings_post(&$a,&$b) {
 
         if(x($_POST,'ifttt-submit'))
                 if (isset($_POST['ifttt-rekey']))
-                        del_pconfig(local_user(), 'ifttt', 'key');
+                        PConfig::delete(local_user(), 'ifttt', 'key');
 }
 
 function ifttt_post(&$a) {

--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -381,25 +381,25 @@ function mailstream_plugin_settings_post($a,$post) {
 		PConfig::set(local_user(), 'mailstream', 'address', $_POST['mailstream_address']);
 	}
 	else {
-		del_pconfig(local_user(), 'mailstream', 'address');
+		PConfig::delete(local_user(), 'mailstream', 'address');
 	}
 	if ($_POST['mailstream_nolikes']) {
 		PConfig::set(local_user(), 'mailstream', 'nolikes', $_POST['mailstream_enabled']);
 	}
 	else {
-		del_pconfig(local_user(), 'mailstream', 'nolikes');
+		PConfig::delete(local_user(), 'mailstream', 'nolikes');
 	}
 	if ($_POST['mailstream_enabled']) {
 		PConfig::set(local_user(), 'mailstream', 'enabled', $_POST['mailstream_enabled']);
 	}
 	else {
-		del_pconfig(local_user(), 'mailstream', 'enabled');
+		PConfig::delete(local_user(), 'mailstream', 'enabled');
 	}
 	if ($_POST['mailstream_attachimg']) {
 		PConfig::set(local_user(), 'mailstream', 'attachimg', $_POST['mailstream_attachimg']);
 	}
 	else {
-		del_pconfig(local_user(), 'mailstream', 'attachimg');
+		PConfig::delete(local_user(), 'mailstream', 'attachimg');
 	}
 }
 

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -348,7 +348,7 @@ function pumpio_settings_post(&$a,&$b) {
 			PConfig::set(local_user(),'pumpio','post_by_default',intval($_POST['pumpio_bydefault']));
 
 			if (!$_POST['pumpio_mirror'])
-				del_pconfig(local_user(),'pumpio','lastdate');
+				PConfig::delete(local_user(),'pumpio','lastdate');
 
 			//header("Location: ".$a->get_baseurl()."/pumpio/connect");
 		}

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -174,18 +174,18 @@ function statusnet_settings_post ($a,$post) {
 		/***
 		 * if the GNU Social-disconnect checkbox is set, clear the GNU Social configuration
 		 */
-		del_pconfig(local_user(), 'statusnet', 'consumerkey');
-		del_pconfig(local_user(), 'statusnet', 'consumersecret');
-		del_pconfig(local_user(), 'statusnet', 'post');
-		del_pconfig(local_user(), 'statusnet', 'post_by_default');
-		del_pconfig(local_user(), 'statusnet', 'oauthtoken');
-		del_pconfig(local_user(), 'statusnet', 'oauthsecret');
-		del_pconfig(local_user(), 'statusnet', 'baseapi');
-		del_pconfig(local_user(), 'statusnet', 'lastid');
-		del_pconfig(local_user(), 'statusnet', 'mirror_posts');
-		del_pconfig(local_user(), 'statusnet', 'import');
-		del_pconfig(local_user(), 'statusnet', 'create_user');
-		del_pconfig(local_user(), 'statusnet', 'own_id');
+		PConfig::delete(local_user(), 'statusnet', 'consumerkey');
+		PConfig::delete(local_user(), 'statusnet', 'consumersecret');
+		PConfig::delete(local_user(), 'statusnet', 'post');
+		PConfig::delete(local_user(), 'statusnet', 'post_by_default');
+		PConfig::delete(local_user(), 'statusnet', 'oauthtoken');
+		PConfig::delete(local_user(), 'statusnet', 'oauthsecret');
+		PConfig::delete(local_user(), 'statusnet', 'baseapi');
+		PConfig::delete(local_user(), 'statusnet', 'lastid');
+		PConfig::delete(local_user(), 'statusnet', 'mirror_posts');
+		PConfig::delete(local_user(), 'statusnet', 'import');
+		PConfig::delete(local_user(), 'statusnet', 'create_user');
+		PConfig::delete(local_user(), 'statusnet', 'own_id');
 	} else {
 	if (isset($_POST['statusnet-preconf-apiurl'])) {
 		/***
@@ -265,7 +265,7 @@ function statusnet_settings_post ($a,$post) {
 		PConfig::set(local_user(), 'statusnet', 'create_user', intval($_POST['statusnet-create_user']));
 
 		if (!intval($_POST['statusnet-mirror']))
-			del_pconfig(local_user(),'statusnet','lastid');
+			PConfig::delete(local_user(),'statusnet','lastid');
 
 		info( t('GNU Social settings updated.') . EOL);
 	}}}}
@@ -1687,7 +1687,7 @@ function statusnet_fetch_own_contact($a, $uid) {
 		if(count($r))
 			$contact_id = $r[0]["id"];
 		else
-			del_pconfig($uid, 'statusnet', 'own_url');
+			PConfig::delete($uid, 'statusnet', 'own_url');
 
 	}
 	return($contact_id);

--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -23,7 +23,7 @@ function widgets_settings_post(){
 	if(! local_user())
 		return;
 	if (isset($_POST['widgets-submit'])){
-		del_pconfig(local_user(), 'widgets', 'key');
+		PConfig::delete(local_user(), 'widgets', 'key');
 		
 	}
 }


### PR DESCRIPTION
Some addons were missed during the changes... now all should use the PConfig::delete call.