### PR TITLE
 membersince addon works now with frio

### DIFF
--- a/membersince/membersince.php
+++ b/membersince/membersince.php
@@ -49,7 +49,7 @@ function membersince_display(&$a, &$b)
 		$div->appendChild($hr);
 		$div->appendChild($label);
 		$div->appendChild($entry);
-		$elm->parentNode->appendChild($div);
+		$elm->parentNode->insertBefore($div, $elm->nextSibling);
 
 		$b = $doc->saveHTML();
 	} else {

--- a/membersince/membersince.php
+++ b/membersince/membersince.php
@@ -2,7 +2,7 @@
 /**
  * Name: MemberSince
  * Description: Display membership date in profile
- * Version: 1.0
+ * Version: 1.1
  * Author: Mike Macgirvin <http://macgirvin.com/profile/mike>
  *
  */

--- a/membersince/membersince.php
+++ b/membersince/membersince.php
@@ -23,9 +23,37 @@ function membersince_uninstall()
 
 function membersince_display(&$a, &$b)
 {
-	// Works in Vier
-	$b = preg_replace('/<\/dl>/', "</dl>\n\n\n<dl id=\"aprofile-membersince\" class=\"aprofile\">\n<dt>" . L10n::t('Member since:') . "</dt>\n<dd>" . DateTimeFormat::local($a->profile['register_date']) . "</dd>\n</dl>", $b, 1);
+	if (current_theme() == 'frio') {
+		// Works in Frio.
+		$doc = new DOMDocument();
+		$doc->loadHTML($b);
 
-	// Trying for Frio
-	//$b = preg_replace('/<\/div>/', "<div id=\"aprofile-membersince\" class=\"aprofile\"><hr class=\"profile-separator\"><div class=\"profile-label-name\">" . L10n::t('Member since:') . "</div><div class=\"profile-entry\">" . DateTimeFormat::local($a->profile['register_date']) . "</div></div>", $b, 1);
+		$elm = $doc->getElementById('aprofile-fullname');
+
+		$div = $doc->createElement('div');
+		$div->setAttribute('id','aprofile-membersince');
+		$div->setAttribute('class','col-lg-12 col-md-12 col-sm-12 col-xs-12 aprofile');
+
+		// The seperator line.
+		$hr = $doc->createElement('hr','');
+		$hr->setAttribute('class','profile-separator');
+
+		// The label div.
+		$label = $doc->createElement('div', L10n::t('Member since:'));
+		$label->setAttribute('class', 'col-lg-4 col-md-4 col-sm-4 col-xs-12 profile-label-name text-muted');
+
+		// The div for the register date of the profile owner.
+		$entry = $doc->createElement('div', DateTimeFormat::local($a->profile['register_date']));
+		$entry->setAttribute('class', 'col-lg-8 col-md-8 col-sm-8 col-xs-12 profile-entry');
+
+		$div->appendChild($hr);
+		$div->appendChild($label);
+		$div->appendChild($entry);
+		$elm->parentNode->appendChild($div);
+
+		$b = $doc->saveHTML();
+	} else {
+		// Works in Vier.
+		$b = preg_replace('/<\/dl>/', "</dl>\n\n\n<dl id=\"aprofile-membersince\" class=\"aprofile\">\n<dt>" . L10n::t('Member since:') . "</dt>\n<dd>" . DateTimeFormat::local($a->profile['register_date']) . "</dd>\n</dl>", $b, 1);
+	}
 }


### PR DESCRIPTION
see the title.

The membersince data will be added after the last entry of the content of the `#profile-content-standard` div.
I would like to have it inserted right after the `fullname` entry. But I could not manage it. Maybe someone else can have a look.