### PR TITLE
Namethingy is now unsupported

### DIFF
--- a/namethingy/namethingy.php
+++ b/namethingy/namethingy.php
@@ -5,6 +5,7 @@
  * Description: The Ultimate Random Name Generator
  * Version: 1.0
  * Author: Mike Macgirvin <http://macgirvin.com/profile/mike>
+ * Status: Unsupported
  */
 use Friendica\Core\Addon;
 


### PR DESCRIPTION
This addon doesn't work anymore since it is just a redirector to a website which doesn't exist anymore.