### PR TITLE
membersince: mark membersince as unsupported because it is now in core

### DIFF
--- a/membersince/membersince.php
+++ b/membersince/membersince.php
@@ -4,7 +4,7 @@
  * Description: Display membership date in profile
  * Version: 1.1
  * Author: Mike Macgirvin <http://macgirvin.com/profile/mike>
- *
+ * Status: Unsupported
  */
 
 use Friendica\Core\Addon;


### PR DESCRIPTION
The membersince addon was moved to core (https://github.com/friendica/friendica/pull/4432). So we can mark it as unsupported.