### PR TITLE
Results are now cached, format limits to other networks are respected

### DIFF
--- a/openstreetmap/openstreetmap.php
+++ b/openstreetmap/openstreetmap.php
@@ -16,7 +16,7 @@ use Friendica\Core\System;
 use Friendica\Util\Network;
 
 const OSM_TMS = 'http://www.openstreetmap.org';
-const OSM_NOM =	'http://nominatim.openstreetmap.org/search.php';
+const OSM_NOM = 'http://nominatim.openstreetmap.org/search.php';
 const OSM_ZOOM = 16;
 const OSM_MARKER = 0;
 

--- a/openstreetmap/openstreetmap.php
+++ b/openstreetmap/openstreetmap.php
@@ -12,13 +12,20 @@ use Friendica\Core\Addon;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
+use Friendica\Core\System;
 use Friendica\Util\Network;
+
+const OSM_TMS = 'http://www.openstreetmap.org';
+const OSM_NOM =	'http://nominatim.openstreetmap.org/search.php';
+const OSM_ZOOM = 16;
+const OSM_MARKER = 0;
 
 function openstreetmap_install()
 {
 	Addon::registerHook('render_location', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_location');
 	Addon::registerHook('generate_map', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_generate_map');
 	Addon::registerHook('generate_named_map', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_generate_named_map');
+	Addon::registerHook('Map::getCoordinates', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_get_coordinates');
 	Addon::registerHook('page_header', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_alterheader');
 
 	logger("installed openstreetmap");
@@ -29,6 +36,7 @@ function openstreetmap_uninstall()
 	Addon::unregisterHook('render_location', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_location');
 	Addon::unregisterHook('generate_map', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_generate_map');
 	Addon::unregisterHook('generate_named_map', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_generate_named_map');
+	Addon::unregisterHook('Map::getCoordinates', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_get_coordinates');
 	Addon::unregisterHook('page_header', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_alterheader');
 
 	logger("removed openstreetmap");
@@ -49,9 +57,9 @@ function openstreetmap_alterheader($a, &$navHtml)
  * @param mixed $a
  * @param array& $item
  */
-function openstreetmap_location($a, &$item) {
-
-	if(! (strlen($item['location']) || strlen($item['coord']))) {
+function openstreetmap_location($a, &$item)
+{
+	if (!(strlen($item['location']) || strlen($item['coord']))) {
 		return;
 	}
 
@@ -63,34 +71,25 @@ function openstreetmap_location($a, &$item) {
 	 * ?mlat=lat&mlon=lon for markers.
 	 */
 
-	$tmsserver = Config::get('openstreetmap', 'tmsserver');
-	if(! $tmsserver) {
-		$tmsserver = 'http://www.openstreetmap.org';
-	}
+	$tmsserver = Config::get('openstreetmap', 'tmsserver', OSM_TMS);
+	$nomserver = Config::get('openstreetmap', 'nomserver', OSM_NOM);
+	$zoom = Config::get('openstreetmap', 'zoom', OSM_ZOOM);
+	$marker = Config::get('openstreetmap', 'marker', OSM_MARKER);
 
-	$nomserver = Config::get('openstreetmap', 'nomserver');
-	if(! $nomserver) {
-		$nomserver = 'http://nominatim.openstreetmap.org/search.php';
-	}
-
-	$zoom = Config::get('openstreetmap', 'zoom');
-	if(! $zoom) {
-		$zoom = 16;
-	}
-
-	$marker = Config::get('openstreetmap', 'marker');
-	if(! $marker) {
-		$marker = 0;
+	// This is needed since we stored an empty string in the config in previous versions
+	if (empty($nomserver)) {
+		$nomserver = OSM_NOM;
 	}
 
 	if ($item['coord'] != "") {
 		$coords = explode(' ', $item['coord']);
-		if(count($coords) > 1) {
+		if (count($coords) > 1) {
 			$lat = urlencode(round($coords[0], 5));
 			$lon = urlencode(round($coords[1], 5));
 			$target = $tmsserver;
-			if($marker > 0)
-				$target .= '?mlat='.$lat.'&mlon='.$lon;
+			if ($marker > 0) {
+				$target .= '?mlat=' . $lat . '&mlon=' . $lon;
+			}
 			$target .= '#map='.intval($zoom).'/'.$lat.'/'.$lon;
 		}
 	}
@@ -108,46 +107,53 @@ function openstreetmap_location($a, &$item) {
 	$item['html'] = '<a target="map" title="'.$title.'" href= "'.$target.'">'.$title.'</a>';
 }
 
+function openstreetmap_get_coordinates($a, &$b)
+{
+	$nomserver = Config::get('openstreetmap', 'nomserver', OSM_NOM);
+
+	// This is needed since we stored an empty string in the config in previous versions
+	if (empty($nomserver)) {
+		$nomserver = OSM_NOM;
+	}
+
+	$args = '?q=' . urlencode($b['location']) . '&format=json';
+
+	$cachekey = "openstreetmap:" . $b['location'];
+	$j = Cache::get($cachekey);
+
+	if (is_null($j)) {
+		$x = Network::curl($nomserver . $args);
+		if ($x['success']) {
+			$j = json_decode($x['body'], true);
+			Cache::set($cachekey, $j, CACHE_MONTH);
+		}
+	}
+
+	if (!empty($j[0]['lat']) && !empty($j[0]['lon'])) {
+		$b['lat'] = $j[0]['lat'];
+		$b['lon'] = $j[0]['lon'];
+	}
+}
 
 function openstreetmap_generate_named_map(&$a, &$b)
 {
-	$nomserver = Config::get('openstreetmap', 'nomserver');
-	if(! $nomserver)
-		$nomserver = 'http://nominatim.openstreetmap.org/search.php';
-	$args = '?q=' . urlencode($b['location']) . '&format=json';
+	openstreetmap_get_coordinates($a, $b);
 
-	$x = Network::curl($nomserver . $args);
-	if($x['success']) {
-		$j = json_decode($x['body'],true);
-
-		if($j && is_array($j) && $j[0]['lat'] && $j[0]['lon']) {
-			$arr = ['lat' => $j[0]['lat'],'lon' => $j[0]['lon'],'location' => $b['location'], 'html' => ''];
-			openstreetmap_generate_map($a,$arr);
-			$b['html'] = $arr['html'];
-		}
+	if (!empty($b['lat']) && !empty($b['lon'])) {
+		openstreetmap_generate_map($a, $b);
 	}
 }
 
 function openstreetmap_generate_map(&$a, &$b)
 {
-	$tmsserver = Config::get('openstreetmap', 'tmsserver');
-	if(! $tmsserver) {
-		$tmsserver = 'http://www.openstreetmap.org';
-	}
-	if(strpos(z_root(),'https:') !== false) {
+	$tmsserver = Config::get('openstreetmap', 'tmsserver', OSM_TMS);
+
+	if (strpos(z_root(), 'https:') !== false) {
 		$tmsserver = str_replace('http:','https:',$tmsserver);
 	}
 
-
-	$zoom = Config::get('openstreetmap', 'zoom');
-	if (!$zoom) {
-		$zoom = 16;
-	}
-
-	$marker = Config::get('openstreetmap', 'marker');
-	if (!$marker) {
-		$marker = 0;
-	}
+	$zoom = Config::get('openstreetmap', 'zoom', OSM_ZOOM);
+	$marker = Config::get('openstreetmap', 'marker', OSM_MARKER);
 
 	$lat = $b['lat']; // round($b['lat'], 5);
 	$lon = $b['lon']; // round($b['lon'], 5);
@@ -155,10 +161,21 @@ function openstreetmap_generate_map(&$a, &$b)
 	logger('lat: ' . $lat, LOGGER_DATA);
 	logger('lon: ' . $lon, LOGGER_DATA);
 
+	$cardlink = '<a href="' . $tmsserver;
 
-	$b['html'] = '<iframe style="width:100%; height:300px; border:1px solid #ccc" src="' . $tmsserver . '/export/embed.html?bbox=' . ($lon - 0.01) . '%2C' . ($lat - 0.01) . '%2C' . ($lon + 0.01) . '%2C' . ($lat + 0.01) ;
+	if ($marker > 0) {
+		$cardlink .= '?mlat=' . $lat . '&mlon=' . $lon;
+	}
 
-	$b['html'] .=  '&amp;layer=mapnik&amp;marker=' . $lat . '%2C' . $lon . '" style="border: 1px solid black"></iframe><br/><small><a href="' . $tmsserver . '/?mlat=' . $lat . '&mlon=' . $lon . '#map=16/' . $lat . '/' . $lon . '">' . (($b['location']) ? escape_tags($b['location']) : L10n::t('View Larger')) . '</a></small>';
+	$cardlink .= '#map=' . $zoom . '/' . $lat . '/' . $lon . '">' . ($b['location'] ? escape_tags($b['location']) : L10n::t('View Larger')) . '</a>';
+	if (empty($b['mode'])) {
+		$b['html'] = '<iframe style="width:100%; height:300px; border:1px solid #ccc" src="' . $tmsserver .
+				'/export/embed.html?bbox=' . ($lon - 0.01) . '%2C' . ($lat - 0.01) . '%2C' . ($lon + 0.01) . '%2C' . ($lat + 0.01) .
+				'&amp;layer=mapnik&amp;marker=' . $lat . '%2C' . $lon . '" style="border: 1px solid black"></iframe>' .
+				'<br/><small>' . $cardlink . '</small>';
+	} else {
+		$b['html'] .= '<br/>' . $cardlink;
+	}
 
 	logger('generate_map: ' . $b['html'], LOGGER_DATA);
 }
@@ -166,21 +183,14 @@ function openstreetmap_generate_map(&$a, &$b)
 function openstreetmap_addon_admin(&$a, &$o)
 {
 	$t = get_markup_template("admin.tpl", "addon/openstreetmap/");
-	$tmsserver = Config::get('openstreetmap', 'tmsserver');
-	if (!$tmsserver) {
-		$tmsserver = 'http://www.openstreetmap.org';
-	}
-	$nomserver = Config::get('openstreetmap', 'nomserver');
-	if (!$nomserver) {
-		$nomserver = 'http://nominatim.openstreetmap.org/search.php';
-	}
-	$zoom = Config::get('openstreetmap', 'zoom');
-	if (!$zoom) {
-		$zoom = 16;
-	}
-	$marker = Config::get('openstreetmap', 'marker');
-	if (!$marker) {
-		$marker = 0;
+	$tmsserver = Config::get('openstreetmap', 'tmsserver', OSM_TMS);
+	$nomserver = Config::get('openstreetmap', 'nomserver', OSM_NOM);
+	$zoom = Config::get('openstreetmap', 'zoom', OSM_ZOOM);
+	$marker = Config::get('openstreetmap', 'marker', OSM_MARKER);
+
+	// This is needed since we stored an empty string in the config in previous versions
+	if (empty($nomserver)) {
+		$nomserver = OSM_NOM;
 	}
 
 	$o = replace_macros($t, [
@@ -194,13 +204,15 @@ function openstreetmap_addon_admin(&$a, &$o)
 
 function openstreetmap_addon_admin_post(&$a)
 {
-	$urltms = ((x($_POST, 'tmsserver')) ? notags(trim($_POST['tmsserver'])) : '');
-	$urlnom = ((x($_POST, 'nomserver')) ? notags(trim($_POST['nomserver'])) : '');
-	$zoom = ((x($_POST, 'zoom')) ? intval(trim($_POST['zoom'])) : '16');
-	$marker = ((x($_POST, 'marker')) ? intval(trim($_POST['marker'])) : '0');
+	$urltms = defaults($_POST, 'tmsserver', OSM_TMS);
+	$urlnom = defaults($_POST, 'nomserver', OSM_NOM);
+	$zoom = defaults($_POST, 'zoom', OSM_ZOOM);
+	$marker = defaults($_POST, 'marker', OSM_MARKER);
+
 	Config::set('openstreetmap', 'tmsserver', $urltms);
 	Config::set('openstreetmap', 'nomserver', $urlnom);
 	Config::set('openstreetmap', 'zoom', $zoom);
 	Config::set('openstreetmap', 'marker', $marker);
+
 	info(L10n::t('Settings updated.') . EOL);
 }

--- a/openstreetmap/templates/admin.tpl
+++ b/openstreetmap/templates/admin.tpl
@@ -1,5 +1,5 @@
 {{include file="field_input.tpl" field=$tmsserver}}
-<!-- {{include file="field_input.tpl" field=$nomserver}}-->
+{{include file="field_input.tpl" field=$nomserver}}
 {{include file="field_input.tpl" field=$zoom}}
 {{include file="field_checkbox.tpl" field=$marker}}
 <div class="submit"><input type="submit" name="openstreetmap" value="{{$submit}}"></div>


### PR DESCRIPTION
This belongs to PR https://github.com/friendica/friendica/pull/4636

Additionally to the improvements for exports to other networks, there is now a caching of requests to avoid restrictions by the OSM servers.