### PR TITLE
Add content_filter hook

### DIFF
--- a/blockem/blockem.php
+++ b/blockem/blockem.php
@@ -12,7 +12,7 @@ use Friendica\Core\PConfig;
 
 function blockem_install()
 {
-	Addon::registerHook('prepare_body', 'addon/blockem/blockem.php', 'blockem_prepare_body');
+	Addon::registerHook('content_filter', 'addon/blockem/blockem.php', 'blockem_content_filter');
 	Addon::registerHook('display_item', 'addon/blockem/blockem.php', 'blockem_display_item');
 	Addon::registerHook('addon_settings', 'addon/blockem/blockem.php', 'blockem_addon_settings');
 	Addon::registerHook('addon_settings_post', 'addon/blockem/blockem.php', 'blockem_addon_settings_post');
@@ -23,6 +23,7 @@ function blockem_install()
 
 function blockem_uninstall()
 {
+	Addon::unregisterHook('content_filter', 'addon/blockem/blockem.php', 'blockem_content_filter');
 	Addon::unregisterHook('prepare_body', 'addon/blockem/blockem.php', 'blockem_prepare_body');
 	Addon::unregisterHook('display_item', 'addon/blockem/blockem.php', 'blockem_display_item');
 	Addon::unregisterHook('addon_settings', 'addon/blockem/blockem.php', 'blockem_addon_settings');
@@ -106,38 +107,33 @@ function blockem_enotify_store(&$a,&$b) {
 	}
 }
 
-function blockem_prepare_body(&$a,&$b) {
-
-	if(! local_user())
+function blockem_content_filter(\Friendica\App $a, &$hook_data)
+{
+	if (!local_user()) {
 		return;
+	}
 
-	$words = null;
-	if(local_user()) {
-		$words = PConfig::get(local_user(),'blockem','words');
+	$profiles_string = null;
+	if (local_user()) {
+		$profiles_string = PConfig::get(local_user(), 'blockem', 'words');
 	}
-	if($words) {
-		$arr = explode(',',$words);
-	}
-	else {
+
+	if ($profiles_string) {
+		$profiles_array = explode(',', $profiles_string);
+	} else {
 		return;
 	}
 
 	$found = false;
-	if(count($arr)) {
-		foreach($arr as $word) {
-			if(! strlen(trim($word))) {
-				continue;
-			}
-
-			if(link_compare($b['item']['author-link'],$word)) {
-				$found = true;
-				break;
-			}
+	foreach ($profiles_array as $word) {
+		if (link_compare($hook_data['item']['author-link'], trim($word))) {
+			$found = true;
+			break;
 		}
 	}
-	if($found) {
-		$rnd = random_string(8);
-		$b['html'] = '<div id="blockem-wrap-' . $rnd . '" class="fakelink" onclick=openClose(\'blockem-' . $rnd . '\'); >' . L10n::t('Hidden content by %s - Click to open/close', $word) . '</div><div id="blockem-' . $rnd . '" style="display: none; " >' . $b['html'] . '</div>';
+
+	if ($found) {
+		$hook_data['filter_reasons'][] = L10n::t('Filtered user: %s', $hook_data['item']['author-name']);
 	}
 }
 

--- a/blockem/blockem.php
+++ b/blockem/blockem.php
@@ -12,7 +12,7 @@ use Friendica\Core\PConfig;
 
 function blockem_install()
 {
-	Addon::registerHook('content_filter', 'addon/blockem/blockem.php', 'blockem_content_filter');
+	Addon::registerHook('prepare_body_content_filter', 'addon/blockem/blockem.php', 'blockem_prepare_body_content_filter');
 	Addon::registerHook('display_item', 'addon/blockem/blockem.php', 'blockem_display_item');
 	Addon::registerHook('addon_settings', 'addon/blockem/blockem.php', 'blockem_addon_settings');
 	Addon::registerHook('addon_settings_post', 'addon/blockem/blockem.php', 'blockem_addon_settings_post');
@@ -23,7 +23,7 @@ function blockem_install()
 
 function blockem_uninstall()
 {
-	Addon::unregisterHook('content_filter', 'addon/blockem/blockem.php', 'blockem_content_filter');
+	Addon::unregisterHook('prepare_body_content_filter', 'addon/blockem/blockem.php', 'blockem_prepare_body_content_filter');
 	Addon::unregisterHook('prepare_body', 'addon/blockem/blockem.php', 'blockem_prepare_body');
 	Addon::unregisterHook('display_item', 'addon/blockem/blockem.php', 'blockem_display_item');
 	Addon::unregisterHook('addon_settings', 'addon/blockem/blockem.php', 'blockem_addon_settings');
@@ -107,7 +107,7 @@ function blockem_enotify_store(&$a,&$b) {
 	}
 }
 
-function blockem_content_filter(\Friendica\App $a, &$hook_data)
+function blockem_prepare_body_content_filter(\Friendica\App $a, &$hook_data)
 {
 	if (!local_user()) {
 		return;

--- a/blockem/lang/C/messages.po
+++ b/blockem/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-09 13:00+0100\n"
+"POT-Creation-Date: 2018-04-01 11:11-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,41 +17,41 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: blockem.php:51 blockem.php:55
+#: blockem.php:52 blockem.php:56
 msgid "\"Blockem\""
 msgstr ""
 
-#: blockem.php:59
+#: blockem.php:60
 msgid ""
 "Hides user's content by collapsing posts. Also replaces their avatar with "
 "generic image."
 msgstr ""
 
-#: blockem.php:60
+#: blockem.php:61
 msgid "Comma separated profile URLS:"
 msgstr ""
 
-#: blockem.php:64
+#: blockem.php:65
 msgid "Save Settings"
 msgstr ""
 
-#: blockem.php:77
+#: blockem.php:78
 msgid "BLOCKEM Settings saved."
 msgstr ""
 
-#: blockem.php:140
+#: blockem.php:136
 #, php-format
-msgid "Hidden content by %s - Click to open/close"
+msgid "Filtered user: %s"
 msgstr ""
 
-#: blockem.php:193
+#: blockem.php:189
 msgid "Unblock Author"
 msgstr ""
 
-#: blockem.php:195
+#: blockem.php:191
 msgid "Block Author"
 msgstr ""
 
-#: blockem.php:227
+#: blockem.php:223
 msgid "blockem settings updated"
 msgstr ""

--- a/fromgplus/fromgplus.php
+++ b/fromgplus/fromgplus.php
@@ -103,7 +103,7 @@ function fromgplus_addon_admin(&$a, &$o)
 
 	$o = replace_macros($t, [
 			'$submit' => L10n::t('Save Settings'),
-			'$key' => ['key', L10n::t('Key'), trim(Config::get('fromgplus', 'key')), L10n::t('')],
+			'$key' => ['key', L10n::t('Key'), trim(Config::get('fromgplus', 'key')), ''],
 	]);
 }
 

--- a/fromgplus/lang/C/messages.po
+++ b/fromgplus/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-12 16:52+0000\n"
+"POT-Creation-Date: 2018-04-01 11:14-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,34 +17,34 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: fromgplus.php:46 fromgplus.php:50
+#: fromgplus.php:55 fromgplus.php:59
 msgid "Google+ Mirror"
 msgstr ""
 
-#: fromgplus.php:55
+#: fromgplus.php:64
 msgid "Enable Google+ Import"
 msgstr ""
 
-#: fromgplus.php:58
+#: fromgplus.php:67
 msgid "Google Account ID"
 msgstr ""
 
-#: fromgplus.php:61
+#: fromgplus.php:70
 msgid "Add keywords to post"
 msgstr ""
 
-#: fromgplus.php:66 fromgplus.php:95
+#: fromgplus.php:75 fromgplus.php:105
 msgid "Save Settings"
 msgstr ""
 
-#: fromgplus.php:87
+#: fromgplus.php:96
 msgid "Google+ Import Settings saved."
 msgstr ""
 
-#: fromgplus.php:96
+#: fromgplus.php:106
 msgid "Key"
 msgstr ""
 
-#: fromgplus.php:103
+#: fromgplus.php:114
 msgid "Settings updated."
 msgstr ""

--- a/langfilter/lang/C/messages.po
+++ b/langfilter/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-29 22:43+0700\n"
+"POT-Creation-Date: 2018-04-01 11:11-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,62 +17,62 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: langfilter.php:57
+#: langfilter.php:58
 msgid "Language Filter"
 msgstr ""
 
-#: langfilter.php:58
+#: langfilter.php:59
 msgid ""
 "This addon tries to identify the language posts are writen in. If it does "
 "not match any language specifed below, posts will be hidden by collapsing "
 "them."
 msgstr ""
 
-#: langfilter.php:59
+#: langfilter.php:60
 msgid "Use the language filter"
 msgstr ""
 
-#: langfilter.php:60
+#: langfilter.php:61
 msgid "Able to read"
 msgstr ""
 
-#: langfilter.php:60
+#: langfilter.php:61
 msgid ""
 "List of abbreviations (iso2 codes) for languages you speak, comma separated. "
 "For example \"de,it\"."
 msgstr ""
 
-#: langfilter.php:61
+#: langfilter.php:62
 msgid "Minimum confidence in language detection"
 msgstr ""
 
-#: langfilter.php:61
+#: langfilter.php:62
 msgid ""
 "Minimum confidence in language detection being correct, from 0 to 100. Posts "
 "will not be filtered when the confidence of language detection is below this "
 "percent value."
 msgstr ""
 
-#: langfilter.php:62
+#: langfilter.php:63
 msgid "Minimum length of message body"
 msgstr ""
 
-#: langfilter.php:62
+#: langfilter.php:63
 msgid ""
 "Minimum number of characters in message body for filter to be used. Posts "
 "shorter than this will not be filtered. Note: Language detection is "
 "unreliable for short content (<200 characters)."
 msgstr ""
 
-#: langfilter.php:63
+#: langfilter.php:64
 msgid "Save Settings"
 msgstr ""
 
-#: langfilter.php:104
+#: langfilter.php:105
 msgid "Language Filter Settings saved."
 msgstr ""
 
-#: langfilter.php:181
+#: langfilter.php:182
 #, php-format
-msgid "Hidden content in %s - Click to open/close"
+msgid "Filtered language: %s"
 msgstr ""

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -19,14 +19,14 @@ use Friendica\Core\PConfig;
 
 function langfilter_install()
 {
-	Addon::registerHook('content_filter', 'addon/langfilter/langfilter.php', 'langfilter_content_filter', 10);
+	Addon::registerHook('prepare_body_content_filter', 'addon/langfilter/langfilter.php', 'langfilter_prepare_body_content_filter', 10);
 	Addon::registerHook('addon_settings', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings');
 	Addon::registerHook('addon_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
 }
 
 function langfilter_uninstall()
 {
-	Addon::unregisterHook('content_filter', 'addon/langfilter/langfilter.php', 'langfilter_content_filter');
+	Addon::unregisterHook('prepare_body_content_filter', 'addon/langfilter/langfilter.php', 'langfilter_prepare_body_content_filter');
 	Addon::unregisterHook('prepare_body', 'addon/langfilter/langfilter.php', 'langfilter_prepare_body');
 	Addon::unregisterHook('addon_settings', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings');
 	Addon::unregisterHook('addon_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
@@ -115,7 +115,7 @@ function langfilter_addon_settings_post(App $a, &$b)
  *     expand it again.
  */
 
-function langfilter_content_filter(App $a, &$hook_data)
+function langfilter_prepare_body_content_filter(App $a, &$hook_data)
 {
 	$logged_user = local_user();
 	if (!$logged_user) {

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -19,13 +19,14 @@ use Friendica\Core\PConfig;
 
 function langfilter_install()
 {
-	Addon::registerHook('prepare_body', 'addon/langfilter/langfilter.php', 'langfilter_prepare_body', 10);
+	Addon::registerHook('content_filter', 'addon/langfilter/langfilter.php', 'langfilter_content_filter', 10);
 	Addon::registerHook('addon_settings', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings');
 	Addon::registerHook('addon_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
 }
 
 function langfilter_uninstall()
 {
+	Addon::unregisterHook('content_filter', 'addon/langfilter/langfilter.php', 'langfilter_content_filter');
 	Addon::unregisterHook('prepare_body', 'addon/langfilter/langfilter.php', 'langfilter_prepare_body');
 	Addon::unregisterHook('addon_settings', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings');
 	Addon::unregisterHook('addon_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
@@ -114,7 +115,7 @@ function langfilter_addon_settings_post(App $a, &$b)
  *     expand it again.
  */
 
-function langfilter_prepare_body(App $a, &$b)
+function langfilter_content_filter(App $a, &$hook_data)
 {
 	$logged_user = local_user();
 	if (!$logged_user) {
@@ -124,7 +125,7 @@ function langfilter_prepare_body(App $a, &$b)
 	// Never filter own messages
 	// TODO: find a better way to extract this
 	$logged_user_profile = $a->get_baseurl() . '/profile/' . $a->user['nickname'];
-	if ($logged_user_profile == $b['item']['author-link']) {
+	if ($logged_user_profile == $hook_data['item']['author-link']) {
 		return;
 	}
 
@@ -138,24 +139,26 @@ function langfilter_prepare_body(App $a, &$b)
 	if (!$minlen) {
 		$minlen = 32;
 	}
-	if (strlen($b['item']['body']) < $minlen) {
+	if (strlen($hook_data['item']['body']) < $minlen) {
 		return;
 	}
 
-	$spoken_config = PConfig::get(local_user(), 'langfilter', 'languages');
+	$read_languages_string = PConfig::get(local_user(), 'langfilter', 'languages');
 	$minconfidence = PConfig::get(local_user(), 'langfilter', 'minconfidence');
 
 	// Don't filter if no spoken languages are configured
-	if (!$spoken_config)
+	if (!$read_languages_string) {
 		return;
-	$spoken_languages = explode(',', $spoken_config);
+	}
+	$read_languages_array = explode(',', $read_languages_string);
 
 	// Extract the language of the post
-	$opts = $b['item']['postopts'];
+	$opts = $hook_data['item']['postopts'];
 	if (!$opts) {
 		// no options associated to post
 		return;
 	}
+
 	if (!preg_match('/\blang=([^;]*);([^:]*)/', $opts, $matches)) {
 		// no lang options associated to post
 		return;
@@ -174,10 +177,8 @@ function langfilter_prepare_body(App $a, &$b)
 	if (!$iso2) {
 		return;
 	}
-	$spoken = in_array($iso2, $spoken_languages);
 
-	if (!$spoken) {
-		$rnd = random_string(8);
-		$b['html'] = '<div id="langfilter-wrap-' . $rnd . '" class="fakelink" onclick=openClose(\'langfilter-' . $rnd . '\'); >' . L10n::t('Hidden content in %s - Click to open/close', $lang) . '</div><div id="langfilter-' . $rnd . '" style="display: none; " >' . $b['html'] . '</div>';
+	if (!in_array($iso2, $read_languages_array)) {
+		$hook_data['filter_reasons'][] = L10n::t('Filtered language: %s', ucfirst($lang));
 	}
 }

--- a/nsfw/lang/C/messages.po
+++ b/nsfw/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-15 17:54+0700\n"
+"POT-Creation-Date: 2018-04-01 11:11-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,12 @@ msgstr ""
 msgid "NSFW Settings saved."
 msgstr ""
 
-#: nsfw.php:167
+#: nsfw.php:162
 #, php-format
-msgid "%s - Click to open/close"
+msgid "Filtered tag: %s"
+msgstr ""
+
+#: nsfw.php:164
+#, php-format
+msgid "Filtered word: %s"
 msgstr ""

--- a/nsfw/nsfw.php
+++ b/nsfw/nsfw.php
@@ -13,14 +13,14 @@ use Friendica\Core\PConfig;
 
 function nsfw_install()
 {
-	Addon::registerHook('content_filter', 'addon/nsfw/nsfw.php', 'nsfw_content_filter', 10);
+	Addon::registerHook('prepare_body_content_filter', 'addon/nsfw/nsfw.php', 'nsfw_prepare_body_content_filter', 10);
 	Addon::registerHook('addon_settings', 'addon/nsfw/nsfw.php', 'nsfw_addon_settings');
 	Addon::registerHook('addon_settings_post', 'addon/nsfw/nsfw.php', 'nsfw_addon_settings_post');
 }
 
 function nsfw_uninstall()
 {
-	Addon::unregisterHook('content_filter', 'addon/nsfw/nsfw.php', 'nsfw_content_filter');
+	Addon::unregisterHook('prepare_body_content_filter', 'addon/nsfw/nsfw.php', 'nsfw_prepare_body_content_filter');
 	Addon::unregisterHook('prepare_body', 'addon/nsfw/nsfw.php', 'nsfw_prepare_body');
 	Addon::unregisterHook('addon_settings', 'addon/nsfw/nsfw.php', 'nsfw_addon_settings');
 	Addon::unregisterHook('addon_settings_post', 'addon/nsfw/nsfw.php', 'nsfw_addon_settings_post');
@@ -110,7 +110,7 @@ function nsfw_addon_settings_post(&$a, &$b)
 	}
 }
 
-function nsfw_content_filter(\Friendica\App $a, &$hook_data)
+function nsfw_prepare_body_content_filter(\Friendica\App $a, &$hook_data)
 {
 	$words = null;
 	if (PConfig::get(local_user(), 'nsfw', 'disable')) {

--- a/showmore/lang/C/messages.po
+++ b/showmore/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"POT-Creation-Date: 2018-04-01 11:11-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,26 +17,26 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: showmore.php:38
+#: showmore.php:41 showmore.php:45
 msgid "\"Show more\" Settings"
 msgstr ""
 
-#: showmore.php:41
+#: showmore.php:50
 msgid "Enable Show More"
 msgstr ""
 
-#: showmore.php:44
+#: showmore.php:53
 msgid "Cutting posts after how much characters"
 msgstr ""
 
-#: showmore.php:48
-msgid "Submit"
+#: showmore.php:57
+msgid "Save Settings"
 msgstr ""
 
-#: showmore.php:65
+#: showmore.php:74
 msgid "Show More Settings saved."
 msgstr ""
 
-#: showmore.php:119
+#: showmore.php:134
 msgid "show more"
 msgstr ""

--- a/showmore/showmore.php
+++ b/showmore/showmore.php
@@ -107,26 +107,32 @@ function get_body_length($body) {
 	return strlen($string);
 }
 
-function showmore_prepare_body(&$a,&$b) {
-
-	$words = null;
-	if(PConfig::get(local_user(),'showmore','disable'))
+function showmore_prepare_body(\Friendica\App $a, &$hook_data)
+{
+	// No combination with content filters
+	if (!empty($hook_data['filter_reasons'])) {
 		return;
-
-	$chars = (int)PConfig::get(local_user(),'showmore','chars');
-	if(!$chars)
-		$chars = 1100;
-
-	if (get_body_length($b['html']) > $chars) {
-		$found = true;
-		$shortened = trim(showmore_cutitem($b['html'], $chars))."...";
 	}
 
-	if($found) {
+	if (PConfig::get(local_user(), 'showmore', 'disable')) {
+		return;
+	}
+
+	$chars = (int) PConfig::get(local_user(), 'showmore', 'chars');
+	if (!$chars) {
+		$chars = 1100;
+	}
+
+	if (get_body_length($hook_data['html']) > $chars) {
+		$found = true;
+		$shortened = trim(showmore_cutitem($hook_data['html'], $chars)) . "...";
+	}
+
+	if ($found) {
 		$rnd = random_string(8);
-		$b['html'] = '<span id="showmore-teaser-'.$rnd.'" class="showmore-teaser" style="display: block;">'.$shortened." ".
-				'<span id="showmore-wrap-'.$rnd.'" style="white-space:nowrap;" class="showmore-wrap fakelink" onclick="openClose(\'showmore-'.$rnd.'\'); openClose(\'showmore-teaser-'.$rnd.'\');" >'.L10n::t('show more').'</span></span>'.
-				'<div id="showmore-'.$rnd.'" class="showmore-content" style="display: none;">'.$b['html'].'</div>';
+		$hook_data['html'] = '<span id="showmore-teaser-' . $rnd . '" class="showmore-teaser" style="display: block;">' . $shortened . " " .
+			'<span id="showmore-wrap-' . $rnd . '" style="white-space:nowrap;" class="showmore-wrap fakelink" onclick="openClose(\'showmore-' . $rnd . '\'); openClose(\'showmore-teaser-' . $rnd . '\');" >' . L10n::t('show more') . '</span></span>' .
+			'<div id="showmore-' . $rnd . '" class="showmore-content" style="display: none;">' . $hook_data['html'] . '</div>';
 	}
 }
 


### PR DESCRIPTION
See: https://friendica.mrpetovan.com/display/735a2029715ab80d1874cf6808556656

Depends on https://github.com/friendica/friendica/pull/4722

Please review the translation strings I added, they may not be the best way of presening the content filtering reasons.

Additionally, the showmore addon now disabled when there is a content-filter applied because of display incompatibility.