### PR TITLE
Guess language from plaintext

### DIFF
--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -8,12 +8,12 @@
 require 'addon/buffer/bufferapp.php';
 
 use Friendica\App;
-use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\Plaintext;
 use Friendica\Core\Addon;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
+use Friendica\Model\Item;
 
 function buffer_install() {
 	Addon::registerHook('post_local',           'addon/buffer/buffer.php', 'buffer_post_local');
@@ -338,7 +338,7 @@ function buffer_send(App $a, &$b)
 					$item["body"] = preg_replace("(\[s\](.*?)\[\/s\])ism",'-$1-',$item["body"]);
 				}
 
-				$post = BBCode::toPlaintext($item, $limit, $includedlinks, $htmlmode);
+				$post = Item::getPlaintextPost($item, $limit, $includedlinks, $htmlmode);
 				logger("buffer_send: converted message ".$b["id"]." result: ".print_r($post, true), LOGGER_DEBUG);
 
 				// The image proxy is used as a sanitizer. Buffer seems to be really picky about pictures

--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -13,7 +13,7 @@ use Friendica\Core\Addon;
 use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\Model\Item;
+use Friendica\Model\ItemContent;
 
 function buffer_install() {
 	Addon::registerHook('post_local',           'addon/buffer/buffer.php', 'buffer_post_local');
@@ -338,7 +338,7 @@ function buffer_send(App $a, &$b)
 					$item["body"] = preg_replace("(\[s\](.*?)\[\/s\])ism",'-$1-',$item["body"]);
 				}
 
-				$post = Item::getPlaintextPost($item, $limit, $includedlinks, $htmlmode);
+				$post = ItemContent::getPlaintextPost($item, $limit, $includedlinks, $htmlmode);
 				logger("buffer_send: converted message ".$b["id"]." result: ".print_r($post, true), LOGGER_DEBUG);
 
 				// The image proxy is used as a sanitizer. Buffer seems to be really picky about pictures

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -134,12 +134,15 @@ function langfilter_prepare_body_content_filter(App $a, &$hook_data)
 		return;
 	}
 
+	$naked_body = Text\BBCode::toPlaintext($hook_data['item']['body'], false);
+
 	// Don't filter if body lenght is below minimum
-	$minlen = PConfig::get(local_user(), 'langfilter', 'minlength');
+	$minlen = PConfig::get(local_user(), 'langfilter', 'minlength', 32);
 	if (!$minlen) {
 		$minlen = 32;
 	}
-	if (strlen($hook_data['item']['body']) < $minlen) {
+
+	if (strlen($naked_body) < $minlen) {
 		return;
 	}
 

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -8,6 +8,7 @@
  */
 
 use Friendica\App;
+use Friendica\Content\Text\BBCode;
 use Friendica\Core\Addon;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
@@ -134,7 +135,7 @@ function langfilter_prepare_body_content_filter(App $a, &$hook_data)
 		return;
 	}
 
-	$naked_body = Text\BBCode::toPlaintext($hook_data['item']['body'], false);
+	$naked_body = BBCode::toPlaintext($hook_data['item']['body'], false);
 
 	// Don't filter if body lenght is below minimum
 	$minlen = PConfig::get(local_user(), 'langfilter', 'minlength', 32);

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -550,7 +550,7 @@ function statusnet_post_hook(App $a, &$b)
 		PConfig::set($b['uid'], 'statusnet', 'max_char', $max_char);
 
 		$tempfile = "";
-		$msgarr = BBCode::toPlaintext($b, $max_char, true, 7);
+		$msgarr = Item::getPlaintextPost($b, $max_char, true, 7);
 		$msg = $msgarr["text"];
 
 		if (($msg == "") && isset($msgarr["title"]))
@@ -709,7 +709,7 @@ function statusnet_prepare_body(App $a, &$b)
 			}
 		}
 
-		$msgarr = BBCode::toPlaintext($item, $max_char, true, 7);
+		$msgarr = Item::getPlaintextPost($item, $max_char, true, 7);
 		$msg = $msgarr["text"];
 
 		if (isset($msgarr["url"]) && ($msgarr["type"] != "photo")) {

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -41,7 +41,6 @@ require_once 'include/enotify.php';
 use CodebirdSN\CodebirdSN;
 use Friendica\App;
 use Friendica\Content\OEmbed;
-use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\HTML;
 use Friendica\Content\Text\Plaintext;
 use Friendica\Core\Addon;
@@ -51,6 +50,7 @@ use Friendica\Core\PConfig;
 use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
+use Friendica\Model\ItemContent;
 use Friendica\Model\Photo;
 use Friendica\Model\User;
 use Friendica\Util\DateTimeFormat;
@@ -550,7 +550,7 @@ function statusnet_post_hook(App $a, &$b)
 		PConfig::set($b['uid'], 'statusnet', 'max_char', $max_char);
 
 		$tempfile = "";
-		$msgarr = Item::getPlaintextPost($b, $max_char, true, 7);
+		$msgarr = ItemContent::getPlaintextPost($b, $max_char, true, 7);
 		$msg = $msgarr["text"];
 
 		if (($msg == "") && isset($msgarr["title"]))
@@ -709,7 +709,7 @@ function statusnet_prepare_body(App $a, &$b)
 			}
 		}
 
-		$msgarr = Item::getPlaintextPost($item, $max_char, true, 7);
+		$msgarr = ItemContent::getPlaintextPost($item, $max_char, true, 7);
 		$msg = $msgarr["text"];
 
 		if (isset($msgarr["url"]) && ($msgarr["type"] != "photo")) {

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -532,7 +532,7 @@ function twitter_post_hook(App $a, &$b)
 		$connection->setTimeouts(10, 30);
 
 		$max_char = 280;
-		$msgarr = BBCode::toPlaintext($b, $max_char, true, 8);
+		$msgarr = Item::getPlaintextPost($b, $max_char, true, 8);
 		$msg = $msgarr["text"];
 
 		if (($msg == "") && isset($msgarr["title"])) {
@@ -766,7 +766,7 @@ function twitter_prepare_body(App $a, &$b)
 			}
 		}
 
-		$msgarr = BBCode::toPlaintext($item, $max_char, true, 8);
+		$msgarr = Item::getPlaintextPost($item, $max_char, true, 8);
 		$msg = $msgarr["text"];
 
 		if (isset($msgarr["url"]) && ($msgarr["type"] != "photo")) {

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -63,7 +63,6 @@
 use Abraham\TwitterOAuth\TwitterOAuth;
 use Friendica\App;
 use Friendica\Content\OEmbed;
-use Friendica\Content\Text\BBCode;
 use Friendica\Content\Text\Plaintext;
 use Friendica\Core\Addon;
 use Friendica\Core\Config;
@@ -73,6 +72,7 @@ use Friendica\Core\Worker;
 use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
+use Friendica\Model\ItemContent;
 use Friendica\Model\Photo;
 use Friendica\Model\Queue;
 use Friendica\Model\User;
@@ -532,7 +532,7 @@ function twitter_post_hook(App $a, &$b)
 		$connection->setTimeouts(10, 30);
 
 		$max_char = 280;
-		$msgarr = Item::getPlaintextPost($b, $max_char, true, 8);
+		$msgarr = ItemContent::getPlaintextPost($b, $max_char, true, 8);
 		$msg = $msgarr["text"];
 
 		if (($msg == "") && isset($msgarr["title"])) {
@@ -766,7 +766,7 @@ function twitter_prepare_body(App $a, &$b)
 			}
 		}
 
-		$msgarr = Item::getPlaintextPost($item, $max_char, true, 8);
+		$msgarr = ItemContent::getPlaintextPost($item, $max_char, true, 8);
 		$msg = $msgarr["text"];
 
 		if (isset($msgarr["url"]) && ($msgarr["type"] != "photo")) {


### PR DESCRIPTION
Depends on https://github.com/friendica/friendica/pull/4881
Part of https://github.com/friendica/friendica/issues/4867

This PR contains the backward-incompatible changes introduced in https://github.com/friendica/friendica/pull/4881 as well as an improvement to the `langfilter` addon that now uses the plaintext body to calculate the minimum body length, using the same text transformation function as the language detection does.