### PR TITLE
notifyall: enclose senders name in quotation marks

### DIFF
--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -12,41 +12,53 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Core\L10n;
 use Friendica\Util\Emailer;
 
-function notifyall_install() {
+function notifyall_install() 
+{
 	logger("installed notifyall");
 }
 
-function notifyall_uninstall() {
+function notifyall_uninstall() 
+{
 	logger("removed notifyall");
 }
 
 function notifyall_module() {}
 
-function notifyall_addon_admin(&$a, &$o) {
-
+function notifyall_addon_admin(&$a, &$o) 
+{
 	$o = '<div></div>&nbsp;&nbsp;&nbsp;&nbsp;<a href="' . z_root() . '/notifyall">' . L10n::t('Send email to all members') . '</a></br/>';
 }
 
 
-function notifyall_post(&$a) {
+function notifyall_post(&$a) 
+{
 	if(! is_site_admin())
+	{
 		return;
+	}
 
 	$text = trim($_REQUEST['text']);
+	
 	if(! $text)
+	{
 		return;
+	}
 
 	$sitename = $a->config['sitename'];
 
 	if (!x($a->config['admin_name']))
-		$sender_name = L10n::t('%s Administrator', $sitename);
-	else
-		$sender_name = L10n::t('%1$s, %2$s Administrator', $a->config['admin_name'], $sitename);
+	{
+		$sender_name = '"' . L10n::t('%s Administrator', $sitename) . '"';
+	}	else 	{
+		$sender_name = '"' . L10n::t('%1$s, %2$s Administrator', $a->config['admin_name'], $sitename) . '"';
+	}
 
 	if (! x($a->config['sender_email']))
+	{
 		$sender_email = 'noreply@' . $a->get_hostname();
-	else
+	} else {
 		$sender_email = $a->config['sender_email'];
+	}
 
 	$subject = $_REQUEST['subject'];
 
@@ -57,7 +69,8 @@ function notifyall_post(&$a) {
 
 	// if this is a test, send it only to the admin(s)
 	// admin_email might be a comma separated list, but we need "a@b','c@d','e@f
-	if (intval($_REQUEST['test'])) {
+	if (intval($_REQUEST['test'])) 
+	{
 		$email = $a->config['admin_email'];
 		$email = "'" . str_replace([" ",","], ["","','"], $email) . "'";
 	}
@@ -65,12 +78,14 @@ function notifyall_post(&$a) {
 
 	$recips = q("SELECT DISTINCT `email` FROM `user` WHERE `verified` AND NOT `account_removed` AND NOT `account_expired` $sql_extra");
 
-	if (! $recips) {
+	if (! $recips) 
+	{
 		notice(L10n::t('No recipients found.') . EOL);
 		return;
 	}
 
-	foreach ($recips as $recip) {
+	foreach ($recips as $recip) 
+	{
 		Emailer::send([
 			'fromName'             => $sender_name,
 			'fromEmail'            => $sender_email,

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -74,7 +74,7 @@ function notifyall_post(App $a)
 
 	$recips = q("SELECT DISTINCT `email` FROM `user` WHERE `verified` AND NOT `account_removed` AND NOT `account_expired` $sql_extra");
 
-	if (! $recips)  {
+	if (! $recips) {
 		notice(L10n::t('No recipients found.') . EOL);
 		return;
 	}

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -46,7 +46,7 @@ function notifyall_post(&$a)
 
 	$sitename = $a->config['sitename'];
 
-	if (!x($a->config['admin_name']))
+	if (empty($a->config['admin_name']))
 	{
 		$sender_name = '"' . L10n::t('%s Administrator', $sitename) . '"';
 	}	else 	{

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -25,13 +25,13 @@ function notifyall_uninstall()
 
 function notifyall_module() {}
 
-function notifyall_addon_admin(App &$a, &$o) 
+function notifyall_addon_admin(App $a, &$o) 
 {
 	$o = '<div></div>&nbsp;&nbsp;&nbsp;&nbsp;<a href="' . z_root() . '/notifyall">' . L10n::t('Send email to all members') . '</a></br/>';
 }
 
 
-function notifyall_post(App &$a) 
+function notifyall_post(App $a) 
 {
 	if(! is_site_admin())
 	{

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -11,6 +11,7 @@
 use Friendica\Content\Text\BBCode;
 use Friendica\Core\L10n;
 use Friendica\Util\Emailer;
+use Friendica\App;
 
 function notifyall_install() 
 {
@@ -24,13 +25,13 @@ function notifyall_uninstall()
 
 function notifyall_module() {}
 
-function notifyall_addon_admin(&$a, &$o) 
+function notifyall_addon_admin(App &$a, &$o) 
 {
 	$o = '<div></div>&nbsp;&nbsp;&nbsp;&nbsp;<a href="' . z_root() . '/notifyall">' . L10n::t('Send email to all members') . '</a></br/>';
 }
 
 
-function notifyall_post(&$a) 
+function notifyall_post(App &$a) 
 {
 	if(! is_site_admin())
 	{

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -33,7 +33,7 @@ function notifyall_addon_admin(App $a, &$o)
 
 function notifyall_post(App $a) 
 {
-	if(! is_site_admin())
+	if(!is_site_admin())
 	{
 		return;
 	}
@@ -50,7 +50,7 @@ function notifyall_post(App $a)
 	if (empty($a->config['admin_name']))
 	{
 		$sender_name = '"' . L10n::t('%s Administrator', $sitename) . '"';
-	}	else 	{
+	} else {
 		$sender_name = '"' . L10n::t('%1$s, %2$s Administrator', $a->config['admin_name'], $sitename) . '"';
 	}
 

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -33,29 +33,25 @@ function notifyall_addon_admin(App $a, &$o)
 
 function notifyall_post(App $a) 
 {
-	if(!is_site_admin())
-	{
+	if(!is_site_admin()) {
 		return;
 	}
 
 	$text = trim($_REQUEST['text']);
 	
-	if(! $text)
-	{
+	if(! $text) {
 		return;
 	}
 
 	$sitename = $a->config['sitename'];
 
-	if (empty($a->config['admin_name']))
-	{
+	if (empty($a->config['admin_name'])) {
 		$sender_name = '"' . L10n::t('%s Administrator', $sitename) . '"';
 	} else {
 		$sender_name = '"' . L10n::t('%1$s, %2$s Administrator', $a->config['admin_name'], $sitename) . '"';
 	}
 
-	if (! x($a->config['sender_email']))
-	{
+	if (! x($a->config['sender_email'])) {
 		$sender_email = 'noreply@' . $a->get_hostname();
 	} else {
 		$sender_email = $a->config['sender_email'];
@@ -70,8 +66,7 @@ function notifyall_post(App $a)
 
 	// if this is a test, send it only to the admin(s)
 	// admin_email might be a comma separated list, but we need "a@b','c@d','e@f
-	if (intval($_REQUEST['test'])) 
-	{
+	if (intval($_REQUEST['test'])) {
 		$email = $a->config['admin_email'];
 		$email = "'" . str_replace([" ",","], ["","','"], $email) . "'";
 	}
@@ -79,14 +74,12 @@ function notifyall_post(App $a)
 
 	$recips = q("SELECT DISTINCT `email` FROM `user` WHERE `verified` AND NOT `account_removed` AND NOT `account_expired` $sql_extra");
 
-	if (! $recips) 
-	{
+	if (! $recips)  {
 		notice(L10n::t('No recipients found.') . EOL);
 		return;
 	}
 
-	foreach ($recips as $recip) 
-	{
+	foreach ($recips as $recip) {
 		Emailer::send([
 			'fromName'             => $sender_name,
 			'fromEmail'            => $sender_email,


### PR DESCRIPTION
enclose the *senders name* construct

    $nodename, Administrator

with quotation marks so it does not get interpreted as multible email addresses.

this might solve friendica/friendica#4976