### PR TITLE
langfilter: dont add languages when none are set to the settings

### DIFF
--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -50,10 +50,6 @@ function langfilter_addon_settings(App $a, &$s)
 	$minconfidence  = PConfig::get(local_user(), 'langfilter', 'minconfidence') * 100;
 	$minlength      = PConfig::get(local_user(), 'langfilter', 'minlength');
 
-	if (!$languages) {
-		$languages = 'en,de,fr,it,es';
-	}
-
 	$t = get_markup_template("settings.tpl", "addon/langfilter/");
 	$s .= replace_macros($t, [
 		'$title'         => L10n::t("Language Filter"),


### PR DESCRIPTION
As mentioned in friendica/friendica#4710 there should not be a preset for the filtered languages.