### PR TITLE
Some notices had been removed / expiring of item related tables in twitter

### DIFF
--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -271,6 +271,7 @@ function buffer_send(App $a, &$b)
 	$client_id = Config::get("buffer", "client_id");
 	$client_secret = Config::get("buffer", "client_secret");
 	$access_token = PConfig::get($b['uid'], "buffer","access_token");
+	$callback_url = "";
 
 	if ($access_token) {
 		$buffer = new BufferApp($client_id, $client_secret, $callback_url, $access_token);

--- a/leistungsschutzrecht/leistungsschutzrecht.php
+++ b/leistungsschutzrecht/leistungsschutzrecht.php
@@ -142,6 +142,10 @@ function leistungsschutzrecht_is_member_site($url) {
 		return false;
 	}
 
+	if (count($hostname) <= 2) {
+		return false;
+	}
+
 	$site = $hostname[sizeof($hostname) - 2].".".$hostname[sizeof($hostname) - 1];
 
 	return (isset($sites[$site]));

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -1125,6 +1125,8 @@ function pumpio_dopost(&$a, $client, $uid, $self, $post, $own_id, $threadcomplet
 		$receiptians = array_merge($receiptians, $post->to);
 	}
 
+	$public = false;
+
 	foreach ($receiptians AS $receiver) {
 		if (is_string($receiver->objectType) && ($receiver->id == "http://activityschema.org/collection/public")) {
 			$public = true;

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -983,10 +983,24 @@ function pumpio_dolike(&$a, $uid, $self, $post, $own_id, $threadcompletion = tru
 
 function pumpio_get_contact($uid, $contact, $no_insert = false)
 {
-	GContact::update(["url" => $contact->url, "network" => NETWORK_PUMPIO, "generation" => 2,
-			"photo" => $contact->image->url, "name" => $contact->displayName,  "hide" => true,
-			"nick" => $contact->preferredUsername, "location" => $contact->location->displayName,
-			"about" => $contact->summary, "addr" => str_replace("acct:", "", $contact->id)]);
+	$gcontact = ["url" => $contact->url, "network" => NETWORK_PUMPIO, "generation" => 2,
+		"name" => $contact->displayName,  "hide" => true,
+		"nick" => $contact->preferredUsername,
+		"addr" => str_replace("acct:", "", $contact->id)];
+
+	if (!empty($contact->location->displayName)) {
+		$gcontact["location"] = $contact->location->displayName;
+	}
+
+	if (!empty($contact->summary)) {
+		$gcontact["about"] = $contact->summary;
+	}
+
+	if (!empty($contact->image->url)) {
+		$gcontact["photo"] = $contact->image->url;
+	}
+
+	GContact::update($gcontact);
 	$cid = Contact::getIdForURL($contact->url, $uid);
 
 	if ($no_insert) {
@@ -1047,7 +1061,9 @@ function pumpio_get_contact($uid, $contact, $no_insert = false)
 		*/
 	}
 
-	Contact::updateAvatar($contact->image->url, $uid, $contact_id);
+	if (!empty($contact->image->url)) {
+		Contact::updateAvatar($contact->image->url, $uid, $contact_id);
+	}
 
 	return $contact_id;
 }

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -586,11 +586,11 @@ function statusnet_post_hook(App $a, &$b)
 			logger('statusnet_post send, result: ' . print_r($result, true) .
 				"\nmessage: " . $msg, LOGGER_DEBUG . "\nOriginal post: " . print_r($b, true) . "\nPost Data: " . print_r($postdata, true));
 
-			if ($result->source) {
+			if (!empty($result->source)) {
 				PConfig::set($b["uid"], "statusnet", "application_name", strip_tags($result->source));
 			}
 
-			if ($result->error) {
+			if (!empty($result->error)) {
 				logger('Send to GNU Social failed: "' . $result->error . '"');
 			} elseif ($iscomment) {
 				logger('statusnet_post: Update extid ' . $result->id . " for post id " . $b['id']);
@@ -819,7 +819,7 @@ function statusnet_fetchtimeline(App $a, $uid)
 				continue;
 			}
 
-			if (is_object($post->retweeted_status)) {
+			if (!empty($post->retweeted_status)) {
 				continue;
 			}
 
@@ -1554,12 +1554,12 @@ function statusnet_is_retweet(App $a, $uid, $body)
 
 	$link = "";
 	preg_match("/link='(.*?)'/ism", $attributes, $matches);
-	if ($matches[1] != "") {
+	if (!empty($matches[1])) {
 		$link = $matches[1];
 	}
 
 	preg_match('/link="(.*?)"/ism', $attributes, $matches);
-	if ($matches[1] != "") {
+	if (!empty($matches[1])) {
 		$link = $matches[1];
 	}
 

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -412,7 +412,7 @@ function tumblr_send(&$a,&$b) {
 			$params['caption'] = '<h1>'.$title."</h1>".
 						"<p>".$params['caption']."</p>";
 
-		if (trim($params['caption']) == "")
+		if (empty($params['caption']))
 			$params['caption'] = BBCode::convert("[quote]" . $siteinfo["description"] . "[/quote]", false, 4);
 
 		$consumer_key = Config::get('tumblr','consumer_key');


### PR DESCRIPTION
This is mostly about removing notices. Additionally it is a fix for some issue. Normally when finally deleting an item, also the content and activity data is deleted. This doesn't work for twitter posts that we delete earlier by the addon. Therefore we have to delete the content here as well. We should move this action into the item class in the future.