### PR TITLE
[mastodon-custom-emojis] Fixes E_NOTICE for absent 'port' element

### DIFF
--- a/mastodoncustomemojis/mastodoncustomemojis.php
+++ b/mastodoncustomemojis/mastodoncustomemojis.php
@@ -62,7 +62,7 @@ function mastodoncustomemojis_get_custom_emojis_for_author($author_link)
 
 	$url_parts = parse_url($author_link);
 
-	$api_base_url = $url_parts['scheme'] . '://' . $url_parts['host'] . ($url_parts['port'] ? ':' . $url_parts['port'] : '');
+	$api_base_url = $url_parts['scheme'] . '://' . $url_parts['host'] . (isset($url_parts['port']) ? ':' . $url_parts['port'] : '');
 
 	$cache_key = 'mastodoncustomemojis:' . $api_base_url;
 


### PR DESCRIPTION
This fixes an E_NOTICE (`error_reporting(E_ALL)` was used) in an addon.