### PR TITLE
Unify header level for weather widget.

### DIFF
--- a/curweather/templates/widget.tpl
+++ b/curweather/templates/widget.tpl
@@ -1,6 +1,6 @@
 <div id="curweather-network" class="widget">
 	<div class="title tool">
-		<h4 title="{{$lastupdate}}">{{$title}}: {{$city}}</h4>
+		<h3 title="{{$lastupdate}}">{{$title}}: {{$city}}</h3>
 	</div>
 	<p>
 	<img src="{{$icon}}" title="{{$description}}">


### PR DESCRIPTION
The weather widget uses h4 instead of h3 for the aside. Fix that.

Old:
![screenshot_2018-07-19 friendica social network network](https://user-images.githubusercontent.com/206846/42921372-06a80de4-8b1c-11e8-8ba8-df9dcccbcc44.png)

New:
![screenshot_2018-07-19 friendica social network network 1](https://user-images.githubusercontent.com/206846/42921376-0b1b139e-8b1c-11e8-9731-3bdd5b43a5b8.png)
