### PR TITLE
Remote self on Twitter will now only work with original content

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1674,7 +1674,7 @@ function twitter_fetchhometimeline(App $a, $uid)
 
 			$notify = false;
 
-			if ($postarray['uri'] == $postarray['parent-uri']) {
+			if (($postarray['uri'] == $postarray['parent-uri']) && ($postarray['author-link'] == $postarray['owner-link'])) {
 				$contact = DBA::selectFirst('contact', [], ['id' => $postarray['contact-id'], 'self' => false]);
 				if (DBA::isResult($contact)) {
 					$notify = Item::isRemoteSelf($contact, $postarray);


### PR DESCRIPTION
Due to the way that shared posts from Twitter are looking in Friendica, this caused visual problem with "remote self", since these posts had't been recognizable as shared posts.