### PR TITLE
Apply CatAvatar when submiting aproval - fix #5779 in friendica

### DIFF
--- a/catavatar/catavatar.php
+++ b/catavatar/catavatar.php
@@ -171,7 +171,7 @@ function catavatar_content(App $a)
 		$size = intval($a->argv[2]);
 	}
 
-	$condition = ['uid' => $uid, 'blocked' => false,
+	$condition = ['uid' => $uid,
 			'account_expired' => false, 'account_removed' => false];
 	$user = DBA::selectFirst('user', ['email'], $condition);
 


### PR DESCRIPTION
Following Isse at friendica friendica/friendica#5779 the catavatar is now apllied even after aproval.
Removing the check for `account_blocked` isn't needed.
 `account_expired` and `account_removed` will make it.