### PR TITLE
Fix new function name for getBaseurl()

### DIFF
--- a/viewsrc/viewsrc.php
+++ b/viewsrc/viewsrc.php
@@ -52,7 +52,7 @@ function viewsrc_item_photo_menu(&$a, &$b)
 		$item_id = $b['item']['id'];
 	}
 
-	$b['menu'] = array_merge([L10n::t('View Source') => $a->get_baseurl() . '/viewsrc/'. $item_id], $b['menu']);
+	$b['menu'] = array_merge([L10n::t('View Source') => $a->getBaseurl() . '/viewsrc/'. $item_id], $b['menu']);
 
 	//if((! local_user()) || (local_user() != $b['item']['uid']))
 	//	return;


### PR DESCRIPTION
To PR https://github.com/friendica/friendica/pull/5862 I noticed in `/contacts/[id]/conversations` 

    "PHP message: PHP Fatal error:  Uncaught Error: Call to undefined method Friendica\App::get_baseurl() in /var/www/friendica/addon/viewsrc/viewsrc.php:55

Should be fixing it