### PR TITLE
[twitter] Normalize mentions/foreign reshares

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1891,7 +1891,7 @@ function twitter_update_mentions($body)
 	return $return;
 }
 
-function twitter_convert_share(array $attributes, array $author_contact, $content)
+function twitter_convert_share(array $attributes, array $author_contact, $content, $is_quote_share)
 {
 	if ($author_contact['network'] == Protocol::TWITTER) {
 		$mention = '@' . $author_contact['nickname'];
@@ -1899,5 +1899,5 @@ function twitter_convert_share(array $attributes, array $author_contact, $conten
 		$mention = Protocol::formatMention($attributes['profile'], $attributes['author']);
 	}
 
-	return 'RT ' . $mention . ': ' . $content;
+	return ($is_quote_share ? "\n\n" : '' ) . 'RT ' . $mention . ': ' . $content . "\n\n" . $attributes['link'];
 }

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -553,6 +553,9 @@ function twitter_post_hook(App $a, array &$b)
 		$connection->setTimeouts(10, 30);
 
 		$max_char = 280;
+
+		$b['body'] = twitter_update_mentions($b['body']);
+
 		$msgarr = ItemContent::getPlaintextPost($b, $max_char, true, 8);
 		$msg = $msgarr["text"];
 
@@ -1858,4 +1861,24 @@ function twitter_is_retweet(App $a, $uid, $body)
 	logger('twitter_is_retweet: result ' . print_r($result, true), LOGGER_DEBUG);
 
 	return !isset($result->errors);
+}
+
+function twitter_update_mentions($body)
+{
+	$URLSearchString = "^\[\]";
+	$return = preg_replace_callback(
+		"/@\[url\=([$URLSearchString]*)\](.*?)\[\/url\]/ism",
+		function ($matches) {
+			if (strpos($matches[1], 'twitter.com')) {
+				$return = '@' . substr($matches[1], strrpos($matches[1], '/') + 1);
+			} else {
+				$return = $matches[2] . ' (' . $matches[1] . ')';
+			}
+
+			return $return;
+		},
+		$body
+	);
+
+	return $return;
 }

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -554,6 +554,14 @@ function twitter_post_hook(App $a, array &$b)
 
 		$max_char = 280;
 
+		// Handling non-native reshares
+		$b['body'] = Friendica\Content\Text\BBCode::convertShare(
+			$b['body'],
+			function (array $attributes, array $author_contact, $content) {
+				return twitter_convert_share($attributes, $author_contact, $content);
+			}
+		);
+
 		$b['body'] = twitter_update_mentions($b['body']);
 
 		$msgarr = ItemContent::getPlaintextPost($b, $max_char, true, 8);
@@ -1881,4 +1889,15 @@ function twitter_update_mentions($body)
 	);
 
 	return $return;
+}
+
+function twitter_convert_share(array $attributes, array $author_contact, $content)
+{
+	if ($author_contact['network'] == Protocol::TWITTER) {
+		$mention = '@' . $author_contact['nickname'];
+	} else {
+		$mention = Protocol::formatMention($attributes['profile'], $attributes['author']);
+	}
+
+	return 'RT ' . $mention . ': ' . $content;
 }


### PR DESCRIPTION
Fixes #3218
Depends on https://github.com/friendica/friendica/pull/5942

The two new addon functions handles respectively mentions (native or foreign) and foregn reshares, avoiding to mentions random accounts based on the foreign contact username.