### PR TITLE
Leistungsschutzrecht: Optionally suppress pictures

### DIFF
--- a/leistungsschutzrecht/README.md
+++ b/leistungsschutzrecht/README.md
@@ -1,0 +1,16 @@
+Leistungsschutzrecht Addon
+==========================
+
+Main author Michael Vogel
+
+This addon handles legal problems with the German link tax, named "Leistungsschutzrecht" by shortening preview texts.
+Additionally it is possibly to suppress preview pictures completely to avoid any legal problems.
+
+## configuration
+
+If you want to suppress pictures in previews, add this to your global `config/addon.config.php`:
+
+	'leistungsschutzrecht' => [
+		'suppress_photos' => true,
+	],
+

--- a/leistungsschutzrecht/leistungsschutzrecht.php
+++ b/leistungsschutzrecht/leistungsschutzrecht.php
@@ -24,22 +24,24 @@ function leistungsschutzrecht_uninstall() {
 }
 
 function leistungsschutzrecht_getsiteinfo($a, &$siteinfo) {
-	if (!isset($siteinfo["url"])) {
+	if (!isset($siteinfo["url"]) || empty($siteinfo['type'])) {
 		return;
+	}
+
+	// Avoid any third party pictures, to avoid copyright issues
+	if (($siteinfo['type'] != 'photo') && Config::get('leistungsschutzrecht', 'suppress_photos', false)) {
+		unset($siteinfo["image"]);
+		unset($siteinfo["images"]);
 	}
 
 	if (!leistungsschutzrecht_is_member_site($siteinfo["url"])) {
 		return;
 	}
 
-	//$siteinfo["title"] = $siteinfo["url"];
-
 	if (!empty($siteinfo["text"])) {
 		$siteinfo["text"] = leistungsschutzrecht_cuttext($siteinfo["text"]);
 	}
 
-	unset($siteinfo["image"]);
-	unset($siteinfo["images"]);
 	unset($siteinfo["keywords"]);
 }
 


### PR DESCRIPTION
There is a new config value to control the new behaviour.

Question: Where do we document this setting?