### PR TITLE
LSR: Show preview pictures of videos (should be legally safe)

### DIFF
--- a/leistungsschutzrecht/leistungsschutzrecht.php
+++ b/leistungsschutzrecht/leistungsschutzrecht.php
@@ -29,7 +29,7 @@ function leistungsschutzrecht_getsiteinfo($a, &$siteinfo) {
 	}
 
 	// Avoid any third party pictures, to avoid copyright issues
-	if (($siteinfo['type'] != 'photo') && Config::get('leistungsschutzrecht', 'suppress_photos', false)) {
+	if (!in_array($siteinfo['type'], ['photo', 'video']) && Config::get('leistungsschutzrecht', 'suppress_photos', false)) {
 		unset($siteinfo["image"]);
 		unset($siteinfo["images"]);
 	}


### PR DESCRIPTION
Hopefully legal problems with preview pictures should only occur when they are part of a link to an news article.