### PR TITLE
[twitter] Add expected wall = 1 for own posts

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1469,6 +1469,8 @@ function twitter_createpost(App $a, $uid, $post, array $self, $create_user, $onl
 				intval($uid));
 
 			if (DBA::isResult($r)) {
+				$postarray['wall'] = 1;
+
 				$contactid = $r[0]["id"];
 
 				$postarray['owner-name']   = $r[0]["name"];


### PR DESCRIPTION
Pendant to https://github.com/friendica/friendica/pull/6389

Fixes a issue where own Twitter posts aren't recognized as being our own in the notification process.