### PR TITLE
new addon - cookienotice - configure, show and handle a simple cookie…

### DIFF
--- a/cookienotice/README
+++ b/cookienotice/README
@@ -1,0 +1,7 @@
+Cookie Notice
+
+For server admins only.
+
+Configure, show and handle a simple cookie usage notice.
+
+Author: Peter liebetrau <https://socivitas.com/profile/peerteer>

--- a/cookienotice/cookienotice.css
+++ b/cookienotice/cookienotice.css
@@ -1,0 +1,23 @@
+#cookienotice-label {
+    float: left;
+    width: 300px;
+    margin-top: 10px;
+}
+
+#cookienotice-text {
+    float: left;
+    margin-top: 10px;
+    width: 400px;
+    height: 150px;
+}
+
+#cookienotice-submit {
+    margin-top: 15px;
+}
+
+.cookienotice {
+    text-align: center;
+    width: 100%;
+    margin-top: 25px;
+    font-size: 20px;
+}

--- a/cookienotice/cookienotice.php
+++ b/cookienotice/cookienotice.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Name: Cookie Notice
+ * Description: Configure, show and handle a simple cookie notice
+ * Version: 1.0
+ * Author: Peter Liebetrau <https://socivitas/profile/peerteer>
+ * 
+ */
+use Friendica\Core\Addon;
+use Friendica\Core\Config;
+use Friendica\Core\L10n;
+
+function cookienotice_install()
+{
+    $file = 'addon/cookienotice/cookienotice.php';
+    Addon::registerHook('page_content_top', $file, 'cookienotice_page_content_top');
+    Addon::registerHook('page_end', $file, 'cookienotice_page_end');
+    Addon::registerHook('addon_settings', $file, 'cookienotice_addon_settings');
+    Addon::registerHook('addon_settings_post', $file, 'cookienotice_addon_settings_post');
+}
+
+function cookienotice_uninstall()
+{
+    $file = 'addon/cookienotice/cookienotice.php';
+    Addon::unregisterHook('page_content_top', $file, 'cookienotice_page_content_top');
+    Addon::unregisterHook('page_end', $file, 'cookienotice_page_end');
+    Addon::unregisterHook('addon_settings', $file, 'cookienotice_addon_settings');
+    Addon::unregisterHook('addon_settings_post', $file, 'cookienotice_addon_settings_post');
+}
+
+function cookienotice_addon_settings(&$a, &$s)
+{
+    if (!is_site_admin())
+        return;
+
+    /* Add our stylesheet to the page so we can make our settings look nice */
+
+    $a->page['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="/addon/cookienotice/cookienotice.css" media="all" />' . "\r\n";
+
+
+    $text = Config::get('cookienotice', 'text');
+    if (!$text) {
+        $text = '';
+    }
+    $oktext = Config::get('cookienotice', 'oktext');
+    if (!$oktext) {
+        $oktext = '';
+    }
+
+    $t = get_markup_template("settings.tpl", "addon/cookienotice/");
+    $s .= replace_macros($t, [
+        '$title'       => L10n::t('"cookienotice" Settings'),
+        '$description' => L10n::t('<b>Configure your cookie usage notice.</b> It should just be a notice, saying that the website uses cookies. It is shown as long as a user didnt confirm clicking the OK button.'),
+        '$text'        => ['cookienotice-text', L10n::t('Cookie Usage Notice'), $text, L10n::t('The cookie usage notice')],
+        '$oktext'      => ['cookienotice-oktext', L10n::t('OK Button Text'), $oktext, L10n::t('The OK Button text')],
+        '$submit'      => L10n::t('Save Settings')
+    ]);
+
+    return;
+}
+
+function cookienotice_addon_settings_post(&$a, &$b)
+{
+
+    if (!is_site_admin())
+        return;
+
+    if ($_POST['cookienotice-submit']) {
+        Config::set('cookienotice', 'text', trim(strip_tags($_POST['cookienotice-text'])));
+        Config::set('cookienotice', 'oktext', trim(strip_tags($_POST['cookienotice-oktext'])));
+        info(L10n::t('cookienotice Settings saved.') . EOL);
+    }
+}
+
+/**
+ * adds the link and script to the page head
+ * 
+ * @param App $a
+ * @param string $b - The page html before page_content_top
+ */
+function cookienotice_page_content_top($a, &$b)
+{
+    $head                = file_get_contents(__DIR__ . '/templates/head.tpl');
+    $a->page['htmlhead'] .= $head;
+}
+
+/**
+ * adds the html to page end
+ * page_end hook function
+ * 
+ * @param App $a
+ * @param string $b - The page html
+ */
+function cookienotice_page_end($a, &$b)
+{
+
+    $text   = (string) Config::get('cookienotice', 'text');
+    $oktext = (string) Config::get('cookienotice', 'oktext');
+
+    $page_end_tpl = get_markup_template("cookienotice.tpl", "addon/cookienotice/");
+
+    $page_end = replace_macros($page_end_tpl, [
+        '$text'   => $text,
+        '$oktext' => $oktext,
+    ]);
+
+    $b .= $page_end;
+}

--- a/cookienotice/templates/cookienotice.tpl
+++ b/cookienotice/templates/cookienotice.tpl
@@ -1,0 +1,23 @@
+<style type="text/css">
+    #cookienotice-box {
+        display: none;
+        position: fixed;
+        z-index: 10000;
+        bottom: 0px;
+        left: 0;
+        width: 100%;
+        background-color: #101010;
+        color: #f0f0f0;
+        padding: 2em 1em;
+        text-align: center;
+    }
+    #cookienotice-ok-button {
+        border: 1px solid darkgoldenrod;
+        background-color: gold;
+        color: #101010;
+        min-width: 80px;
+        padding: .5em .1em;
+    }
+</style>
+<div id="cookienotice-box"><p>{{$text}}</p><button id="cookienotice-ok-button">{{$oktext}}</button></div>
+

--- a/cookienotice/templates/head.tpl
+++ b/cookienotice/templates/head.tpl
@@ -1,0 +1,40 @@
+<!-- <link rel="stylesheet" type="text/css" href="/addon/cookienotice/css/cookienotice.css" /> -->
+<script>
+    window.addEventListener("load", function () {
+        var cookiename = 'cncookiesaccepted'
+        var cookie = getCookie(cookiename);
+        
+        if (cookie == "") {
+            document.getElementById('cookienotice-box').style.display = 'block';
+            document.getElementById('cookienotice-ok-button').onclick = function () {
+                console.log('clicked');
+                setCookie(cookiename, 1, 365);
+                document.getElementById('cookienotice-box').style.display = 'none';
+            };
+        }
+        
+        function setCookie(cname, cvalue, exdays) {
+            var d = new Date();
+            d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+            var expires = "expires=" + d.toUTCString();
+            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+        }
+        
+        function getCookie(cname) {
+            var name = cname + "=";
+            var decodedCookie = decodeURIComponent(document.cookie);
+            var ca = decodedCookie.split(';');
+            for (var i = 0; i < ca.length; i++) {
+                var c = ca[i];
+                while (c.charAt(0) == ' ') {
+                    c = c.substring(1);
+                }
+                if (c.indexOf(name) == 0) {
+                    return c.substring(name.length, c.length);
+                }
+            }
+            return "";
+        }
+
+    });
+</script>

--- a/cookienotice/templates/settings.tpl
+++ b/cookienotice/templates/settings.tpl
@@ -1,0 +1,15 @@
+<span id="settings_cookienotice_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose('settings_cookienotice_expanded'); openClose('settings_cookienotice_inflated');">
+	<h3>{{$title}}</h3>
+</span>
+<div id="settings_cookienotice_expanded" class="settings-block" style="display: none;">
+	<span class="fakelink" onclick="openClose('settings_cookienotice_expanded'); openClose('settings_cookienotice_inflated');">
+		<h3>{{$title}}</h3>
+	</span>
+        <p>{{$description}}</p>
+	{{include file="field_textarea.tpl" field=$text}}
+        {{include file="field_input.tpl" field=$oktext}}
+	<div class="settings-submit-wrapper" >
+		<input type="submit" id="cookienotice-submit" name="cookienotice-submit" class="settings-submit" value="{{$submit}}" />
+	</div>
+</div>
+<div class="clear"></div>

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,7 @@
+include.path=${php.global.include.path}
+php.version=PHP_70
+source.encoding=UTF-8
+src.dir=.
+tags.asp=false
+tags.short=false
+web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.php.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/php-project/1">
+            <name>friendica addons</name>
+        </data>
+    </configuration>
+</project>


### PR DESCRIPTION
similar to the pagheheader addon, an admin user can configure a cookie usage notice which will be shown until the user confirms by clicking an OK Button.
Cookie usage notice and OK button text are configurable.
Handling of the cookie accept cookie is done by the addon.

You can see the addon in action at my https://socivitas.com (german)