### PR TITLE
Regenerated messages.po

### DIFF
--- a/cookienotice/lang/C/messages.po
+++ b/cookienotice/lang/C/messages.po
@@ -8,46 +8,62 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-20 14:51+0100\n"
+"POT-Creation-Date: 2019-01-30 10:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Peter Liebetrau <peter.liebetrau@peterliebetrau.de>\n"
-"Language-Team: German cookienotice <LL@li.org>\n"
-"Language: de\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cookienotice.php:53
+#: cookienotice.php:63
+msgid ""
+"This website uses cookies. If you continue browsing this website, you agree "
+"to the usage of cookies."
+msgstr ""
+
+#: cookienotice.php:64 cookienotice.php:133
+msgid "OK"
+msgstr ""
+
+#: cookienotice.php:68
 msgid "\"cookienotice\" Settings"
 msgstr ""
 
-#: cookienotice.php:54
+#: cookienotice.php:69
 msgid ""
 "<b>Configure your cookie usage notice.</b> It should just be a notice, "
 "saying that the website uses cookies. It is shown as long as a user didnt "
 "confirm clicking the OK button."
 msgstr ""
 
-#: cookienotice.php:55
+#: cookienotice.php:70
 msgid "Cookie Usage Notice"
 msgstr ""
 
-#: cookienotice.php:55
+#: cookienotice.php:70
 msgid "The cookie usage notice"
 msgstr ""
 
-#: cookienotice.php:56
+#: cookienotice.php:71
 msgid "OK Button Text"
 msgstr ""
 
-#: cookienotice.php:56
+#: cookienotice.php:71
 msgid "The OK Button text"
 msgstr ""
 
-#: cookienotice.php:57
+#: cookienotice.php:72
 msgid "Save Settings"
 msgstr ""
 
-#: cookienotice.php:72
+#: cookienotice.php:97
 msgid "cookienotice Settings saved."
+msgstr ""
+
+#: cookienotice.php:132
+msgid ""
+"This website uses cookies to recognize revisiting and logged in users. You "
+"accept the usage of these cookies by continue browsing this website."
 msgstr ""


### PR DESCRIPTION
While translating strings for the cookienotice, I realized there were several strings missing. Also a lot of strings where originally in German which I don't think is normal.

I have regenerated the messages.po hoping it fixes, but I'm not sure about this fix. I also cannot test this unfortunately.