### PR TITLE
nofilter applied to fixed description

### DIFF
--- a/cookienotice/templates/settings.tpl
+++ b/cookienotice/templates/settings.tpl
@@ -5,7 +5,7 @@
 	<span class="fakelink" onclick="openClose('settings_cookienotice_expanded'); openClose('settings_cookienotice_inflated');">
 		<h3>{{$title}}</h3>
 	</span>
-	<p>{{$description}}</p>
+	<p>{{$description nofilter}}</p>
 	{{include file="field_textarea.tpl" field=$text}}
 	{{include file="field_input.tpl" field=$oktext}}
 	<div class="settings-submit-wrapper" >


### PR DESCRIPTION
In the cookiemessage settings the description field containes HTML formatting which got escaped.

This PR applies the `nofilter` to the template.