### PR TITLE
Remove invalid call to composer

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -5,7 +5,6 @@
 To install all addons using git, cd into your top level Friendica directory and
 
 	git clone https://github.com/friendica/friendica-addons.git addon
-	bin/composer.phar install -d addon
 
 This will clone the entire repository in a directory called addon. They can now be activated in the addons section of your admin panel.
 


### PR DESCRIPTION
In INSTALL.txt a call to bin/composer.phar is documented, but neither is it necessary nor possible to call composer for addons.