### PR TITLE
piwik is called matomo nowadays

### DIFF
--- a/piwik/README.md
+++ b/piwik/README.md
@@ -1,14 +1,14 @@
-Piwik Addon
+Matomo / Piwik Addon
 ============
 
 by Tobias Diekershoff and Klaus Weidenbach
 
-This addon allows you to embed the code necessary for the FLOSS webanalytics tool Piwik into the Friendica pages.
+This addon allows you to embed the code necessary for the FLOSS webanalytics tool Matomo (formerly known as Piwik) into the Friendica pages.
 
 Requirements
 ------------
 
-To use this addon you need a [piwik](http://piwik.org/) installation.
+To use this addon you need a [Matomo](https://matomo.org/) installation.
 
 Where to find
 -------------

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Name: Piwik Analytics
- * Description: Piwik Analytics Addon for Friendica
+ * Name: Matomo / Piwik Analytics
+ * Description: Matomo / Piwik Analytics Addon for Friendica
  * Version: 1.3
  * Author: Tobias Diekershoff <https://f.diekershoff.de/profile/tobias>
  * Author: Klaus Weidenbach


### PR DESCRIPTION
This PR reflects the name change of the piwik project to matomo in the README and header of the addon to both variants of the name are rused.