### PR TITLE
blackout addon: bugfix translation was not applied

### DIFF
--- a/blackout/README.md
+++ b/blackout/README.md
@@ -2,7 +2,7 @@ blackout addon
 ==============
 * Description: Blackout your ~friendica node during a given period
 * License: [MIT](http://opensource.org/licenses/MIT)
-* Version: 1.0
+* Version: 1.1
 * Author: Tobias Diekershoff
 
 About
@@ -20,11 +20,6 @@ currently logged in users will be effected as well. But if they log
 out they can't login again. That way you dear admin can double check
 the entered time periode and fix typos without having to hack the
 database directly.
-
-Requirements
--------------
-
-**THIS ADDON REQUIRES PHP VERSION 5.3 OR HIGHER.**
 
 License
 -------

--- a/blackout/lang/C/messages.po
+++ b/blackout/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-06-22 13:18+0200\n"
+"POT-Creation-Date: 2019-03-12 09:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,33 +17,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: blackout.php:99
+#: blackout.php:101
+msgid ""
+"The end-date is prior to the start-date of the blackout, you should fix this"
+msgstr ""
+
+#: blackout.php:103
+#, php-format
+msgid ""
+"Please double check that the current settings for the blackout. Begin will "
+"be <strong>%s</strong> and it will end <strong>%s</strong>."
+msgstr ""
+
+#: blackout.php:106
 msgid "Save Settings"
 msgstr ""
 
-#: blackout.php:100
+#: blackout.php:107
 msgid "Redirect URL"
 msgstr ""
 
-#: blackout.php:100
+#: blackout.php:107
 msgid "all your visitors from the web will be redirected to this URL"
 msgstr ""
 
-#: blackout.php:101
+#: blackout.php:108
 msgid "Begin of the Blackout"
-msgstr ""
-
-#: blackout.php:101
-msgid ""
-"format is <em>YYYY</em> year, <em>MM</em> month, <em>DD</em> day, <em>hh</"
-"em> hour and <em>mm</em> minute"
-msgstr ""
-
-#: blackout.php:102
-msgid "End of the Blackout"
 msgstr ""
 
 #: blackout.php:108
 msgid ""
-"The end-date is prior to the start-date of the blackout, you should fix this."
+"Format is <tt>YYYY-MM-DD hh:mm</tt>; <em>YYYY</em> year, <em>MM</em> month, "
+"<em>DD</em> day, <em>hh</em> hour and <em>mm</em> minute."
+msgstr ""
+
+#: blackout.php:109
+msgid "End of the Blackout"
+msgstr ""
+
+#: blackout.php:111
+msgid ""
+"<strong>Note</strong>: The redirect will be active from the moment you press "
+"the submit button. Users currently logged in will <strong>not</strong> be "
+"thrown out but can't login again after logging out should the blackout is "
+"still in place."
 msgstr ""

--- a/blackout/templates/admin.tpl
+++ b/blackout/templates/admin.tpl
@@ -1,11 +1,9 @@
+<div class="warning-message">{{$adminnote nofilter}}</div>
+
 {{include file="field_input.tpl" field=$startdate}}
 {{include file="field_input.tpl" field=$enddate}}
 {{include file="field_input.tpl" field=$rurl}}
 
-<div style="border: 2px solid #f00; padding: 10px; margin:
-10px;font-size: 1.2em;"><strong>Note</strong>: The redirect will be active from the moment you
-press the submit button. Users currently logged in will <strong>not</strong> be
-thrown out but can't login again after logging out should the blackout is
-still in place.</div>
+<div class="warning-message">{{$aboutredirect nofilter}}</div>
 
 <div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>


### PR DESCRIPTION
I realized, that many of the translation work for the addon was not applied. This is now fixed.

Additionally some more strings, the notes for the admin, were made translate-able. Furthermore the templates were adjusted to the variable replacement possibilities that exist nowadays.

The old note about the requirement of PHP 5.3 or above was removed as Friendica nowadays expects PHP 7 or higher.