### PR TITLE
API response celsius and metric both mean to use °C as unit for the temperature

### DIFF
--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -62,7 +62,7 @@ function getWeather($loc, $units = 'metric', $lang = 'en', $appid = '', $cacheti
 
 	unset($_SESSION['curweather_notice_shown']);
 
-	if ((string) $res->temperature['unit'] === 'metric') {
+	if (in_array((string) $res->temperature['unit'], ['celsius', 'metric'])) {
 		$tunit = '°C';
 		$wunit = 'm/s';
 	} else {

--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -2,7 +2,7 @@
 /**
  * Name: Current Weather
  * Description: Shows current weather conditions for user's location on their network page.
- * Version: 1.1
+ * Version: 1.2
  * Author: Tony Baldwin <http://friendica.tonybaldwin.info/u/t0ny>
  * Author: Fabio Comuni <http://kirkgroup.com/u/fabrixxm>
  * Author: Tobias Diekershoff <https://f.diekershoff.de/u/tobias>


### PR DESCRIPTION
The API result from openweathermap can either be "celsius" or "metric" to signal the usage of Celsius scale for the temperature in contrast to °F. Both replies are now handled accordingly.