### PR TITLE
Don't store non federated contacts in gcontact

### DIFF
--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -18,7 +18,6 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
-use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\User;
@@ -1011,24 +1010,6 @@ function pumpio_dolike(App $a, $uid, $self, $post, $own_id, $threadcompletion = 
 
 function pumpio_get_contact($uid, $contact, $no_insert = false)
 {
-	$gcontact = ["url" => $contact->url, "network" => Protocol::PUMPIO, "generation" => 2,
-		"name" => $contact->displayName,  "hide" => true,
-		"nick" => $contact->preferredUsername,
-		"addr" => str_replace("acct:", "", $contact->id)];
-
-	if (!empty($contact->location->displayName)) {
-		$gcontact["location"] = $contact->location->displayName;
-	}
-
-	if (!empty($contact->summary)) {
-		$gcontact["about"] = $contact->summary;
-	}
-
-	if (!empty($contact->image->url)) {
-		$gcontact["photo"] = $contact->image->url;
-	}
-
-	GContact::update($gcontact);
 	$cid = Contact::getIdForURL($contact->url, $uid);
 
 	if ($no_insert) {

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -51,7 +51,6 @@ use Friendica\Core\Renderer;
 use Friendica\Core\System;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
-use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\ItemContent;
@@ -944,12 +943,6 @@ function statusnet_fetch_contact($uid, $contact, $create_user)
 	if (empty($contact->statusnet_profile_url)) {
 		return -1;
 	}
-
-	GContact::update(["url" => $contact->statusnet_profile_url,
-		"network" => Protocol::STATUSNET, "photo" => $contact->profile_image_url,
-		"name" => $contact->name, "nick" => $contact->screen_name,
-		"location" => $contact->location, "about" => $contact->description,
-		"addr" => statusnet_address($contact), "generation" => 3]);
 
 	$r = q("SELECT * FROM `contact` WHERE `uid` = %d AND `alias` = '%s' AND `network` = '%s'LIMIT 1", intval($uid), DBA::escape(Strings::normaliseLink($contact->statusnet_profile_url)), DBA::escape(Protocol::STATUSNET));
 

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -79,7 +79,6 @@ use Friendica\Core\Worker;
 use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
-use Friendica\Model\GContact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\ItemContent;
@@ -1004,12 +1003,6 @@ function twitter_fetch_contact($uid, $data, $create_user)
 	$avatar = twitter_fix_avatar($data->profile_image_url_https);
 	$url = "https://twitter.com/" . $data->screen_name;
 	$addr = $data->screen_name . "@twitter.com";
-
-	GContact::update(["url" => $url, "network" => Protocol::TWITTER,
-		"photo" => $avatar, "hide" => true,
-		"name" => $data->name, "nick" => $data->screen_name,
-		"location" => $data->location, "about" => $data->description,
-		"addr" => $addr, "generation" => 2]);
 
 	$fields = ['url' => $url, 'network' => Protocol::TWITTER,
 		'name' => $data->name, 'nick' => $data->screen_name, 'addr' => $addr,


### PR DESCRIPTION
The gcontact table shouldn't be flooded with contacts from non federated networks. It had been added in the past since it had been the plan to store every contact there that ever had posted. But that had been replaced by the public contacts.

There will be following PRs in the core that will address the same case as well.