### PR TITLE
[mailstream] Do not send "announce" messages

### DIFF
--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -102,19 +102,28 @@ function mailstream_generate_id($a, $uri) {
 
 function mailstream_post_hook(&$a, &$item) {
 	if (!PConfig::get($item['uid'], 'mailstream', 'enabled')) {
+		Logger::debug('mailstream: not enabled for item ' . $item['id']);
 		return;
 	}
 	if (!$item['uid']) {
+		Logger::debug('mailstream: no uid for item ' . $item['id']);
 		return;
 	}
 	if (!$item['contact-id']) {
+		Logger::debug('mailstream: no contact-id for item ' . $item['id']);
 		return;
 	}
 	if (!$item['uri']) {
+		Logger::debug('mailstream: no uri for item ' . $item['id']);
+		return;
+	}
+	if (!$item['plink']) {
+		Logger::debug('mailstream: no plink for item ' . $item['id']);
 		return;
 	}
 	if (PConfig::get($item['uid'], 'mailstream', 'nolikes')) {
 		if ($item['verb'] == ACTIVITY_LIKE) {
+			Logger::debug('mailstream: like item ' . $item['id']);
 			return;
 		}
 	}


### PR DESCRIPTION
With the new ActivityPub stuff, mailstream sends me annoying duplicate messages from Twitter just saying that someone retweeted the previous message.  I think the simplest way to get rid of these is to not send messages that don't have plinks.  If there's no plink you can't click the link to the original message, so they'll always be kinda crippled.

I also added debug messages explaining why mailstream ignores posts, to aid debugging this feature in future if it misfires.