### PR TITLE
[mailstream] Include BB code as plaintext

### DIFF
--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -299,6 +299,7 @@ function mailstream_send(\Friendica\App $a, $message_id, $item, $user) {
 		$mail->IsHTML(true);
 		$mail->CharSet = 'utf-8';
 		$template = Renderer::getMarkupTemplate('mail.tpl', 'addon/mailstream/');
+		$mail->AltBody = BBCode::toPlaintext($item['body']);
 		$item['body'] = BBCode::convert($item['body']);
 		$item['url'] = $a->getBaseURL() . '/display/' . $item['guid'];
 		$mail->Body = Renderer::replaceMacros($template, [


### PR DESCRIPTION
I noticed that mails from mailstream are only viewable in an HTML-capable mail reader.  Some people disable HTML for security reasons, so to support that this one-liner just dumps the BB code as alt-text.