### PR TITLE
[mailstream] Remove URL parameters when extracting image filenames

### DIFF
--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -157,12 +157,13 @@ function mailstream_do_images($a, &$item, &$attachments) {
 	preg_match_all("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", $item["body"], $matches1);
 	preg_match_all("/\[img\](.*?)\[\/img\]/ism", $item["body"], $matches2);
 	foreach (array_merge($matches1[3], $matches2[1]) as $url) {
+		$components = parse_url($url);
 		$cookiejar = tempnam(get_temppath(), 'cookiejar-mailstream-');
 		$curlResult = Network::fetchUrlFull($url, true, 0, '', $cookiejar);
 		$attachments[$url] = [
 			'data' => $curlResult->getBody(),
 			'guid' => hash("crc32", $url),
-			'filename' => basename($url),
+			'filename' => basename($components['path']),
 			'type' => $curlResult->getContentType()
 		];
 


### PR DESCRIPTION
The filenames used in mailstream sometimes end up looking like "file.jpg?param=123" because I was calling basename on a URL.  This version uses parse_url to get rid of the URL paramters.