### PR TITLE
[mailstream] Support new img format with alt text

### DIFF
--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -163,7 +163,8 @@ function mailstream_do_images($a, &$item, &$attachments) {
 	$attachments = [];
 	preg_match_all("/\[img\=([0-9]*)x([0-9]*)\](.*?)\[\/img\]/ism", $item["body"], $matches1);
 	preg_match_all("/\[img\](.*?)\[\/img\]/ism", $item["body"], $matches2);
-	foreach (array_merge($matches1[3], $matches2[1]) as $url) {
+	preg_match_all("/\[img\=([^\]]*)\]([^[]*)\[\/img\]/ism", $item["body"], $matches3);
+	foreach (array_merge($matches1[3], $matches2[1], $matches3[1]) as $url) {
 		$components = parse_url($url);
 		$cookiejar = tempnam(get_temppath(), 'cookiejar-mailstream-');
 		$curlResult = Network::fetchUrlFull($url, true, 0, '', $cookiejar);

--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -166,6 +166,9 @@ function mailstream_do_images($a, &$item, &$attachments) {
 	preg_match_all("/\[img\=([^\]]*)\]([^[]*)\[\/img\]/ism", $item["body"], $matches3);
 	foreach (array_merge($matches1[3], $matches2[1], $matches3[1]) as $url) {
 		$components = parse_url($url);
+		if (!$components) {
+			continue;
+		}
 		$cookiejar = tempnam(get_temppath(), 'cookiejar-mailstream-');
 		$curlResult = Network::fetchUrlFull($url, true, 0, '', $cookiejar);
 		$attachments[$url] = [


### PR DESCRIPTION
The new release broke mailstream's feature for including images as attachments.  My fault for not testing against develop earlier I guess :(