### PR TITLE
[gnot] Make settings collapsible

### DIFF
--- a/gnot/gnot.php
+++ b/gnot/gnot.php
@@ -78,8 +78,13 @@ function gnot_settings(&$a,&$s) {
 	
 	/* Add some HTML to the existing form */
 
-	$s .= '<div class="settings-block">';
+	$s .= '<span id="settings_gnot_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose(\'settings_gnot_expanded\'); openClose(\'settings_gnot_inflated\');">';
 	$s .= '<h3>' . L10n::t('Gnot Settings') . '</h3>';
+	$s .= '</span>';
+	$s .= '<div id="settings_gnot_expanded" class="settings-block" style="display: none;">';
+	$s .= '<span class="fakelink" onclick="openClose(\'settings_gnot_expanded\'); openClose(\'settings_gnot_inflated\');">';
+	$s .= '<h3>' . L10n::t('Gnot Settings') . '</h3>';
+	$s .= '</span>';
 	$s .= '<div id="gnot-wrapper">';
 	$s .= '<div id="gnot-desc">' . L10n::t("Allows threading of email comment notifications on Gmail and anonymising the subject line.") . '</div>';
 	$s .= '<label id="gnot-label" for="gnot">' . L10n::t('Enable this addon?') . '</label>';

--- a/gnot/gnot.php
+++ b/gnot/gnot.php
@@ -11,6 +11,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
+use Friendica\Core\Renderer;
 
 function gnot_install() {
 
@@ -76,25 +77,16 @@ function gnot_settings(&$a,&$s) {
 
 	$gnot_checked = (($gnot) ? ' checked="checked" ' : '' );
 	
+	$t = Renderer::getMarkupTemplate('settings.tpl', 'addon/gnot/');
 	/* Add some HTML to the existing form */
 
-	$s .= '<span id="settings_gnot_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose(\'settings_gnot_expanded\'); openClose(\'settings_gnot_inflated\');">';
-	$s .= '<h3>' . L10n::t('Gnot Settings') . '</h3>';
-	$s .= '</span>';
-	$s .= '<div id="settings_gnot_expanded" class="settings-block" style="display: none;">';
-	$s .= '<span class="fakelink" onclick="openClose(\'settings_gnot_expanded\'); openClose(\'settings_gnot_inflated\');">';
-	$s .= '<h3>' . L10n::t('Gnot Settings') . '</h3>';
-	$s .= '</span>';
-	$s .= '<div id="gnot-wrapper">';
-	$s .= '<div id="gnot-desc">' . L10n::t("Allows threading of email comment notifications on Gmail and anonymising the subject line.") . '</div>';
-	$s .= '<label id="gnot-label" for="gnot">' . L10n::t('Enable this addon?') . '</label>';
-	$s .= '<input id="gnot-input" type="checkbox" name="gnot" value="1"'.  $gnot_checked . '/>';
-	$s .= '</div><div class="clear"></div>';
-
-	/* provide a submit button */
-
-	$s .= '<div class="settings-submit-wrapper" ><input type="submit" name="gnot-submit" class="settings-submit" value="' . L10n::t('Save Settings') . '" /></div></div>';
-
+	$s .= Renderer::replaceMacros($t, [
+		'$title' => L10n::t('Gnot Settings') ,
+		'$submit' => L10n::t('Save Settings'),
+		'$enable' => L10n::t('Enable this addon?'),
+		'$enabled' => $gnot_checked,
+		'$text' => L10n::t("Allows threading of email comment notifications on Gmail and anonymising the subject line.") 
+	]);
 }
 
 

--- a/gnot/templates/settings.tpl
+++ b/gnot/templates/settings.tpl
@@ -1,0 +1,20 @@
+<span id="settings_gnot_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose(\'settings_gnot_expanded\'); openClose(\'settings_gnot_inflated\');">
+	<h3>{{$title}}</h3>
+</span>
+<div id="settings_gnot_expanded" class="settings-block" style="display: none;">
+	<span class="fakelink" onclick="openClose(\'settings_gnot_expanded\'); openClose(\'settings_gnot_inflated\');">
+		<h3>{{$title}}</h3>
+	</span>
+	<div id="gnot-wrapper">
+		<div id="gnot-desc">{{$text}}</div>
+			<label id="gnot-label" for="gnot">{{$enable}}</label>
+			<input id="gnot-input" type="checkbox" name="gnot" value="1" {{$enabled}} />
+		</div>
+	<div class="clear"></div>
+
+	/* provide a submit button */
+
+	<div class="settings-submit-wrapper" >
+		<input type="submit" name="gnot-submit" class="settings-submit" value="{{$submit}}" />
+	</div>
+</div>


### PR DESCRIPTION
This PR adds the missing HTML to the gnot addons settings block to make it collaps-able.

See discussion [in the support forum](https://forum.friendi.ca/display/e18176ef-195d-9494-9535-ff2105792235).