### PR TITLE
added editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig tool configuration
+# see http://editorconfig.org for docs
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespaces = true
+indent_style = tab


### PR DESCRIPTION
There are cases when the addon repository is not in a sub-directory of the main repo of Friendica on the computer of a developer. At the moment then the `editorconfig` file is not found.

This PR copies over the configuration file used by many editors from the main repo to the addon repository.