### PR TITLE
group membership checked against login instead of DN

### DIFF
--- a/ldapauth/ldapauth.php
+++ b/ldapauth/ldapauth.php
@@ -157,7 +157,7 @@ function ldapauth_authenticate($username, $password)
 		return true;
 	}
 
-	$r = @ldap_compare($connect, $ldap_group, 'member', $dn);
+	$r = @ldap_compare($connect, $ldap_group, 'member', $res);
 	if ($r === -1) {
 		$err = @ldap_error($connect);
 		$eno = @ldap_errno($connect);


### PR DESCRIPTION
Hi , sorry if this is out of the blue. 

After weeks of messing with why Friendica won't work with LDAP, i finally narrowed _my particular_ problem down to Group Membership not parsing the attribute value correctly. 

for my LDAP groups, the `memberUid` attribute is not filled with DNs of my users, but the `uid`s of my users. 

So after changing `$dn` to `$res`, suddenly all my group members would resolve!

It's a very minor change, but it might affect someone else. 

I didn't see an **issues** tab on the `friendica-addons` repo, so I thought I'd just submit this change the pull request way. Sorry if this is out of sequence or something. While not a coder at all, I am happy to help resolve this any other way you'd like. 