### PR TITLE
Issue 7916: Buffer is unsupported now

### DIFF
--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -4,6 +4,7 @@
  * Description: Post to Buffer (Facebook Pages, LinkedIn, Twitter)
  * Version: 0.2
  * Author: Michael Vogel <http://pirati.ca/profile/heluecht>
+ * Status: Unsupported
  */
 require 'addon/buffer/bufferapp.php';
 


### PR DESCRIPTION
See issue https://github.com/friendica/friendica/issues/7916

Buffer doesn't allow the registration of new applications via their API. So we deprecate that addon now. It will possibly still work for people with already registered API keys.