### PR TITLE
[advancedcontentfilter] Fix Hook-call during install 

### DIFF
--- a/advancedcontentfilter/advancedcontentfilter.php
+++ b/advancedcontentfilter/advancedcontentfilter.php
@@ -56,10 +56,11 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'a
 
 function advancedcontentfilter_install(App $a)
 {
-	Hook::add('dbstructure_definition'          , __FILE__, 'advancedcontentfilter_dbstructure_definition');
+	Hook::register('dbstructure_definition'     , __FILE__, 'advancedcontentfilter_dbstructure_definition');
 	Hook::register('prepare_body_content_filter', __FILE__, 'advancedcontentfilter_prepare_body_content_filter');
 	Hook::register('addon_settings'             , __FILE__, 'advancedcontentfilter_addon_settings');
 
+	Hook::add('dbstructure_definition'          , __FILE__, 'advancedcontentfilter_dbstructure_definition');
 	DBStructure::update($a->getBasePath(), false, true);
 
 	Logger::log("installed advancedcontentfilter");
@@ -67,6 +68,7 @@ function advancedcontentfilter_install(App $a)
 
 function advancedcontentfilter_uninstall()
 {
+	Hook::unregister('dbstructure_definition'     , __FILE__, 'advancedcontentfilter_dbstructure_definition');
 	Hook::unregister('prepare_body_content_filter', __FILE__, 'advancedcontentfilter_prepare_body_content_filter');
 	Hook::unregister('addon_settings'             , __FILE__, 'advancedcontentfilter_addon_settings');
 }

--- a/advancedcontentfilter/advancedcontentfilter.php
+++ b/advancedcontentfilter/advancedcontentfilter.php
@@ -56,7 +56,7 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'a
 
 function advancedcontentfilter_install(App $a)
 {
-	Hook::add('dbstructure_definition'     , __FILE__, 'advancedcontentfilter_dbstructure_definition');
+	Hook::add('dbstructure_definition'          , __FILE__, 'advancedcontentfilter_dbstructure_definition');
 	Hook::register('prepare_body_content_filter', __FILE__, 'advancedcontentfilter_prepare_body_content_filter');
 	Hook::register('addon_settings'             , __FILE__, 'advancedcontentfilter_addon_settings');
 

--- a/advancedcontentfilter/advancedcontentfilter.php
+++ b/advancedcontentfilter/advancedcontentfilter.php
@@ -56,7 +56,7 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'a
 
 function advancedcontentfilter_install(App $a)
 {
-	Hook::register('dbstructure_definition'     , __FILE__, 'advancedcontentfilter_dbstructure_definition');
+	Hook::add('dbstructure_definition'     , __FILE__, 'advancedcontentfilter_dbstructure_definition');
 	Hook::register('prepare_body_content_filter', __FILE__, 'advancedcontentfilter_prepare_body_content_filter');
 	Hook::register('addon_settings'             , __FILE__, 'advancedcontentfilter_addon_settings');
 
@@ -67,7 +67,6 @@ function advancedcontentfilter_install(App $a)
 
 function advancedcontentfilter_uninstall()
 {
-	Hook::unregister('dbstructure_definition'     , __FILE__, 'advancedcontentfilter_dbstructure_definition');
 	Hook::unregister('prepare_body_content_filter', __FILE__, 'advancedcontentfilter_prepare_body_content_filter');
 	Hook::unregister('addon_settings'             , __FILE__, 'advancedcontentfilter_addon_settings');
 }


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/7989

Types of hook-calls:
 * `Hook::register()` just registers hooks, but doesn't add them to the current call
 * `Hook::add()` just adds hook to the current call, but doesn't register them

Since we  want to call the db-definition hook just **once** during the install process, I switched from `Hook::register()` to `Hook:add()` and therefore removed the unregister call as well.