### PR TITLE
New Addon Markdown

### DIFF
--- a/markdown/README
+++ b/markdown/README
@@ -1,0 +1,5 @@
+Markdown
+========
+
+The Markdown addon parses user input for new items and comments via the Markdown parser.
+This enables users to use the Markdown syntax additionally to the BBCode syntax.

--- a/markdown/lang/C/messages.po
+++ b/markdown/lang/C/messages.po
@@ -1,0 +1,35 @@
+# ADDON markdown
+# Copyright (C) 
+# This file is distributed under the same license as the Friendica markdown addon package.
+# 
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-12-26 10:04+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: markdown.php:32
+msgid "Markdown"
+msgstr ""
+
+#: markdown.php:33
+msgid "Enable Markdown parsing"
+msgstr ""
+
+#: markdown.php:33
+msgid ""
+"If enabled, self created items will additionally be parsed via Markdown."
+msgstr ""
+
+#: markdown.php:34
+msgid "Save Settings"
+msgstr ""

--- a/markdown/markdown.php
+++ b/markdown/markdown.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Name: Markdown
+ * Description: Parse Markdown code when creating new items
+ * Version: 0.1
+ * Author: Michael Vogel <https://pirati.ca/profile/heluecht>
+ */
+use Friendica\App;
+use Friendica\Core\Hook;
+use Friendica\Core\Logger;
+use Friendica\Content\Text\Markdown;
+use Friendica\Core\Renderer;
+use Friendica\Core\PConfig;
+use Friendica\Core\L10n;
+
+function markdown_install() {
+	Hook::register('post_local_start',      __FILE__, 'markdown_post_local_start');
+	Hook::register('addon_settings',        __FILE__, 'markdown_addon_settings');
+	Hook::register('addon_settings_post',   __FILE__, 'markdown_addon_settings_post');
+}
+
+function markdown_addon_settings(App $a, &$s)
+{
+	if (!local_user()) {
+		return;
+	}
+
+	$enabled = intval(PConfig::get(local_user(), 'markdown', 'enabled'));
+
+	$t = Renderer::getMarkupTemplate('settings.tpl', 'addon/markdown/');
+	$s .= Renderer::replaceMacros($t, [
+		'$title'   => L10n::t('Markdown'),
+		'$enabled' => ['enabled', L10n::t('Enable Markdown parsing'), $enabled, L10n::t('If enabled, self created items will additionally be parsed via Markdown.')],
+		'$submit'  => L10n::t('Save Settings'),
+	]);
+}
+
+function markdown_addon_settings_post(App $a, &$b)
+{
+	if (!local_user() || empty($_POST['markdown-submit'])) {
+		return;
+	}
+
+	PConfig::set(local_user(), 'markdown', 'enabled', intval($_POST['enabled']));
+}
+
+function markdown_post_local_start(App $a, &$request) {
+	if (empty($request['body']) || !PConfig::get(local_user(), 'markdown', 'enabled')) {
+		return;
+	}
+
+	$request['body'] = Markdown::toBBCode($request['body']);
+}

--- a/markdown/templates/settings.tpl
+++ b/markdown/templates/settings.tpl
@@ -1,0 +1,15 @@
+<span id="settings_markdown_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose('settings_markdown_expanded'); openClose('settings_markdown_inflated');">
+	<h3>{{$title}}</h3>
+</span>
+<div id="settings_markdown_expanded" class="settings-block" style="display: none;">
+	<span class="fakelink" onclick="openClose('settings_markdown_expanded'); openClose('settings_markdown_inflated');">
+		<h3>{{$title}}</h3>
+	</span>
+
+	<div id="markdown-wrapper">
+		{{include file="field_checkbox.tpl" field=$enabled}}
+	</div>
+	<div class="settings-submit-wrapper" >
+		<input type="submit" id="markdown-submit" name="markdown-submit" class="settings-submit" value="{{$submit}}" />
+	</div>
+</div>	


### PR DESCRIPTION
This addon parses user input for Markdown content as well. This is highly experimental and could possibly lead to wrong parsing of BBCode elements. But since it can be enabled and disabled on a user level, users can test it out and report problems.