### PR TITLE
Markdown: Protecting some more BBCode elements

### DIFF
--- a/markdown/markdown.php
+++ b/markdown/markdown.php
@@ -50,7 +50,8 @@ function markdown_post_local_start(App $a, &$request) {
 	}
 
 	// Elements that shouldn't be parsed
-	$elements = ['code', 'noparse', 'nobb', 'pre', 'share', 'url', 'img'];
+	$elements = ['code', 'noparse', 'nobb', 'pre', 'share', 'url', 'img', 'bookmark',
+		'audio', 'video', 'youtube', 'vimeo', 'attachment', 'iframe', 'map', 'mail'];
 	foreach ($elements as $element) {
 		$request['body'] = preg_replace_callback("/\[" . $element . "(.*?)\](.*?)\[\/" . $element . "\]/ism",
 			function ($match) use ($element) {


### PR DESCRIPTION
I hope that these are now all elements that do contain content that could be falsely parsed by the Markdown parser.