### PR TITLE
Explicit methods in DI Registry 

### DIFF
--- a/advancedcontentfilter/advancedcontentfilter.php
+++ b/advancedcontentfilter/advancedcontentfilter.php
@@ -42,11 +42,11 @@ use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\Database\DBStructure;
-use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\Term;
 use Friendica\Module\Security\Login;
 use Friendica\Network\HTTPException;
+use Friendica\Registry\Core;
 use Friendica\Util\DateTimeFormat;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -114,7 +114,7 @@ function advancedcontentfilter_prepare_body_content_filter(App $a, &$hook_data)
 		$vars[str_replace('-', '_', $key)] = $value;
 	}
 
-	$rules = DI::cache()->get('rules_' . local_user());
+	$rules = Core::cache()->get('rules_' . local_user());
 	if (!isset($rules)) {
 		$rules = DBA::toArray(DBA::select(
 			'advancedcontentfilter_rules',
@@ -122,7 +122,7 @@ function advancedcontentfilter_prepare_body_content_filter(App $a, &$hook_data)
 			['uid' => local_user(), 'active' => true]
 		));
 
-		DI::cache()->set('rules_' . local_user(), $rules);
+		Core::cache()->set('rules_' . local_user(), $rules);
 	}
 
 	if ($rules) {

--- a/blockem/blockem.php
+++ b/blockem/blockem.php
@@ -11,7 +11,7 @@ use Friendica\App;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Strings;
 
 function blockem_install()
@@ -44,7 +44,7 @@ function blockem_addon_settings (App $a, &$s)
 	}
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/blockem/blockem.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/blockem/blockem.css' . '" media="all" />' . "\r\n";
 
 	$words = PConfig::get(local_user(), 'blockem', 'words');
 
@@ -149,7 +149,7 @@ function blockem_prepare_body_content_filter(App $a, array &$hook_data)
 function blockem_display_item(App $a, array &$b = null)
 {
 	if (!empty($b['output']['body']) && strstr($b['output']['body'], 'id="blockem-wrap-')) {
-		$b['output']['thumb'] = DI::baseUrl()->get() . "/images/person-80.jpg";
+		$b['output']['thumb'] = A::baseUrl()->get() . "/images/person-80.jpg";
 	}
 }
 
@@ -165,7 +165,7 @@ function blockem_conversation_start(App $a, array &$b)
 		$a->data['blockem'] = explode(',', $words);
 	}
 
-	DI::page()['htmlhead'] .= <<< EOT
+	A::page()['htmlhead'] .= <<< EOT
 
 <script>
 function blockemBlock(author) {

--- a/blockem/blockem.php
+++ b/blockem/blockem.php
@@ -11,7 +11,7 @@ use Friendica\App;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Strings;
 
 function blockem_install()
@@ -44,7 +44,7 @@ function blockem_addon_settings (App $a, &$s)
 	}
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/blockem/blockem.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/blockem/blockem.css' . '" media="all" />' . "\r\n";
 
 	$words = PConfig::get(local_user(), 'blockem', 'words');
 
@@ -149,7 +149,7 @@ function blockem_prepare_body_content_filter(App $a, array &$hook_data)
 function blockem_display_item(App $a, array &$b = null)
 {
 	if (!empty($b['output']['body']) && strstr($b['output']['body'], 'id="blockem-wrap-')) {
-		$b['output']['thumb'] = A::baseUrl()->get() . "/images/person-80.jpg";
+		$b['output']['thumb'] = AppR::baseUrl()->get() . "/images/person-80.jpg";
 	}
 }
 
@@ -165,7 +165,7 @@ function blockem_conversation_start(App $a, array &$b)
 		$a->data['blockem'] = explode(',', $words);
 	}
 
-	A::page()['htmlhead'] .= <<< EOT
+	AppR::page()['htmlhead'] .= <<< EOT
 
 <script>
 function blockemBlock(author) {

--- a/blogger/blogger.php
+++ b/blogger/blogger.php
@@ -12,7 +12,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
 
@@ -69,7 +69,7 @@ function blogger_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/blogger/blogger.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/blogger/blogger.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 

--- a/blogger/blogger.php
+++ b/blogger/blogger.php
@@ -12,7 +12,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
 
@@ -69,7 +69,7 @@ function blogger_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/blogger/blogger.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/blogger/blogger.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 

--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -17,8 +17,8 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\ItemContent;
+use Friendica\Registry\App as A;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Strings;
 
@@ -111,7 +111,7 @@ function buffer_connect(App $a)
 	$client_secret = Config::get('buffer','client_secret');
 
 	// The callback URL is the script that gets called after the user authenticates with buffer
-	$callback_url = DI::baseUrl()->get()."/buffer/connect";
+	$callback_url = A::baseUrl()->get() . "/buffer/connect";
 
 	$buffer = new BufferApp($client_id, $client_secret, $callback_url);
 
@@ -120,7 +120,7 @@ function buffer_connect(App $a)
 	} else {
 		Logger::log("buffer_connect: authenticated");
 		$o = L10n::t("You are now authenticated to buffer. ");
-		$o .= '<br /><a href="' . DI::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
+		$o .= '<br /><a href="' . A::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
 		PConfig::set(local_user(), 'buffer','access_token', $buffer->access_token);
 	}
 
@@ -153,7 +153,7 @@ function buffer_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/buffer/buffer.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/buffer/buffer.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -182,7 +182,7 @@ function buffer_settings(App $a, &$s)
 
 	if ($access_token == "") {
 		$s .= '<div id="buffer-authenticate-wrapper">';
-		$s .= '<a href="'.DI::baseUrl()->get().'/buffer/connect">'.L10n::t("Authenticate your Buffer connection").'</a>';
+		$s .= '<a href="' . A::baseUrl()->get() . '/buffer/connect">' . L10n::t("Authenticate your Buffer connection") . '</a>';
 		$s .= '</div><div class="clear"></div>';
 	} else {
 		$s .= '<div id="buffer-enable-wrapper">';
@@ -201,7 +201,7 @@ function buffer_settings(App $a, &$s)
 		$s .= '</div><div class="clear"></div>';
 
 		// The callback URL is the script that gets called after the user authenticates with buffer
-		$callback_url = DI::baseUrl()->get() . '/buffer/connect';
+		$callback_url = A::baseUrl()->get() . '/buffer/connect';
 
 		$buffer = new BufferApp($client_id, $client_secret, $callback_url, $access_token);
 

--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -18,7 +18,7 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\Model\ItemContent;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Strings;
 
@@ -111,7 +111,7 @@ function buffer_connect(App $a)
 	$client_secret = Config::get('buffer','client_secret');
 
 	// The callback URL is the script that gets called after the user authenticates with buffer
-	$callback_url = A::baseUrl()->get() . "/buffer/connect";
+	$callback_url = AppR::baseUrl()->get() . "/buffer/connect";
 
 	$buffer = new BufferApp($client_id, $client_secret, $callback_url);
 
@@ -120,7 +120,7 @@ function buffer_connect(App $a)
 	} else {
 		Logger::log("buffer_connect: authenticated");
 		$o = L10n::t("You are now authenticated to buffer. ");
-		$o .= '<br /><a href="' . A::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
+		$o .= '<br /><a href="' . AppR::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
 		PConfig::set(local_user(), 'buffer','access_token', $buffer->access_token);
 	}
 
@@ -153,7 +153,7 @@ function buffer_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/buffer/buffer.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/buffer/buffer.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -182,7 +182,7 @@ function buffer_settings(App $a, &$s)
 
 	if ($access_token == "") {
 		$s .= '<div id="buffer-authenticate-wrapper">';
-		$s .= '<a href="' . A::baseUrl()->get() . '/buffer/connect">' . L10n::t("Authenticate your Buffer connection") . '</a>';
+		$s .= '<a href="' . AppR::baseUrl()->get() . '/buffer/connect">' . L10n::t("Authenticate your Buffer connection") . '</a>';
 		$s .= '</div><div class="clear"></div>';
 	} else {
 		$s .= '<div id="buffer-enable-wrapper">';
@@ -201,7 +201,7 @@ function buffer_settings(App $a, &$s)
 		$s .= '</div><div class="clear"></div>';
 
 		// The callback URL is the script that gets called after the user authenticates with buffer
-		$callback_url = A::baseUrl()->get() . '/buffer/connect';
+		$callback_url = AppR::baseUrl()->get() . '/buffer/connect';
 
 		$buffer = new BufferApp($client_id, $client_secret, $callback_url, $access_token);
 

--- a/calc/calc.php
+++ b/calc/calc.php
@@ -6,7 +6,7 @@
  * Author: Mike Macgirvin <http://macgirvin.com/profile/mike>
  */
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function calc_install() {
 	Hook::register('app_menu', 'addon/calc/calc.php', 'calc_app_menu');
@@ -285,7 +285,7 @@ id.value = ""
 </script>
 
 EOT;
-DI::page()['htmlhead'] .= $x;
+App::page()['htmlhead'] .= $x;
 }
 
 function calc_content($app) {

--- a/catavatar/catavatar.php
+++ b/catavatar/catavatar.php
@@ -18,7 +18,7 @@ use Friendica\Database\DBA;
 use Friendica\Model\Contact;
 use Friendica\Model\Photo;
 use Friendica\Network\HTTPException\NotFoundException;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 define("CATAVATAR_SIZE", 256);
 
@@ -85,7 +85,7 @@ function catavatar_addon_settings_post(App $a, &$s)
 	$seed = PConfig::get(local_user(), 'catavatar', 'seed', md5(trim(strtolower($user['email']))));
 
 	if (!empty($_POST['catavatar-usecat'])) {
-		$url = A::baseUrl()->get() . '/catavatar/' . local_user() . '?ts=' . time();
+		$url = AppR::baseUrl()->get() . '/catavatar/' . local_user() . '?ts=' . time();
 
 		$self = DBA::selectFirst('contact', ['id'], ['uid' => local_user(), 'self' => true]);
 		if (!DBA::isResult($self)) {
@@ -112,7 +112,7 @@ function catavatar_addon_settings_post(App $a, &$s)
 		Contact::updateSelfFromUserID(local_user(), true);
 
 		// Update global directory in background
-		$url = A::baseUrl()->get() . '/profile/' . $a->user['nickname'];
+		$url = AppR::baseUrl()->get() . '/profile/' . $a->user['nickname'];
 		if ($url && strlen(Config::get('system', 'directory'))) {
 			Worker::add(PRIORITY_LOW, 'Directory', $url);
 		}
@@ -141,7 +141,7 @@ function catavatar_addon_settings_post(App $a, &$s)
 function catavatar_lookup(App $a, &$b)
 {
 	$user = DBA::selectFirst('user', ['uid'], ['email' => $b['email']]);
-	$url = A::baseUrl()->get() . '/catavatar/' . $user['uid'];
+	$url = AppR::baseUrl()->get() . '/catavatar/' . $user['uid'];
 
 	switch($b['size']) {
 		case 300: $url .= "/4"; break;

--- a/catavatar/catavatar.php
+++ b/catavatar/catavatar.php
@@ -15,10 +15,10 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Photo;
 use Friendica\Network\HTTPException\NotFoundException;
+use Friendica\Registry\App as A;
 
 define("CATAVATAR_SIZE", 256);
 
@@ -85,7 +85,7 @@ function catavatar_addon_settings_post(App $a, &$s)
 	$seed = PConfig::get(local_user(), 'catavatar', 'seed', md5(trim(strtolower($user['email']))));
 
 	if (!empty($_POST['catavatar-usecat'])) {
-		$url = DI::baseUrl()->get() . '/catavatar/' . local_user() . '?ts=' . time();
+		$url = A::baseUrl()->get() . '/catavatar/' . local_user() . '?ts=' . time();
 
 		$self = DBA::selectFirst('contact', ['id'], ['uid' => local_user(), 'self' => true]);
 		if (!DBA::isResult($self)) {
@@ -112,7 +112,7 @@ function catavatar_addon_settings_post(App $a, &$s)
 		Contact::updateSelfFromUserID(local_user(), true);
 
 		// Update global directory in background
-		$url = DI::baseUrl()->get() . '/profile/' . $a->user['nickname'];
+		$url = A::baseUrl()->get() . '/profile/' . $a->user['nickname'];
 		if ($url && strlen(Config::get('system', 'directory'))) {
 			Worker::add(PRIORITY_LOW, 'Directory', $url);
 		}
@@ -141,7 +141,7 @@ function catavatar_addon_settings_post(App $a, &$s)
 function catavatar_lookup(App $a, &$b)
 {
 	$user = DBA::selectFirst('user', ['uid'], ['email' => $b['email']]);
-	$url = DI::baseUrl()->get() . '/catavatar/' . $user['uid'];
+	$url = A::baseUrl()->get() . '/catavatar/' . $user['uid'];
 
 	switch($b['size']) {
 		case 300: $url .= "/4"; break;

--- a/cookienotice/cookienotice.php
+++ b/cookienotice/cookienotice.php
@@ -12,7 +12,7 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 
 /**
  * cookienotice_install
@@ -91,8 +91,8 @@ function cookienotice_page_content_top(App $a, &$b)
 	$stylesheetPath = __DIR__ . '/cookienotice.css';
 	$footerscriptPath = __DIR__ . '/cookienotice.js';
 
-	DI::page()->registerStylesheet($stylesheetPath);
-	DI::page()->registerFooterScript($footerscriptPath);
+	A::page()->registerStylesheet($stylesheetPath);
+	A::page()->registerFooterScript($footerscriptPath);
 }
 
 /**

--- a/cookienotice/cookienotice.php
+++ b/cookienotice/cookienotice.php
@@ -12,7 +12,7 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 /**
  * cookienotice_install
@@ -91,8 +91,8 @@ function cookienotice_page_content_top(App $a, &$b)
 	$stylesheetPath = __DIR__ . '/cookienotice.css';
 	$footerscriptPath = __DIR__ . '/cookienotice.js';
 
-	A::page()->registerStylesheet($stylesheetPath);
-	A::page()->registerFooterScript($footerscriptPath);
+	AppR::page()->registerStylesheet($stylesheetPath);
+	AppR::page()->registerFooterScript($footerscriptPath);
 }
 
 /**

--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -10,7 +10,7 @@
  */
 
 use Friendica\App;
-use Friendica\Core\Cache;
+use Friendica\Core\Cache\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
@@ -18,6 +18,7 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
 use Friendica\Registry\App as A;
+use Friendica\Registry\Core;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy as ProxyUtils;
 
@@ -39,7 +40,7 @@ function curweather_uninstall()
 function getWeather($loc, $units = 'metric', $lang = 'en', $appid = '', $cachetime = 0)
 {
 	$url = "http://api.openweathermap.org/data/2.5/weather?q=" . $loc . "&appid=" . $appid . "&lang=" . $lang . "&units=" . $units . "&mode=xml";
-	$cached = Cache::get('curweather'.md5($url));
+	$cached = Core::cache()->get('curweather'.md5($url));
 	$now = new DateTime();
 
 	if (!is_null($cached)) {
@@ -93,7 +94,7 @@ function getWeather($loc, $units = 'metric', $lang = 'en', $appid = '', $cacheti
 	];
 
 	PConfig::set(local_user(), 'curweather', 'last', $now->getTimestamp());
-	Cache::set('curweather'.md5($url), serialize($r), Cache::HOUR);
+	Core::cache()->set('curweather'.md5($url), serialize($r), Cache::HOUR);
 
 	return $r;
 }

--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -17,7 +17,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy as ProxyUtils;
 
@@ -104,7 +104,7 @@ function curweather_network_mod_init(App $a, &$b)
 		return;
 	}
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/curweather/curweather.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/curweather/curweather.css' . '" media="all" />' . "\r\n";
 
 	// $rpt value is needed for location
 	// $lang will be taken from the browser session to honour user settings
@@ -137,7 +137,7 @@ function curweather_network_mod_init(App $a, &$b)
 
 	if ($ok) {
 		$t = Renderer::getMarkupTemplate("widget.tpl", "addon/curweather/" );
-		$curweather = Renderer::replaceMacros($t, [
+		$curweather              = Renderer::replaceMacros($t, [
 			'$title' => L10n::t("Current Weather"),
 			'$icon' => ProxyUtils::proxifyUrl('http://openweathermap.org/img/w/'.$res['icon'].'.png'),
 			'$city' => $res['city'],
@@ -161,7 +161,7 @@ function curweather_network_mod_init(App $a, &$b)
 		]);
 	}
 
-	DI::page()['aside'] = $curweather . DI::page()['aside'];
+	A::page()['aside'] = $curweather . A::page()['aside'];
 }
 
 function curweather_addon_settings_post(App $a, $post)

--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -17,7 +17,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Core\Session;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Registry\Core;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy as ProxyUtils;
@@ -105,7 +105,7 @@ function curweather_network_mod_init(App $a, &$b)
 		return;
 	}
 
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/curweather/curweather.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/curweather/curweather.css' . '" media="all" />' . "\r\n";
 
 	// $rpt value is needed for location
 	// $lang will be taken from the browser session to honour user settings
@@ -162,7 +162,7 @@ function curweather_network_mod_init(App $a, &$b)
 		]);
 	}
 
-	A::page()['aside'] = $curweather . A::page()['aside'];
+	AppR::page()['aside'] = $curweather . AppR::page()['aside'];
 }
 
 function curweather_addon_settings_post(App $a, $post)

--- a/diaspora/diaspora.php
+++ b/diaspora/diaspora.php
@@ -17,7 +17,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
 use Friendica\Core\Worker;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 function diaspora_install()
 {
@@ -65,7 +65,7 @@ function diaspora_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/diaspora/diaspora.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/diaspora/diaspora.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -231,7 +231,7 @@ function diaspora_post_local(App $a, array &$b)
 
 function diaspora_send(App $a, array &$b)
 {
-	$hostname = A::baseUrl()->getHostname();
+	$hostname = AppR::baseUrl()->getHostname();
 
 	Logger::log('diaspora_send: invoked');
 

--- a/diaspora/diaspora.php
+++ b/diaspora/diaspora.php
@@ -15,10 +15,9 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\Core\Worker;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 
 function diaspora_install()
 {
@@ -66,7 +65,7 @@ function diaspora_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/diaspora/diaspora.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/diaspora/diaspora.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -232,7 +231,7 @@ function diaspora_post_local(App $a, array &$b)
 
 function diaspora_send(App $a, array &$b)
 {
-	$hostname = DI::baseUrl()->getHostname();
+	$hostname = A::baseUrl()->getHostname();
 
 	Logger::log('diaspora_send: invoked');
 

--- a/dwpost/dwpost.php
+++ b/dwpost/dwpost.php
@@ -15,7 +15,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
@@ -64,7 +64,7 @@ function dwpost_settings(App $a, &$s)
 	}
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/dwpost/dwpost.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/dwpost/dwpost.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 	$enabled = PConfig::get(local_user(), 'dwpost', 'post');

--- a/dwpost/dwpost.php
+++ b/dwpost/dwpost.php
@@ -15,7 +15,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
@@ -64,7 +64,7 @@ function dwpost_settings(App $a, &$s)
 	}
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/dwpost/dwpost.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/dwpost/dwpost.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 	$enabled = PConfig::get(local_user(), 'dwpost', 'post');

--- a/forumdirectory/forumdirectory.php
+++ b/forumdirectory/forumdirectory.php
@@ -15,8 +15,8 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\Profile;
+use Friendica\Registry\App as A;
 use Friendica\Util\Strings;
 
 function forumdirectory_install()
@@ -42,7 +42,7 @@ function forumdirectory_app_menu(App $a, array &$b)
 function forumdirectory_init(App $a)
 {
 	if (local_user()) {
-		DI::page()['aside'] .= Widget::findPeople();
+		A::page()['aside'] .= Widget::findPeople();
 	}
 }
 
@@ -108,7 +108,7 @@ function forumdirectory_content(App $a)
 		$total = $cnt['total'];
 	}
 
-	$pager = new Pager(DI::args()->getQueryString(), 60);
+	$pager = new Pager(A::args()->getQueryString(), 60);
 
 	$order = " ORDER BY `name` ASC ";
 

--- a/forumdirectory/forumdirectory.php
+++ b/forumdirectory/forumdirectory.php
@@ -16,7 +16,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\Model\Profile;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Strings;
 
 function forumdirectory_install()
@@ -42,7 +42,7 @@ function forumdirectory_app_menu(App $a, array &$b)
 function forumdirectory_init(App $a)
 {
 	if (local_user()) {
-		A::page()['aside'] .= Widget::findPeople();
+		AppR::page()['aside'] .= Widget::findPeople();
 	}
 }
 
@@ -108,7 +108,7 @@ function forumdirectory_content(App $a)
 		$total = $cnt['total'];
 	}
 
-	$pager = new Pager(A::args()->getQueryString(), 60);
+	$pager = new Pager(AppR::args()->getQueryString(), 60);
 
 	$order = " ORDER BY `name` ASC ";
 

--- a/fromapp/fromapp.php
+++ b/fromapp/fromapp.php
@@ -10,7 +10,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function fromapp_install()
 {
@@ -49,7 +49,7 @@ function fromapp_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/fromapp/fromapp.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/fromapp/fromapp.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/geocoordinates/geocoordinates.php
+++ b/geocoordinates/geocoordinates.php
@@ -11,6 +11,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
+use Friendica\Registry\Core;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 
@@ -48,7 +49,7 @@ function geocoordinates_resolve_item(&$item)
 	$coords[0] = round($coords[0], 5);
 	$coords[1] = round($coords[1], 5);
 
-	$result = Cache::get("geocoordinates:".$language.":".$coords[0]."-".$coords[1]);
+	$result = Core::cache()->get("geocoordinates:".$language.":".$coords[0]."-".$coords[1]);
 	if (!is_null($result)) {
 		$item["location"] = $result;
 		return;
@@ -78,7 +79,7 @@ function geocoordinates_resolve_item(&$item)
 	Logger::log("Got location for coordinates ".$coords[0]."-".$coords[1].": ".$item["location"], Logger::DEBUG);
 
 	if ($item["location"] != "")
-		Cache::set("geocoordinates:".$language.":".$coords[0]."-".$coords[1], $item["location"]);
+		Core::cache()->set("geocoordinates:".$language.":".$coords[0]."-".$coords[1], $item["location"]);
 }
 
 function geocoordinates_post_hook($a, &$item)

--- a/geonames/geonames.php
+++ b/geonames/geonames.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
@@ -137,7 +137,7 @@ function geonames_addon_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 	$stylesheetPath = __DIR__ . '/geonames.css';
-	DI::page()->registerStylesheet($stylesheetPath);
+	A::page()->registerStylesheet($stylesheetPath);
 
 	/* Get the current state of our config variable */
 	$enabled = intval(PConfig::get(local_user(), 'geonames', 'enable'));

--- a/geonames/geonames.php
+++ b/geonames/geonames.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
@@ -137,7 +137,7 @@ function geonames_addon_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 	$stylesheetPath = __DIR__ . '/geonames.css';
-	A::page()->registerStylesheet($stylesheetPath);
+	AppR::page()->registerStylesheet($stylesheetPath);
 
 	/* Get the current state of our config variable */
 	$enabled = intval(PConfig::get(local_user(), 'geonames', 'enable'));

--- a/gnot/gnot.php
+++ b/gnot/gnot.php
@@ -12,7 +12,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function gnot_install() {
 
@@ -70,7 +70,7 @@ function gnot_settings(&$a,&$s) {
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/gnot/gnot.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/gnot/gnot.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/group_text/group_text.php
+++ b/group_text/group_text.php
@@ -9,7 +9,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function group_text_install() {
 
@@ -65,7 +65,7 @@ function group_text_settings(&$a,&$s) {
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/group_text/group_text.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/group_text/group_text.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/highlightjs/highlightjs.php
+++ b/highlightjs/highlightjs.php
@@ -8,7 +8,7 @@
 
 use Friendica\App;
 use Friendica\Core\Hook;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 function highlightjs_install()
 {
@@ -30,11 +30,11 @@ function highlightjs_head(App $a, &$b)
 		$style = 'default';
 	}
 
-	A::page()->registerStylesheet(__DIR__ . '/asset/styles/' . $style . '.css');
+	AppR::page()->registerStylesheet(__DIR__ . '/asset/styles/' . $style . '.css');
 }
 
 function highlightjs_footer(App $a, &$b)
 {
-	A::page()->registerFooterScript(__DIR__ . '/asset/highlight.pack.js');
-	A::page()->registerFooterScript(__DIR__ . '/highlightjs.js');
+	AppR::page()->registerFooterScript(__DIR__ . '/asset/highlight.pack.js');
+	AppR::page()->registerFooterScript(__DIR__ . '/highlightjs.js');
 }

--- a/highlightjs/highlightjs.php
+++ b/highlightjs/highlightjs.php
@@ -8,7 +8,7 @@
 
 use Friendica\App;
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 
 function highlightjs_install()
 {
@@ -30,11 +30,11 @@ function highlightjs_head(App $a, &$b)
 		$style = 'default';
 	}
 
-	DI::page()->registerStylesheet(__DIR__ . '/asset/styles/' . $style . '.css');
+	A::page()->registerStylesheet(__DIR__ . '/asset/styles/' . $style . '.css');
 }
 
 function highlightjs_footer(App $a, &$b)
 {
-	DI::page()->registerFooterScript(__DIR__ . '/asset/highlight.pack.js');
-	DI::page()->registerFooterScript(__DIR__ . '/highlightjs.js');
+	A::page()->registerFooterScript(__DIR__ . '/asset/highlight.pack.js');
+	A::page()->registerFooterScript(__DIR__ . '/highlightjs.js');
 }

--- a/ifttt/ifttt.php
+++ b/ifttt/ifttt.php
@@ -15,7 +15,7 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\Model\Item;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Strings;
 
 function ifttt_install()
@@ -64,7 +64,7 @@ function ifttt_settings(App $a, &$s)
 	$s .= '<div id="ifttt-configuration-wrapper">';
 	$s .= '<p>' . L10n::t('Create an account at <a href="http://www.ifttt.com">IFTTT</a>. Create three Facebook recipes that are connected with <a href="https://ifttt.com/maker">Maker</a> (In the form "if Facebook then Maker") with the following parameters:') . '</p>';
 	$s .= '<h4>URL</h4>';
-	$s .= '<p>' . A::baseUrl()->get() . '/ifttt/' . $a->user['nickname'] . '</p>';
+	$s .= '<p>' . AppR::baseUrl()->get() . '/ifttt/' . $a->user['nickname'] . '</p>';
 	$s .= '<h4>Method</h4>';
 	$s .= '<p>POST</p>';
 	$s .= '<h4>Content Type</h4>';

--- a/ifttt/ifttt.php
+++ b/ifttt/ifttt.php
@@ -14,8 +14,8 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\Item;
+use Friendica\Registry\App as A;
 use Friendica\Util\Strings;
 
 function ifttt_install()
@@ -64,7 +64,7 @@ function ifttt_settings(App $a, &$s)
 	$s .= '<div id="ifttt-configuration-wrapper">';
 	$s .= '<p>' . L10n::t('Create an account at <a href="http://www.ifttt.com">IFTTT</a>. Create three Facebook recipes that are connected with <a href="https://ifttt.com/maker">Maker</a> (In the form "if Facebook then Maker") with the following parameters:') . '</p>';
 	$s .= '<h4>URL</h4>';
-	$s .= '<p>' . DI::baseUrl()->get() . '/ifttt/' . $a->user['nickname'] . '</p>';
+	$s .= '<p>' . A::baseUrl()->get() . '/ifttt/' . $a->user['nickname'] . '</p>';
 	$s .= '<h4>Method</h4>';
 	$s .= '<p>POST</p>';
 	$s .= '<h4>Content Type</h4>';
@@ -161,13 +161,11 @@ function ifttt_post(App $a)
 		$item['msg'] = substr($item['msg'], 3, -3);
 	}
 
-	ifttt_message($uid, $item);
+	ifttt_message($a, $uid, $item);
 }
 
-function ifttt_message($uid, $item)
+function ifttt_message(App $a, $uid, $item)
 {
-	$a = DI::app();
-
 	$_SESSION['authenticated'] = true;
 	$_SESSION['uid'] = $uid;
 

--- a/ijpost/ijpost.php
+++ b/ijpost/ijpost.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
@@ -62,7 +62,7 @@ function ijpost_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/ijpost/ijpost.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/ijpost/ijpost.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 

--- a/impressum/impressum.php
+++ b/impressum/impressum.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\Proxy as ProxyUtils;
 use Friendica\Util\Strings;
@@ -35,7 +35,7 @@ function impressum_uninstall() {
 function impressum_module() {
 }
 function impressum_content() {
-    DI::baseUrl()->redirect('friendica/');
+    App::baseUrl()->redirect('friendica/');
 }
 
 function obfuscate_email ($s) {
@@ -47,8 +47,8 @@ function impressum_footer($a, &$b) {
     $text = ProxyUtils::proxifyHtml(BBCode::convert(Config::get('impressum','footer_text')));
 
     if (! $text == '') {
-        DI::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="'.DI::baseUrl()->get().'/addon/impressum/impressum.css" media="all" />';
-        $b .= '<div class="clear"></div>';
+        App::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="' . App::baseUrl()->get() . '/addon/impressum/impressum.css" media="all" />';
+        $b                      .= '<div class="clear"></div>';
         $b .= '<div id="impressum_footer">'.$text.'</div>';
     }
 }

--- a/infiniteimprobabilitydrive/infiniteimprobabilitydrive.php
+++ b/infiniteimprobabilitydrive/infiniteimprobabilitydrive.php
@@ -7,7 +7,7 @@
 */
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function infiniteimprobabilitydrive_install()
 {
@@ -33,13 +33,13 @@ function infiniteimprobabilitydrive_module()
 
 function infiniteimprobabilitydrive_content(&$a)
 {
-	$baseurl = DI::baseUrl()->get() . '/addon/infiniteimprobabilitydrive';
+	$baseurl = App::baseUrl()->get() . '/addon/infiniteimprobabilitydrive';
 	$o = '';
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="'.DI::baseUrl()->get().'/addon/infiniteimprobabilitydrive/infiniteimprobabilitydrive.css"/>';
+	App::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="' . App::baseUrl()->get() . '/addon/infiniteimprobabilitydrive/infiniteimprobabilitydrive.css"/>';
 
 
-	$baseurl = DI::baseUrl()->get();
+	$baseurl = App::baseUrl()->get();
 
 	$o .= <<< EOT
 

--- a/irc/irc.php
+++ b/irc/irc.php
@@ -12,7 +12,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function irc_install() {
 	Hook::register('app_menu', 'addon/irc/irc.php', 'irc_app_menu');
@@ -81,7 +81,7 @@ function irc_module() {
 
 function irc_content(&$a) {
 
-	$baseurl = DI::baseUrl()->get() . '/addon/irc';
+	$baseurl = App::baseUrl()->get() . '/addon/irc';
 	$o = '';
 
 	/* set the list of popular channels */
@@ -98,11 +98,11 @@ function irc_content(&$a) {
 		$chats = ['friendica','chat','chatback','hottub','ircbar','dateroom','debian'];
 
 
-	DI::page()['aside'] .= '<div class="widget"><h3>' . L10n::t('Popular Channels') . '</h3><ul>';
+	App::page()['aside'] .= '<div class="widget"><h3>' . L10n::t('Popular Channels') . '</h3><ul>';
 	foreach($chats as $chat) {
-		DI::page()['aside'] .= '<li><a href="' . DI::baseUrl()->get() . '/irc?channels=' . $chat . '" >' . '#' . $chat . '</a></li>';
+		App::page()['aside'] .= '<li><a href="' . App::baseUrl()->get() . '/irc?channels=' . $chat . '" >' . '#' . $chat . '</a></li>';
 	}
-	DI::page()['aside'] .= '</ul></div>';
+	App::page()['aside'] .= '</ul></div>';
 
         /* setting the channel(s) to auto connect */
 	if (local_user()) {

--- a/irc/irc.php
+++ b/irc/irc.php
@@ -33,7 +33,7 @@ function irc_addon_settings(&$a,&$s) {
 
     /* Add our stylesheet to the page so we can make our settings look nice */
 
-//	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . $a->getBaseURL() . '/addon/irc/irc.css' . '" media="all" />' . "\r\n";
+//	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . $a->getBaseURL() . '/addon/irc/irc.css' . '" media="all" />' . "\r\n";
 
     /* setting popular channels, auto connect channels */
 	$sitechats = PConfig::get( local_user(), 'irc','sitechats'); /* popular channels */

--- a/irc/irc.php
+++ b/irc/irc.php
@@ -33,7 +33,7 @@ function irc_addon_settings(&$a,&$s) {
 
     /* Add our stylesheet to the page so we can make our settings look nice */
 
-//	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . $a->getBaseURL() . '/addon/irc/irc.css' . '" media="all" />' . "\r\n";
+//	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . $a->getBaseURL() . '/addon/irc/irc.css' . '" media="all" />' . "\r\n";
 
     /* setting popular channels, auto connect channels */
 	$sitechats = PConfig::get( local_user(), 'irc','sitechats'); /* popular channels */

--- a/jappixmini/jappixmini.php
+++ b/jappixmini/jappixmini.php
@@ -71,7 +71,7 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
 use Friendica\Model\User;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Network;
 
 function jappixmini_install()
@@ -325,10 +325,10 @@ function jappixmini_settings(App $a, &$s)
 
 	if (!$activate) {
 		// load scripts if not yet activated so that password can be saved
-		A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
-		A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
+		AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
+		AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
 
-		A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
+		AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
 	}
 
 	$s .= '<span id="settings_jappixmini_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose(\'settings_jappixmini_expanded\'); openClose(\'settings_jappixmini_inflated\');">';
@@ -387,7 +387,7 @@ function jappixmini_settings(App $a, &$s)
 
 	$s .= '</div>';
 
-	A::page()['htmlhead'] .= "<script type=\"text/javascript\">
+	AppR::page()['htmlhead'] .= "<script type=\"text/javascript\">
         function jappixmini_set_password() {
             encrypt = document.getElementById('jappixmini-encrypt').checked;
             password = document.getElementById('jappixmini-password');
@@ -491,10 +491,10 @@ function jappixmini_script(App $a)
 		return;
 	}
 
-	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
-	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
+	AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
+	AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
 
-	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
+	AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
 
 	$username = PConfig::get(local_user(), 'jappixmini', 'username');
 	$username = str_replace("'", "\\'", $username);
@@ -515,7 +515,7 @@ function jappixmini_script(App $a)
 	// set proxy if necessary
 	$use_proxy = Config::get('jappixmini', 'bosh_proxy');
 	if ($use_proxy) {
-		$proxy = A::baseUrl()->get() . '/addon/jappixmini/proxy.php';
+		$proxy = AppR::baseUrl()->get() . '/addon/jappixmini/proxy.php';
 	} else {
 		$proxy = "";
 	}
@@ -557,7 +557,7 @@ function jappixmini_script(App $a)
 	}
 
 	// add javascript to start Jappix Mini
-	A::page()['htmlhead'] .= "<script type=\"text/javascript\">
+	AppR::page()['htmlhead'] .= "<script type=\"text/javascript\">
         jQuery(document).ready(function() {
            jappixmini_addon_start('$server', '$username', '$proxy', '$bosh', $encrypt, '$password', $nickname, $contacts_json, '$contacts_hash', $autoapprove, $autosubscribe, $groupchats);
         });
@@ -570,10 +570,10 @@ function jappixmini_login(App $a, &$o)
 {
 	// create client secret on login to be able to encrypt jabber passwords
 	// for setDB and str_sha1, needed by jappixmini_addon_set_client_secret
-	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=datastore.js~jsjac.js"></script>' . "\r\n";
+	AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=datastore.js~jsjac.js"></script>' . "\r\n";
 
 	// for jappixmini_addon_set_client_secret
-	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
+	AppR::page()['htmlhead'] .= '<script type="text/javascript" src="' . AppR::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
 
 	// save hash of password
 	$o = str_replace("<form ", "<form onsubmit=\"jappixmini_addon_set_client_secret(this.elements['id_password'].value);return true;\" ", $o);
@@ -701,6 +701,6 @@ function jappixmini_download_source(App $a, &$b)
 {
 	// Jappix Mini source download link on About page
 	$b .= '<h1>Jappix Mini</h1>';
-	$b .= '<p>This site uses the jappixmini addon, which includes Jappix Mini by the <a href="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/AUTHORS">Jappix authors</a> and is distributed under the terms of the <a href="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/COPYING">GNU Affero General Public License</a>.</p>';
-	$b .= '<p>You can download the <a href="' . A::baseUrl()->get() . '/addon/jappixmini.tgz">source code of the addon</a>. The rest of Friendica is distributed under compatible licenses and can be retrieved from <a href="https://github.com/friendica/friendica">https://github.com/friendica/friendica</a> and <a href="https://github.com/friendica/friendica-addons">https://github.com/friendica/friendica-addons</a></p>';
+	$b .= '<p>This site uses the jappixmini addon, which includes Jappix Mini by the <a href="' . AppR::baseUrl()->get() . '/addon/jappixmini/jappix/AUTHORS">Jappix authors</a> and is distributed under the terms of the <a href="' . AppR::baseUrl()->get() . '/addon/jappixmini/jappix/COPYING">GNU Affero General Public License</a>.</p>';
+	$b .= '<p>You can download the <a href="' . AppR::baseUrl()->get() . '/addon/jappixmini.tgz">source code of the addon</a>. The rest of Friendica is distributed under compatible licenses and can be retrieved from <a href="https://github.com/friendica/friendica">https://github.com/friendica/friendica</a> and <a href="https://github.com/friendica/friendica-addons">https://github.com/friendica/friendica-addons</a></p>';
 }

--- a/jappixmini/jappixmini.php
+++ b/jappixmini/jappixmini.php
@@ -70,8 +70,8 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\User;
+use Friendica\Registry\App as A;
 use Friendica\Util\Network;
 
 function jappixmini_install()
@@ -325,10 +325,10 @@ function jappixmini_settings(App $a, &$s)
 
 	if (!$activate) {
 		// load scripts if not yet activated so that password can be saved
-		DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
-		DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
+		A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
+		A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
 
-		DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
+		A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
 	}
 
 	$s .= '<span id="settings_jappixmini_inflated" class="settings-block fakelink" style="display: block;" onclick="openClose(\'settings_jappixmini_expanded\'); openClose(\'settings_jappixmini_inflated\');">';
@@ -387,7 +387,7 @@ function jappixmini_settings(App $a, &$s)
 
 	$s .= '</div>';
 
-	DI::page()['htmlhead'] .= "<script type=\"text/javascript\">
+	A::page()['htmlhead'] .= "<script type=\"text/javascript\">
         function jappixmini_set_password() {
             encrypt = document.getElementById('jappixmini-encrypt').checked;
             password = document.getElementById('jappixmini-password');
@@ -491,10 +491,10 @@ function jappixmini_script(App $a)
 		return;
 	}
 
-	DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
-	DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
+	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;g=mini.xml"></script>' . "\r\n";
+	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=presence.js~caps.js~name.js~roster.js"></script>' . "\r\n";
 
-	DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
+	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
 
 	$username = PConfig::get(local_user(), 'jappixmini', 'username');
 	$username = str_replace("'", "\\'", $username);
@@ -515,7 +515,7 @@ function jappixmini_script(App $a)
 	// set proxy if necessary
 	$use_proxy = Config::get('jappixmini', 'bosh_proxy');
 	if ($use_proxy) {
-		$proxy = DI::baseUrl()->get() . '/addon/jappixmini/proxy.php';
+		$proxy = A::baseUrl()->get() . '/addon/jappixmini/proxy.php';
 	} else {
 		$proxy = "";
 	}
@@ -557,7 +557,7 @@ function jappixmini_script(App $a)
 	}
 
 	// add javascript to start Jappix Mini
-	DI::page()['htmlhead'] .= "<script type=\"text/javascript\">
+	A::page()['htmlhead'] .= "<script type=\"text/javascript\">
         jQuery(document).ready(function() {
            jappixmini_addon_start('$server', '$username', '$proxy', '$bosh', $encrypt, '$password', $nickname, $contacts_json, '$contacts_hash', $autoapprove, $autosubscribe, $groupchats);
         });
@@ -570,10 +570,10 @@ function jappixmini_login(App $a, &$o)
 {
 	// create client secret on login to be able to encrypt jabber passwords
 	// for setDB and str_sha1, needed by jappixmini_addon_set_client_secret
-	DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=datastore.js~jsjac.js"></script>' . "\r\n";
+	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/php/get.php?t=js&amp;f=datastore.js~jsjac.js"></script>' . "\r\n";
 
 	// for jappixmini_addon_set_client_secret
-	DI::page()['htmlhead'] .= '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
+	A::page()['htmlhead'] .= '<script type="text/javascript" src="' . A::baseUrl()->get() . '/addon/jappixmini/lib.js"></script>' . "\r\n";
 
 	// save hash of password
 	$o = str_replace("<form ", "<form onsubmit=\"jappixmini_addon_set_client_secret(this.elements['id_password'].value);return true;\" ", $o);
@@ -701,6 +701,6 @@ function jappixmini_download_source(App $a, &$b)
 {
 	// Jappix Mini source download link on About page
 	$b .= '<h1>Jappix Mini</h1>';
-	$b .= '<p>This site uses the jappixmini addon, which includes Jappix Mini by the <a href="' . DI::baseUrl()->get() . '/addon/jappixmini/jappix/AUTHORS">Jappix authors</a> and is distributed under the terms of the <a href="' . DI::baseUrl()->get() . '/addon/jappixmini/jappix/COPYING">GNU Affero General Public License</a>.</p>';
-	$b .= '<p>You can download the <a href="' . DI::baseUrl()->get() . '/addon/jappixmini.tgz">source code of the addon</a>. The rest of Friendica is distributed under compatible licenses and can be retrieved from <a href="https://github.com/friendica/friendica">https://github.com/friendica/friendica</a> and <a href="https://github.com/friendica/friendica-addons">https://github.com/friendica/friendica-addons</a></p>';
+	$b .= '<p>This site uses the jappixmini addon, which includes Jappix Mini by the <a href="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/AUTHORS">Jappix authors</a> and is distributed under the terms of the <a href="' . A::baseUrl()->get() . '/addon/jappixmini/jappix/COPYING">GNU Affero General Public License</a>.</p>';
+	$b .= '<p>You can download the <a href="' . A::baseUrl()->get() . '/addon/jappixmini.tgz">source code of the addon</a>. The rest of Friendica is distributed under compatible licenses and can be retrieved from <a href="https://github.com/friendica/friendica">https://github.com/friendica/friendica</a> and <a href="https://github.com/friendica/friendica-addons">https://github.com/friendica/friendica-addons</a></p>';
 }

--- a/js_upload/js_upload.php
+++ b/js_upload/js_upload.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 function js_upload_install()
 {
@@ -27,8 +27,8 @@ function js_upload_form(App $a, array &$b)
 {
 	$b['default_upload'] = false;
 
-	A::page()->registerStylesheet('addon/js_upload/file-uploader/client/fileuploader.css');
-	A::page()->registerFooterScript('addon/js_upload/file-uploader/client/fileuploader.js');
+	AppR::page()->registerStylesheet('addon/js_upload/file-uploader/client/fileuploader.css');
+	AppR::page()->registerFooterScript('addon/js_upload/file-uploader/client/fileuploader.js');
 
 	$tpl = Renderer::getMarkupTemplate('js_upload.tpl', 'addon/js_upload');
 	$b['addon_text'] .= Renderer::replaceMacros($tpl, [

--- a/js_upload/js_upload.php
+++ b/js_upload/js_upload.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 
 function js_upload_install()
 {
@@ -27,8 +27,8 @@ function js_upload_form(App $a, array &$b)
 {
 	$b['default_upload'] = false;
 
-	DI::page()->registerStylesheet('addon/js_upload/file-uploader/client/fileuploader.css');
-	DI::page()->registerFooterScript('addon/js_upload/file-uploader/client/fileuploader.js');
+	A::page()->registerStylesheet('addon/js_upload/file-uploader/client/fileuploader.css');
+	A::page()->registerFooterScript('addon/js_upload/file-uploader/client/fileuploader.js');
 
 	$tpl = Renderer::getMarkupTemplate('js_upload.tpl', 'addon/js_upload');
 	$b['addon_text'] .= Renderer::replaceMacros($tpl, [

--- a/krynn/krynn.php
+++ b/krynn/krynn.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function krynn_install() {
 
@@ -143,7 +143,7 @@ function krynn_settings(&$a,&$s) {
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/krynn/krynn.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/krynn/krynn.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 /* Define the hooks we want to use
  * that is, we have settings, we need to save the settings and we want
@@ -123,7 +123,7 @@ function langfilter_prepare_body_content_filter(App $a, &$hook_data)
 
 	// Never filter own messages
 	// TODO: find a better way to extract this
-	$logged_user_profile = A::baseUrl()->get() . '/profile/' . $a->user['nickname'];
+	$logged_user_profile = AppR::baseUrl()->get() . '/profile/' . $a->user['nickname'];
 	if ($logged_user_profile == $hook_data['item']['author-link']) {
 		return;
 	}

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 
 /* Define the hooks we want to use
  * that is, we have settings, we need to save the settings and we want
@@ -123,7 +123,7 @@ function langfilter_prepare_body_content_filter(App $a, &$hook_data)
 
 	// Never filter own messages
 	// TODO: find a better way to extract this
-	$logged_user_profile = DI::baseUrl()->get() . '/profile/' . $a->user['nickname'];
+	$logged_user_profile = A::baseUrl()->get() . '/profile/' . $a->user['nickname'];
 	if ($logged_user_profile == $hook_data['item']['author-link']) {
 		return;
 	}

--- a/libertree/libertree.php
+++ b/libertree/libertree.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Network;
 
 function libertree_install()
@@ -62,7 +62,7 @@ function libertree_settings(&$a,&$s) {
 
     /* Add our stylesheet to the page so we can make our settings look nice */
 
-    A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/libertree/libertree.css' . '" media="all" />' . "\r\n";
+    AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/libertree/libertree.css' . '" media="all" />' . "\r\n";
 
     /* Get the current state of our config variables */
 
@@ -207,7 +207,7 @@ function libertree_send(&$a,&$b) {
 	$ltree_api_token = PConfig::get($b['uid'],'libertree','libertree_api_token');
 	$ltree_url = PConfig::get($b['uid'],'libertree','libertree_url');
 	$ltree_blog = "$ltree_url/api/v1/posts/create/?token=$ltree_api_token";
-	$ltree_source = A::baseUrl()->getHostname();
+	$ltree_source = AppR::baseUrl()->getHostname();
 
 	if ($b['app'] != "")
 		$ltree_source .= " (".$b['app'].")";

--- a/libertree/libertree.php
+++ b/libertree/libertree.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Network;
 
 function libertree_install()
@@ -62,7 +62,7 @@ function libertree_settings(&$a,&$s) {
 
     /* Add our stylesheet to the page so we can make our settings look nice */
 
-    DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/libertree/libertree.css' . '" media="all" />' . "\r\n";
+    A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/libertree/libertree.css' . '" media="all" />' . "\r\n";
 
     /* Get the current state of our config variables */
 
@@ -207,7 +207,7 @@ function libertree_send(&$a,&$b) {
 	$ltree_api_token = PConfig::get($b['uid'],'libertree','libertree_api_token');
 	$ltree_url = PConfig::get($b['uid'],'libertree','libertree_url');
 	$ltree_blog = "$ltree_url/api/v1/posts/create/?token=$ltree_api_token";
-	$ltree_source = DI::baseUrl()->getHostname();
+	$ltree_source = A::baseUrl()->getHostname();
 
 	if ($b['app'] != "")
 		$ltree_source .= " (".$b['app'].")";

--- a/ljpost/ljpost.php
+++ b/ljpost/ljpost.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\XML;
@@ -62,7 +62,7 @@ function ljpost_settings(&$a,&$s) {
 
     /* Add our stylesheet to the page so we can make our settings look nice */
 
-    DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/ljpost/ljpost.css' . '" media="all" />' . "\r\n";
+    App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/ljpost/ljpost.css' . '" media="all" />' . "\r\n";
 
     /* Get the current state of our config variables */
 

--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -14,8 +14,8 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Protocol\Activity;
+use Friendica\Registry\App;
 use Friendica\Util\Network;
 use Friendica\Model\Item;
 
@@ -95,7 +95,7 @@ function mailstream_addon_admin_post ($a) {
 
 function mailstream_generate_id($a, $uri) {
 	// http://www.jwz.org/doc/mid.html
-	$host = DI::baseUrl()->getHostname();
+	$host = App::baseUrl()->getHostname();
 	$resource = hash('md5', $uri);
 	$message_id = "<" . $resource . "@" . $host . ">";
 	Logger::debug('mailstream: Generated message ID ' . $message_id . ' for URI ' . $uri);
@@ -307,7 +307,7 @@ function mailstream_send(\Friendica\App $a, $message_id, $item, $user) {
 		$template = Renderer::getMarkupTemplate('mail.tpl', 'addon/mailstream/');
 		$mail->AltBody = BBCode::toPlaintext($item['body']);
 		$item['body'] = BBCode::convert($item['body']);
-		$item['url'] = DI::baseUrl()->get() . '/display/' . $item['guid'];
+		$item['url'] = App::baseUrl()->get() . '/display/' . $item['guid'];
 		$mail->Body = Renderer::replaceMacros($template, [
 						 '$upstream' => L10n::t('Upstream'),
 						 '$local' => L10n::t('Local'),

--- a/mastodoncustomemojis/mastodoncustomemojis.php
+++ b/mastodoncustomemojis/mastodoncustomemojis.php
@@ -11,11 +11,12 @@
 
 use Friendica\App;
 use Friendica\Content\Smilies;
-use Friendica\Core\Cache;
+use Friendica\Core\Cache\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\Protocol;
 use Friendica\Registry\App as A;
+use Friendica\Registry\Core;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy as ProxyUtils;
 
@@ -74,12 +75,12 @@ function mastodoncustomemojis_get_custom_emojis_for_author($author_link)
 
 	$cache_key = 'mastodoncustomemojis:' . $api_base_url;
 
-	$return = Cache::get($cache_key);
+	$return = Core::cache()->get($cache_key);
 
 	if (empty($return) || Config::get('system', 'ignore_cache')) {
 		$return = mastodoncustomemojis_fetch_custom_emojis_for_url($api_base_url);
 
-		Cache::set($cache_key, $return, empty($return['texts']) ? Cache::QUARTER_HOUR : Cache::HOUR);
+		Core::cache()->set($cache_key, $return, empty($return['texts']) ? Cache::QUARTER_HOUR : Cache::HOUR);
 	}
 
 	return $return;

--- a/mastodoncustomemojis/mastodoncustomemojis.php
+++ b/mastodoncustomemojis/mastodoncustomemojis.php
@@ -15,7 +15,7 @@ use Friendica\Core\Cache\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\Protocol;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Registry\Core;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy as ProxyUtils;
@@ -42,7 +42,7 @@ function mastodoncustomemojis_uninstall()
 
 function mastodoncustomemojis_css_hook(App $a)
 {
-	A::page()['htmlhead'] .= <<<HTML
+	AppR::page()['htmlhead'] .= <<<HTML
 <!-- Style added by mastodoncustomemojis -->
 <style type="text/css">
 	.emoji.mastodon {

--- a/mastodoncustomemojis/mastodoncustomemojis.php
+++ b/mastodoncustomemojis/mastodoncustomemojis.php
@@ -15,7 +15,7 @@ use Friendica\Core\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\Protocol;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Network;
 use Friendica\Util\Proxy as ProxyUtils;
 
@@ -41,7 +41,7 @@ function mastodoncustomemojis_uninstall()
 
 function mastodoncustomemojis_css_hook(App $a)
 {
-	DI::page()['htmlhead'] .= <<<HTML
+	A::page()['htmlhead'] .= <<<HTML
 <!-- Style added by mastodoncustomemojis -->
 <style type="text/css">
 	.emoji.mastodon {

--- a/mathjax/mathjax.php
+++ b/mathjax/mathjax.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 function mathjax_install()
 {
@@ -65,7 +65,7 @@ function mathjax_footer(App $a, &$b)
 	//  if the visitor of the page is not a local_user, use MathJax
 	//  otherwise check the users settings.
 	if (!local_user() || PConfig::get(local_user(), 'mathjax', 'use', false)) {
-		A::page()->registerFooterScript(__DIR__ . '/asset/MathJax.js?config=TeX-MML-AM_CHTML');
-		A::page()->registerFooterScript(__DIR__ . '/mathjax.js');
+		AppR::page()->registerFooterScript(__DIR__ . '/asset/MathJax.js?config=TeX-MML-AM_CHTML');
+		AppR::page()->registerFooterScript(__DIR__ . '/mathjax.js');
 	}
 }

--- a/mathjax/mathjax.php
+++ b/mathjax/mathjax.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 
 function mathjax_install()
 {
@@ -65,7 +65,7 @@ function mathjax_footer(App $a, &$b)
 	//  if the visitor of the page is not a local_user, use MathJax
 	//  otherwise check the users settings.
 	if (!local_user() || PConfig::get(local_user(), 'mathjax', 'use', false)) {
-		DI::page()->registerFooterScript(__DIR__ . '/asset/MathJax.js?config=TeX-MML-AM_CHTML');
-		DI::page()->registerFooterScript(__DIR__ . '/mathjax.js');
+		A::page()->registerFooterScript(__DIR__ . '/asset/MathJax.js?config=TeX-MML-AM_CHTML');
+		A::page()->registerFooterScript(__DIR__ . '/mathjax.js');
 	}
 }

--- a/namethingy/namethingy.php
+++ b/namethingy/namethingy.php
@@ -8,7 +8,7 @@
  * Status: Unsupported
  */
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function namethingy_install() {
     Hook::register('app_menu', 'addon/namethingy/namethingy.php', 'namethingy_app_menu');
@@ -28,7 +28,7 @@ function namethingy_module() {}
 
 function namethingy_content(&$a) {
 
-$baseurl = DI::baseUrl()->get() . '/addon/namethingy';
+$baseurl = App::baseUrl()->get() . '/addon/namethingy';
 
 $o .= <<< EOT
 <iframe src="http://namethingy.com" width="900" height="700" />

--- a/newmemberwidget/newmemberwidget.php
+++ b/newmemberwidget/newmemberwidget.php
@@ -12,7 +12,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\Strings;
 
 function newmemberwidget_install()
@@ -41,7 +41,7 @@ function newmemberwidget_network_mod_init ($a, $b)
 	}
 
 	if (Config::get('newmemberwidget','linklocalsupport', false)) {
-		$t .= '<a href="'.DI::baseUrl()->get().'/profile/'.Config::get('newmemberwidget','localsupport').'" target="_new">'.L10n::t('Local Support Forum').'</a><br />'.EOL;
+		$t .= '<a href="' . App::baseUrl()->get() . '/profile/' . Config::get('newmemberwidget','localsupport') . '" target="_new">' . L10n::t('Local Support Forum') . '</a><br />' . EOL;
 	}
 
 	$ft = Config::get('newmemberwidget','freetext', '');
@@ -49,8 +49,8 @@ function newmemberwidget_network_mod_init ($a, $b)
 		$t .= '<p>'.BBCode::convert(trim($ft)).'</p>';
 	}
 
-	$t .= '</div><div class="clear"></div>';
-	DI::page()['aside'] = $t . DI::page()['aside'];
+	$t                   .= '</div><div class="clear"></div>';
+	App::page()['aside'] = $t . App::page()['aside'];
 }
 
 function newmemberwidget_addon_admin_post(&$a)

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -14,7 +14,7 @@ use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Emailer;
 
 function notifyall_install()
@@ -31,7 +31,7 @@ function notifyall_module() {}
 
 function notifyall_addon_admin(App $a, &$o)
 {
-	$o = '<div></div>&nbsp;&nbsp;&nbsp;&nbsp;<a href="' . A::baseUrl()->get() . '/notifyall">' . L10n::t('Send email to all members') . '</a></br/>';
+	$o = '<div></div>&nbsp;&nbsp;&nbsp;&nbsp;<a href="' . AppR::baseUrl()->get() . '/notifyall">' . L10n::t('Send email to all members') . '</a></br/>';
 }
 
 
@@ -56,7 +56,7 @@ function notifyall_post(App $a)
 	}
 
 	if (!Config::get('config', 'sender_email')) {
-		$sender_email = 'noreply@' . A::baseUrl()->getHostname();
+		$sender_email = 'noreply@' . AppR::baseUrl()->getHostname();
 	} else {
 		$sender_email = Config::get('config', 'sender_email');
 	}
@@ -96,7 +96,7 @@ function notifyall_post(App $a)
 	}
 
 	notice(L10n::t('Emails sent'));
-	A::baseUrl()->redirect('admin');
+	AppR::baseUrl()->redirect('admin');
 }
 
 function notifyall_content(&$a)

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -14,8 +14,7 @@ use Friendica\Core\Config;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
-use Friendica\Core\System;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Emailer;
 
 function notifyall_install()
@@ -32,7 +31,7 @@ function notifyall_module() {}
 
 function notifyall_addon_admin(App $a, &$o)
 {
-	$o = '<div></div>&nbsp;&nbsp;&nbsp;&nbsp;<a href="' . DI::baseUrl()->get() . '/notifyall">' . L10n::t('Send email to all members') . '</a></br/>';
+	$o = '<div></div>&nbsp;&nbsp;&nbsp;&nbsp;<a href="' . A::baseUrl()->get() . '/notifyall">' . L10n::t('Send email to all members') . '</a></br/>';
 }
 
 
@@ -57,7 +56,7 @@ function notifyall_post(App $a)
 	}
 
 	if (!Config::get('config', 'sender_email')) {
-		$sender_email = 'noreply@' . DI::baseUrl()->getHostname();
+		$sender_email = 'noreply@' . A::baseUrl()->getHostname();
 	} else {
 		$sender_email = Config::get('config', 'sender_email');
 	}
@@ -97,7 +96,7 @@ function notifyall_post(App $a)
 	}
 
 	notice(L10n::t('Emails sent'));
-	DI::baseUrl()->redirect('admin');
+	A::baseUrl()->redirect('admin');
 }
 
 function notifyall_content(&$a)

--- a/notimeline/notimeline.php
+++ b/notimeline/notimeline.php
@@ -10,7 +10,7 @@
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function notimeline_install()
 {
@@ -42,7 +42,7 @@ function notimeline_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/notimeline/notimeline.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/notimeline/notimeline.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/nsfw/nsfw.php
+++ b/nsfw/nsfw.php
@@ -10,7 +10,7 @@
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function nsfw_install()
 {
@@ -66,7 +66,7 @@ function nsfw_addon_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/nsfw/nsfw.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/nsfw/nsfw.css' . '" media="all" />' . "\r\n";
 
 	$enable_checked = (intval(PConfig::get(local_user(), 'nsfw', 'disable')) ? '' : ' checked="checked" ');
 	$words = PConfig::get(local_user(), 'nsfw', 'words');

--- a/numfriends/numfriends.php
+++ b/numfriends/numfriends.php
@@ -9,7 +9,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function numfriends_install() {
 
@@ -60,7 +60,7 @@ function numfriends_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/numfriends/numfriends.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/numfriends/numfriends.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/openstreetmap/openstreetmap.php
+++ b/openstreetmap/openstreetmap.php
@@ -9,13 +9,14 @@
  *
  */
 
-use Friendica\Core\Cache;
+use Friendica\Core\Cache\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\Registry\App;
+use Friendica\Registry\Core;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
@@ -131,13 +132,13 @@ function openstreetmap_get_coordinates($a, &$b)
 	$args = '?q=' . urlencode($b['location']) . '&format=json';
 
 	$cachekey = "openstreetmap:" . $b['location'];
-	$j = Cache::get($cachekey);
+	$j = Core::cache()->get($cachekey);
 
 	if (is_null($j)) {
 		$curlResult = Network::curl($nomserver . $args);
 		if ($curlResult->isSuccess()) {
 			$j = json_decode($curlResult->getBody(), true);
-			Cache::set($cachekey, $j, Cache::MONTH);
+			Core::cache()->set($cachekey, $j, Cache::MONTH);
 		}
 	}
 

--- a/openstreetmap/openstreetmap.php
+++ b/openstreetmap/openstreetmap.php
@@ -9,13 +9,13 @@
  *
  */
 
-use Friendica\DI;
 use Friendica\Core\Cache;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
+use Friendica\Registry\App;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
@@ -56,8 +56,8 @@ function openstreetmap_load_config(\Friendica\App $a, ConfigFileLoader $loader)
 
 function openstreetmap_alterheader($a, &$navHtml)
 {
-	$addScriptTag = '<script type="text/javascript" src="' . DI::baseUrl()->get() . '/addon/openstreetmap/openstreetmap.js"></script>' . "\r\n";
-	DI::page()['htmlhead'] .= $addScriptTag;
+	$addScriptTag           = '<script type="text/javascript" src="' . App::baseUrl()->get() . '/addon/openstreetmap/openstreetmap.js"></script>' . "\r\n";
+	App::page()['htmlhead'] .= $addScriptTag;
 }
 
 /**
@@ -160,7 +160,7 @@ function openstreetmap_generate_map(&$a, &$b)
 {
 	$tmsserver = Config::get('openstreetmap', 'tmsserver', OSM_TMS);
 
-	if (strpos(DI::baseUrl()->get(true), 'https:') !== false) {
+	if (strpos(App::baseUrl()->get(true), 'https:') !== false) {
 		$tmsserver = str_replace('http:','https:',$tmsserver);
 	}
 

--- a/pageheader/pageheader.php
+++ b/pageheader/pageheader.php
@@ -13,7 +13,7 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 
 function pageheader_install() {
     Hook::register('page_content_top', __FILE__, 'pageheader_fetch');
@@ -27,7 +27,7 @@ function pageheader_addon_admin(App &$a, &$s)
 
     /* Add our stylesheet to the page so we can make our settings look nice */
 	$stylesheetPath = __DIR__ . '/pageheader.css';
-	A::page()->registerStylesheet($stylesheetPath);
+	AppR::page()->registerStylesheet($stylesheetPath);
 
 	$words = Config::get('pageheader','text');
 	if(! $words)
@@ -66,7 +66,7 @@ function pageheader_fetch(App $a, &$b)
 	}
 
 	$stylesheetPath = __DIR__ .'/pageheader.css';
-	A::page()->registerStylesheet($stylesheetPath);
+	AppR::page()->registerStylesheet($stylesheetPath);
     
     if ($s) {
         $b .= '<div class="pageheader">' . $s . '</div>';

--- a/pageheader/pageheader.php
+++ b/pageheader/pageheader.php
@@ -13,7 +13,7 @@ use Friendica\Core\Config;
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 
 function pageheader_install() {
     Hook::register('page_content_top', __FILE__, 'pageheader_fetch');
@@ -27,7 +27,7 @@ function pageheader_addon_admin(App &$a, &$s)
 
     /* Add our stylesheet to the page so we can make our settings look nice */
 	$stylesheetPath = __DIR__ . '/pageheader.css';
-	DI::page()->registerStylesheet($stylesheetPath);
+	A::page()->registerStylesheet($stylesheetPath);
 
 	$words = Config::get('pageheader','text');
 	if(! $words)
@@ -66,7 +66,7 @@ function pageheader_fetch(App $a, &$b)
 	}
 
 	$stylesheetPath = __DIR__ .'/pageheader.css';
-	DI::page()->registerStylesheet($stylesheetPath);
+	A::page()->registerStylesheet($stylesheetPath);
     
     if ($s) {
         $b .= '<div class="pageheader">' . $s . '</div>';

--- a/phpmailer/phpmailer.php
+++ b/phpmailer/phpmailer.php
@@ -10,7 +10,7 @@
 use Friendica\App;
 use Friendica\Core\Config;
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\Core;
 use Friendica\Util\ConfigFileLoader;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
@@ -100,6 +100,6 @@ function phpmailer_emailer_send_prepare(App $a, array &$b)
 
 		$b['sent'] = $mail->send();
 	} catch (Exception $e) {
-		DI::logger()->error('PHPMailer error', ['ErrorInfo' => $mail->ErrorInfo, 'code' => $e->getCode(), 'message' => $e->getMessage()]);
+		Core::logger()->error('PHPMailer error', ['ErrorInfo' => $mail->ErrorInfo, 'code' => $e->getCode(), 'message' => $e->getMessage()]);
 	}
 }

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -36,7 +36,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\Strings;
 
@@ -66,7 +66,7 @@ function piwik_analytics($a,&$b) {
 	 *   associated CSS file. We just have to tell Friendica to get it
 	 *   into the page header.
 	 */
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/piwik/piwik.css' . '" media="all" />';
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/piwik/piwik.css' . '" media="all" />';
 
 	/*
 	 *   Get the configuration variables from the config/addon.config.php file.

--- a/planets/planets.php
+++ b/planets/planets.php
@@ -10,7 +10,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function planets_install() {
 
@@ -140,7 +140,7 @@ function planets_settings(&$a,&$s) {
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/planets/planets.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/planets/planets.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/public_server/public_server.php
+++ b/public_server/public_server.php
@@ -14,7 +14,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
@@ -75,8 +75,8 @@ function public_server_cron($a, $b)
 				'to_name'      => $rr['username'],
 				'to_email'     => $rr['email'],
 				'source_name'  => L10n::t('Administrator'),
-				'source_link'  => A::baseUrl()->get(),
-				'source_photo' => A::baseUrl()->get() . '/images/person-80.jpg',
+				'source_link'  => AppR::baseUrl()->get(),
+				'source_photo' => AppR::baseUrl()->get() . '/images/person-80.jpg',
 			]);
 
 			$fields = ['expire_notification_sent' => DateTimeFormat::utcNow()];
@@ -127,7 +127,7 @@ function public_server_enotify(&$a, &$b)
 {
 	if (!empty($b['params']) && $b['params']['type'] == NOTIFY_SYSTEM
 		&& !empty($b['params']['system_type']) && $b['params']['system_type'] === 'public_server_expire') {
-		$b['itemlink'] = A::baseUrl()->get();
+		$b['itemlink'] = AppR::baseUrl()->get();
 		$b['epreamble'] = $b['preamble'] = L10n::t('Your account on %s will expire in a few days.', Config::get('system', 'sitename'));
 		$b['subject'] = L10n::t('Your Friendica account is about to expire.');
 		$b['body'] = L10n::t("Hi %1\$s,\n\nYour account on %2\$s will expire in less than five days. You may keep your account by logging in at least once every 30 days", $b['params']['to_name'], "[url=" . Config::get('system', 'url') . "]" . Config::get('config', 'sitename') . "[/url]");

--- a/public_server/public_server.php
+++ b/public_server/public_server.php
@@ -14,7 +14,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Strings;
@@ -75,8 +75,8 @@ function public_server_cron($a, $b)
 				'to_name'      => $rr['username'],
 				'to_email'     => $rr['email'],
 				'source_name'  => L10n::t('Administrator'),
-				'source_link'  => DI::baseUrl()->get(),
-				'source_photo' => DI::baseUrl()->get() . '/images/person-80.jpg',
+				'source_link'  => A::baseUrl()->get(),
+				'source_photo' => A::baseUrl()->get() . '/images/person-80.jpg',
 			]);
 
 			$fields = ['expire_notification_sent' => DateTimeFormat::utcNow()];
@@ -127,7 +127,7 @@ function public_server_enotify(&$a, &$b)
 {
 	if (!empty($b['params']) && $b['params']['type'] == NOTIFY_SYSTEM
 		&& !empty($b['params']['system_type']) && $b['params']['system_type'] === 'public_server_expire') {
-		$b['itemlink'] = DI::baseUrl()->get();
+		$b['itemlink'] = A::baseUrl()->get();
 		$b['epreamble'] = $b['preamble'] = L10n::t('Your account on %s will expire in a few days.', Config::get('system', 'sitename'));
 		$b['subject'] = L10n::t('Your Friendica account is about to expire.');
 		$b['body'] = L10n::t("Hi %1\$s,\n\nYour account on %2\$s will expire in less than five days. You may keep your account by logging in at least once every 30 days", $b['params']['to_name'], "[url=" . Config::get('system', 'url') . "]" . Config::get('config', 'sitename') . "[/url]");

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -17,13 +17,13 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityNamespace;
+use Friendica\Registry\App as A;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
@@ -106,7 +106,7 @@ function pumpio_registerclient(App $a, $host)
 	$application_name  = Config::get('pumpio', 'application_name');
 
 	if ($application_name == "") {
-		$application_name = DI::baseUrl()->getHostname();
+		$application_name = A::baseUrl()->getHostname();
 	}
 
 	$adminlist = explode(",", str_replace(" ", "", Config::get('config', 'admin_email')));
@@ -115,8 +115,8 @@ function pumpio_registerclient(App $a, $host)
 	$params["contacts"] = $adminlist[0];
 	$params["application_type"] = "native";
 	$params["application_name"] = $application_name;
-	$params["logo_url"] = DI::baseUrl()->get()."/images/friendica-256.png";
-	$params["redirect_uris"] = DI::baseUrl()->get()."/pumpio/connect";
+	$params["logo_url"] = A::baseUrl()->get() . "/images/friendica-256.png";
+	$params["redirect_uris"] = A::baseUrl()->get() . "/pumpio/connect";
 
 	Logger::log("pumpio_registerclient: ".$url." parameters ".print_r($params, true), Logger::DEBUG);
 
@@ -167,7 +167,7 @@ function pumpio_connect(App $a)
 	}
 
 	// The callback URL is the script that gets called after the user authenticates with pumpio
-	$callback_url = DI::baseUrl()->get()."/pumpio/connect";
+	$callback_url = A::baseUrl()->get() . "/pumpio/connect";
 
 	// Let's begin.  First we need a Request Token.  The request token is required to send the user
 	// to pumpio's login page.
@@ -204,7 +204,7 @@ function pumpio_connect(App $a)
 	if ($success) {
 		Logger::log("pumpio_connect: authenticated");
 		$o = L10n::t("You are now authenticated to pumpio.");
-		$o .= '<br /><a href="'.DI::baseUrl()->get().'/settings/connectors">'.L10n::t("return to the connector page").'</a>';
+		$o .= '<br /><a href="' . A::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
 	} else {
 		Logger::log("pumpio_connect: could not connect");
 		$o = 'Could not connect to pumpio. Refresh the page or try again later.';
@@ -239,7 +239,7 @@ function pumpio_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/pumpio/pumpio.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/pumpio/pumpio.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -289,7 +289,7 @@ function pumpio_settings(App $a, &$s)
 		$s .= '<div id="pumpio-password-wrapper">';
 		if (($oauth_token == "") || ($oauth_token_secret == "")) {
 			$s .= '<div id="pumpio-authenticate-wrapper">';
-			$s .= '<a href="'.DI::baseUrl()->get().'/pumpio/connect">'.L10n::t("Authenticate your pump.io connection").'</a>';
+			$s .= '<a href="' . A::baseUrl()->get() . '/pumpio/connect">' . L10n::t("Authenticate your pump.io connection") . '</a>';
 			$s .= '</div><div class="clear"></div>';
 		} else {
 			$s .= '<div id="pumpio-import-wrapper">';
@@ -773,7 +773,7 @@ function pumpio_fetchtimeline(App $a, $uid)
 		$application_name  = Config::get('pumpio', 'application_name');
 	}
 	if ($application_name == "") {
-		$application_name = DI::baseUrl()->getHostname();
+		$application_name = A::baseUrl()->getHostname();
 	}
 
 	$first_time = ($lastdate == "");

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -23,7 +23,7 @@ use Friendica\Model\Item;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
 use Friendica\Protocol\ActivityNamespace;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
@@ -106,7 +106,7 @@ function pumpio_registerclient(App $a, $host)
 	$application_name  = Config::get('pumpio', 'application_name');
 
 	if ($application_name == "") {
-		$application_name = A::baseUrl()->getHostname();
+		$application_name = AppR::baseUrl()->getHostname();
 	}
 
 	$adminlist = explode(",", str_replace(" ", "", Config::get('config', 'admin_email')));
@@ -115,8 +115,8 @@ function pumpio_registerclient(App $a, $host)
 	$params["contacts"] = $adminlist[0];
 	$params["application_type"] = "native";
 	$params["application_name"] = $application_name;
-	$params["logo_url"] = A::baseUrl()->get() . "/images/friendica-256.png";
-	$params["redirect_uris"] = A::baseUrl()->get() . "/pumpio/connect";
+	$params["logo_url"] = AppR::baseUrl()->get() . "/images/friendica-256.png";
+	$params["redirect_uris"] = AppR::baseUrl()->get() . "/pumpio/connect";
 
 	Logger::log("pumpio_registerclient: ".$url." parameters ".print_r($params, true), Logger::DEBUG);
 
@@ -167,7 +167,7 @@ function pumpio_connect(App $a)
 	}
 
 	// The callback URL is the script that gets called after the user authenticates with pumpio
-	$callback_url = A::baseUrl()->get() . "/pumpio/connect";
+	$callback_url = AppR::baseUrl()->get() . "/pumpio/connect";
 
 	// Let's begin.  First we need a Request Token.  The request token is required to send the user
 	// to pumpio's login page.
@@ -204,7 +204,7 @@ function pumpio_connect(App $a)
 	if ($success) {
 		Logger::log("pumpio_connect: authenticated");
 		$o = L10n::t("You are now authenticated to pumpio.");
-		$o .= '<br /><a href="' . A::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
+		$o .= '<br /><a href="' . AppR::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
 	} else {
 		Logger::log("pumpio_connect: could not connect");
 		$o = 'Could not connect to pumpio. Refresh the page or try again later.';
@@ -239,7 +239,7 @@ function pumpio_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/pumpio/pumpio.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/pumpio/pumpio.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -289,7 +289,7 @@ function pumpio_settings(App $a, &$s)
 		$s .= '<div id="pumpio-password-wrapper">';
 		if (($oauth_token == "") || ($oauth_token_secret == "")) {
 			$s .= '<div id="pumpio-authenticate-wrapper">';
-			$s .= '<a href="' . A::baseUrl()->get() . '/pumpio/connect">' . L10n::t("Authenticate your pump.io connection") . '</a>';
+			$s .= '<a href="' . AppR::baseUrl()->get() . '/pumpio/connect">' . L10n::t("Authenticate your pump.io connection") . '</a>';
 			$s .= '</div><div class="clear"></div>';
 		} else {
 			$s .= '<div id="pumpio-import-wrapper">';
@@ -773,7 +773,7 @@ function pumpio_fetchtimeline(App $a, $uid)
 		$application_name  = Config::get('pumpio', 'application_name');
 	}
 	if ($application_name == "") {
-		$application_name = A::baseUrl()->getHostname();
+		$application_name = AppR::baseUrl()->getHostname();
 	}
 
 	$first_time = ($lastdate == "");

--- a/pumpio/pumpio_sync.php
+++ b/pumpio/pumpio_sync.php
@@ -1,9 +1,10 @@
 <?php
 use Friendica\Core\Config;
 use Friendica\Core\Logger;
+use Friendica\Registry\DI;
 
 function pumpio_sync_run(&$argv, &$argc) {
-	$a = Friendica\DI::app();
+	$a = DI::app();
 
 	require_once("addon/pumpio/pumpio.php");
 

--- a/qcomment/qcomment.php
+++ b/qcomment/qcomment.php
@@ -20,7 +20,7 @@
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\XML;
 
 function qcomment_install() {
@@ -43,7 +43,7 @@ function qcomment_addon_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/qcomment/qcomment.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/qcomment/qcomment.css' . '" media="all" />' . "\r\n";
 
 	$words = PConfig::get(local_user(), 'qcomment', 'words', L10n::t(':-)') . "\n" . L10n::t(':-(') . "\n" .  L10n::t('lol'));
 

--- a/randplace/randplace.php
+++ b/randplace/randplace.php
@@ -22,7 +22,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function randplace_install() {
 
@@ -159,7 +159,7 @@ function randplace_settings(&$a,&$s) {
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/randplace/randplace.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/randplace/randplace.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/remote_permissions/remote_permissions.php
+++ b/remote_permissions/remote_permissions.php
@@ -13,7 +13,8 @@ use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Registry\App;
+use Friendica\Registry\Util;
 use Friendica\Util\Strings;
 
 function remote_permissions_install() {
@@ -39,7 +40,7 @@ function remote_permissions_settings(&$a,&$o) {
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/remote_permissions/settings.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/remote_permissions/settings.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 
@@ -81,7 +82,7 @@ function remote_permissions_content($a, $item_copy) {
 			return;
 
 		// Find out if the contact lives here
-		$baseurl = DI::baseUrl()->get();
+		$baseurl = App::baseUrl()->get();
 		$baseurl = substr($baseurl, strpos($baseurl, '://') + 3);
 		if(strpos($r[0]['url'], $baseurl) === false)
 			return;
@@ -124,7 +125,7 @@ function remote_permissions_content($a, $item_copy) {
 
 			$item = $r[0];
 
-			$aclFormatter = DI::aclFormatter();
+			$aclFormatter = Util::aclFormatter();
 
 			$allowed_users = $aclFormatter->expand($item['allow_cid']);
 			$allowed_groups = $aclFormatter->expand($item['allow_gid']);

--- a/rendertime/rendertime.php
+++ b/rendertime/rendertime.php
@@ -9,7 +9,8 @@
 
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
-use Friendica\DI;
+use Friendica\Registry\App;
+use Friendica\Registry\Util;
 
 function rendertime_install() {
 	Hook::register('page_end', 'addon/rendertime/rendertime.php', 'rendertime_page_end');
@@ -31,14 +32,14 @@ function rendertime_init_1(&$a) {
 function rendertime_page_end(Friendica\App $a, &$o)
 {
 
-	$profiler = DI::profiler();
+	$profiler = Util::profiler();
 
 	$duration = microtime(true) - $profiler->get('start');
 
 	$ignored_modules = ["fbrowser"];
-	$ignored = in_array(DI::module()->getName(), $ignored_modules);
+	$ignored = in_array(App::module()->getName(), $ignored_modules);
 
-	if (is_site_admin() && (($_GET['mode'] ?? '') != 'minimal') && !DI::mode()->isMobile() && !DI::mode()->isMobile() && !$ignored) {
+	if (is_site_admin() && (($_GET['mode'] ?? '') != 'minimal') && !App::mode()->isMobile() && !App::mode()->isMobile() && !$ignored) {
 
 		$o = $o . '<div class="renderinfo">' . L10n::t("Database: %s/%s, Network: %s, Rendering: %s, Session: %s, I/O: %s, Other: %s, Total: %s",
 				round($profiler->get('database') - $profiler->get('database_write'), 3),

--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Emailer;
 
 require_once __DIR__ . '/vendor/autoload.php';
@@ -93,7 +93,7 @@ function securemail_settings_post(App &$a, array &$b)
 		if ($_POST['securemail-submit'] == L10n::t('Save and send test')) {
 			$sitename = Config::get('config', 'sitename');
 
-			$hostname = A::baseUrl()->getHostname();
+			$hostname = AppR::baseUrl()->getHostname();
 			if (strpos($hostname, ':')) {
 				$hostname = substr($hostname, 0, strpos($hostname, ':'));
 			}

--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Emailer;
 
 require_once __DIR__ . '/vendor/autoload.php';
@@ -93,7 +93,7 @@ function securemail_settings_post(App &$a, array &$b)
 		if ($_POST['securemail-submit'] == L10n::t('Save and send test')) {
 			$sitename = Config::get('config', 'sitename');
 
-			$hostname = DI::baseUrl()->getHostname();
+			$hostname = A::baseUrl()->getHostname();
 			if (strpos($hostname, ':')) {
 				$hostname = substr($hostname, 0, strpos($hostname, ':'));
 			}

--- a/showmore/showmore.php
+++ b/showmore/showmore.php
@@ -10,7 +10,7 @@
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\Strings;
 
 function showmore_install()
@@ -35,7 +35,7 @@ function showmore_addon_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="'.DI::baseUrl()->get().'/addon/showmore/showmore.css'.'" media="all"/>'."\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="' . App::baseUrl()->get() . '/addon/showmore/showmore.css' . '" media="all"/>' . "\r\n";
 
 	$enable_checked = (intval(PConfig::get(local_user(), 'showmore', 'disable')) ? '' : ' checked="checked"');
 	$chars = PConfig::get(local_user(), 'showmore', 'chars', 1100);

--- a/smiley_pack/lang/smiley_pack_es/smiley_pack_es.php
+++ b/smiley_pack/lang/smiley_pack_es/smiley_pack_es.php
@@ -7,7 +7,7 @@
  * All smileys from sites offering them as Public Domain
  */
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function smiley_pack_es_install() {
 	Hook::register('smilie', 'addon/smiley_pack_es/smiley_pack_es.php', 'smiley_pack_smilies_es');
@@ -31,459 +31,459 @@ function smiley_pack_smilies_es(&$a,&$b) {
 #Animal smileys.
 
 	$b['texts'][] = ':conejitoflores';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunnyflowers.gif' . '" alt="' . ':conejitoflores' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunnyflowers.gif' . '" alt="' . ':conejitoflores' . '" />';
 
 	$b['texts'][] = ':pollito';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':pollito' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':pollito' . '" />';
 
 	$b['texts'][] = ':abeja';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bee.gif' . '" alt="' . ':abeja' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bee.gif' . '" alt="' . ':abeja' . '" />';
 
 	$b['texts'][] = ':mariquita';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/ladybird.gif' . '" alt="' . ':mariquita' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/ladybird.gif' . '" alt="' . ':mariquita' . '" />';
 
 	$b['texts'][] = ':araña';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bigspider.gif' . '" alt="' . ':araña' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bigspider.gif' . '" alt="' . ':araña' . '" />';
 
 	$b['texts'][] = ':gato';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cat.gif' . '" alt="' . ':gato' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cat.gif' . '" alt="' . ':gato' . '" />';
 
 	$b['texts'][] = ':conejito';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunny.gif' . '" alt="' . ':conejito' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunny.gif' . '" alt="' . ':conejito' . '" />';
 
 	$b['texts'][] = ':vaca';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cow.gif' . '" alt="' . ':vaca' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cow.gif' . '" alt="' . ':vaca' . '" />';
     
 	$b['texts'][] = ':cangrejo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/crab.gif' . '" alt="' . ':cangrejo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/crab.gif' . '" alt="' . ':cangrejo' . '" />';
 
 	$b['texts'][] = ':delfín';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dolphin.gif' . '" alt="' . ':delfín' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dolphin.gif' . '" alt="' . ':delfín' . '" />';
 
 	$b['texts'][] = ':libélula';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dragonfly.gif' . '" alt="' . ':libélula' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dragonfly.gif' . '" alt="' . ':libélula' . '" />';
 
 	$b['texts'][] = ':rana';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/frog.gif' . '" alt="' . ':rana' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/frog.gif' . '" alt="' . ':rana' . '" />';
 
 	$b['texts'][] = ':hamster';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/hamster.gif' . '" alt="' . ':hamster' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/hamster.gif' . '" alt="' . ':hamster' . '" />';
 
 	$b['texts'][] = ':mono';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/monkey.gif' . '" alt="' . ':mono' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/monkey.gif' . '" alt="' . ':mono' . '" />';
 
 	$b['texts'][] = ':caballo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/horse.gif' . '" alt="' . ':caballo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/horse.gif' . '" alt="' . ':caballo' . '" />';
   
 	$b['texts'][] = ':loro';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/parrot.gif' . '" alt="' . ':loro' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/parrot.gif' . '" alt="' . ':loro' . '" />';
 
 	$b['texts'][] = ':tux';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/tux.gif' . '" alt="' . ':tux' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/tux.gif' . '" alt="' . ':tux' . '" />';
 
 	$b['texts'][] = ':caracol';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/snail.gif' . '" alt="' . ':caracol' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/snail.gif' . '" alt="' . ':caracol' . '" />';
 
 	$b['texts'][] = ':oveja';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/sheep.gif' . '" alt="' . ':oveja' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/sheep.gif' . '" alt="' . ':oveja' . '" />';
 
 	$b['texts'][] = ':perro';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dog.gif' . '" alt="' . ':perro' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dog.gif' . '" alt="' . ':perro' . '" />';
 
 	$b['texts'][] = ':elefante';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/elephant.gif' . '" alt="' . ':elefante' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/elephant.gif' . '" alt="' . ':elefante' . '" />';
 
 	$b['texts'][] = ':pez';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/fish.gif' . '" alt="' . ':pez' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/fish.gif' . '" alt="' . ':pez' . '" />';
 
 	$b['texts'][] = ':jirafa';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/giraffe.gif' . '" alt="' . ':jirafa' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/giraffe.gif' . '" alt="' . ':jirafa' . '" />';
 
 	$b['texts'][] = ':cerdo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/pig.gif' . '" alt="' . ':cerdo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/pig.gif' . '" alt="' . ':cerdo' . '" />';
 
 
 
 #Baby Smileys
 
 	$b['texts'][] = ':bebé';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/baby.gif' . '" alt="' . ':bebé' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/baby.gif' . '" alt="' . ':bebé' . '" />';
 
 	$b['texts'][] = ':cuna';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/babycot.gif' . '" alt="' . ':cuna' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/babycot.gif' . '" alt="' . ':cuna' . '" />';
 	
 
 	$b['texts'][] = ':embarazada';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/pregnant.gif' . '" alt="' . ':embarazada' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/pregnant.gif' . '" alt="' . ':embarazada' . '" />';
 
 	$b['texts'][] = ':cigüeña';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/stork.gif' . '" alt="' . ':cigüeña' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/stork.gif' . '" alt="' . ':cigüeña' . '" />';
 
 
 #Confused Smileys	
 	$b['texts'][] = ':confundido';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/confused.gif' . '" alt="' . ':confundido' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/confused.gif' . '" alt="' . ':confundido' . '" />';
     
 	$b['texts'][] = ':encogehombros';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/shrug.gif' . '" alt="' . ':encogehombros' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/shrug.gif' . '" alt="' . ':encogehombros' . '" />';
 
 	$b['texts'][] = ':estúpido';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/stupid.gif' . '" alt="' . ':estúpido' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/stupid.gif' . '" alt="' . ':estúpido' . '" />';
 
 	$b['texts'][] = ':aturdidp';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/dazed.gif' . '" alt="' . ':aturdid' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/dazed.gif' . '" alt="' . ':aturdid' . '" />';
 
 
 #Cool Smileys
 
 	$b['texts'][] = ':afro';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/cool/affro.gif' . '" alt="' . ':afro' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/cool/affro.gif' . '" alt="' . ':afro' . '" />';
 
 	$b['texts'][] = ':guay';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/cool/cool.gif' . '" alt="' . ':guay' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/cool/cool.gif' . '" alt="' . ':guay' . '" />';
 
 #Devil/Angel Smileys
 
 	$b['texts'][] = ':ángel';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/angel.gif' . '" alt="' . ':ángel' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/angel.gif' . '" alt="' . ':ángel' . '" />';
 
 	$b['texts'][] = ':querubín';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/cherub.gif' . '" alt="' . ':querubín' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/cherub.gif' . '" alt="' . ':querubín' . '" />';
 
 	$b['texts'][] = ':ángeldemonio';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/blondedevil.gif' . '" alt="' . ':ángeldemonio' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/blondedevil.gif' . '" alt="' . ':ángeldemonio' . '" />';
 
 	$b['texts'][] = ':gatodemonio';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/catdevil.gif' . '" alt="' . ':gatodemonio' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/catdevil.gif' . '" alt="' . ':gatodemonio' . '" />';
 
 	$b['texts'][] = ':diabólico';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/devil.gif' . '" alt="' . ':diabólico' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/devil.gif' . '" alt="' . ':diabólico' . '" />';
 	
 	$b['texts'][] = ':adbalancín';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/daseesaw.gif' . '" alt="' . ':adbalancín' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/daseesaw.gif' . '" alt="' . ':adbalancín' . '" />';
 
 	$b['texts'][] = ':vuelvedemonio';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/turnevil.gif' . '" alt="' . ':vuelvedemonio' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/turnevil.gif' . '" alt="' . ':vuelvedemonio' . '" />';
 	
 	$b['texts'][] = ':santo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/saint.gif' . '" alt="' . ':santo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/saint.gif' . '" alt="' . ':santo' . '" />';
 
 	$b['texts'][] = ':tumba';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/graveside.gif' . '" alt="' . ':tumba' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/graveside.gif' . '" alt="' . ':tumba' . '" />';
 
 #Unpleasent smileys.
 
 	$b['texts'][] = ':retrete';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/toilet.gif' . '" alt="' . ':retrete' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/toilet.gif' . '" alt="' . ':retrete' . '" />';
 
 	$b['texts'][] = ':pedoencama';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartinbed.gif' . '" alt="' . ':pedoencama' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartinbed.gif' . '" alt="' . ':pedoencama' . '" />';
 
 	$b['texts'][] = ':vómito';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/vomit.gif' . '" alt="' . ':vómito' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/vomit.gif' . '" alt="' . ':vómito' . '" />';
 
 	$b['texts'][] = ':pedosonrojo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartblush.gif' . '" alt="' . ':pedosonrojo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartblush.gif' . '" alt="' . ':pedosonrojo' . '" />';
 
 #Drinks
 
 	$b['texts'][] = ':té';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/drink/tea.gif' . '" alt="' . ':té' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/drink/tea.gif' . '" alt="' . ':té' . '" />';
 
 	$b['texts'][] = ':baba';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/drool/drool.gif' . '" alt="' . ':baba' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/drool/drool.gif' . '" alt="' . ':baba' . '" />';
 
 #Sad smileys
 
 	$b['texts'][] = ':llorar';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/crying.png' . '" alt="' . ':llorar' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/crying.png' . '" alt="' . ':llorar' . '" />';
 
 	$b['texts'][] = ':prisonero';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/prisoner.gif' . '" alt="' . ':prisonero' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/prisoner.gif' . '" alt="' . ':prisonero' . '" />';
 
 	$b['texts'][] = ':suspiro';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/sigh.gif' . '" alt="' . ':suspiro' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/sigh.gif' . '" alt="' . ':suspiro' . '" />';
 
 #Smoking - only one smiley in here, maybe it needs moving elsewhere?
 
 	$b['texts'][] = ':fumar';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/smoking/smoking.gif' . '" alt="' . ':fumar' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/smoking/smoking.gif' . '" alt="' . ':fumar' . '" />';
 
 #Sport smileys
 
 	$b['texts'][] = ':baloncesto';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/basketball.gif' . '" alt="' . ':baloncesto' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/basketball.gif' . '" alt="' . ':baloncesto' . '" />';
 
 	$b['texts'][] = ':bolos';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/bowling.gif' . '" alt="' . ':bolos' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/bowling.gif' . '" alt="' . ':bolos' . '" />';
 
 	$b['texts'][] = ':enbici';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/cycling.gif' . '" alt="' . ':enbici' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/cycling.gif' . '" alt="' . ':enbici' . '" />';
 
 	$b['texts'][] = ':dardos';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/darts.gif' . '" alt="' . ':dardos' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/darts.gif' . '" alt="' . ':dardos' . '" />';
 
 	$b['texts'][] = ':esgrima';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/fencing.gif' . '" alt="' . ':esgrima' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/fencing.gif' . '" alt="' . ':esgrima' . '" />';
 
 	$b['texts'][] = ':golf';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/golf.gif' . '" alt="' . ':golf' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/golf.gif' . '" alt="' . ':golf' . '" />';
 
 	$b['texts'][] = ':malabares';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/juggling.gif' . '" alt="' . ':malabares' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/juggling.gif' . '" alt="' . ':malabares' . '" />';
 
 	$b['texts'][] = ':comba';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/skipping.gif' . '" alt="' . ':comba' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/skipping.gif' . '" alt="' . ':comba' . '" />';
 
 	$b['texts'][] = ':tiroconarco';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/archery.gif' . '" alt="' . ':tiroconarco' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/archery.gif' . '" alt="' . ':tiroconarco' . '" />';
 
 	$b['texts'][] = ':fútbol';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/football.gif' . '" alt="' . ':fútbol' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/football.gif' . '" alt="' . ':fútbol' . '" />';
 
 	$b['texts'][] = ':surf';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/surfing.gif' . '" alt="' . ':surf' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/surfing.gif' . '" alt="' . ':surf' . '" />';
 
 	$b['texts'][] = ':billar';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/snooker.gif' . '" alt="' . ':billar' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/snooker.gif' . '" alt="' . ':billar' . '" />';
   
 	$b['texts'][] = ':tenis';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/tennis.gif' . '" alt="' . ':tenis' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/tennis.gif' . '" alt="' . ':tenis' . '" />';
 
 	$b['texts'][] = ':acaballo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/horseriding.gif' . '" alt="' . ':acaballo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/horseriding.gif' . '" alt="' . ':acaballo' . '" />';
 
 #Love smileys
 
 	$b['texts'][] = ':tequiero';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/iloveyou.gif' . '" alt="' . ':tequiero' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/iloveyou.gif' . '" alt="' . ':tequiero' . '" />';
 
 	$b['texts'][] = ':enamorada';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/inlove.gif' . '" alt="' . ':enamorada' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/inlove.gif' . '" alt="' . ':enamorada' . '" />';
 
 	$b['texts'][] = ':amor';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/love.gif' . '" alt="' . ':amor' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/love.gif' . '" alt="' . ':amor' . '" />';
 
 	$b['texts'][] = ':osoamoroso';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebear.gif' . '" alt="' . ':osoamoroso' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebear.gif' . '" alt="' . ':osoamoroso' . '" />';
 
 	$b['texts'][] = ':camaamor';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebed.gif' . '" alt="' . ':camaamor' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebed.gif' . '" alt="' . ':camaamor' . '" />';
 
 	$b['texts'][] = ':corazónamor';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/loveheart.gif' . '" alt="' . ':corazónamor' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/loveheart.gif' . '" alt="' . ':corazónamor' . '" />';
 
 #Tired/Sleep smileys
 
 	$b['texts'][] = ':contandoovejas';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/countsheep.gif' . '" alt="' . ':contandoovejas' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/countsheep.gif' . '" alt="' . ':contandoovejas' . '" />';
 
 	$b['texts'][] = ':hamaca';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/hammock.gif' . '" alt="' . ':hamaca' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/hammock.gif' . '" alt="' . ':hamaca' . '" />';
 
 	$b['texts'][] = ':almohada';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/pillow.gif' . '" alt="' . ':almohada' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/pillow.gif' . '" alt="' . ':almohada' . '" />';
 
 	$b['texts'][] = ':bostezo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/yawn.gif' . '" alt="' . ':bostezo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/yawn.gif' . '" alt="' . ':bostezo' . '" />';
 
 #Fight/Flame/Violent smileys
 
 	$b['texts'][] = ':pistolas';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/2guns.gif' . '" alt="' . ':pistolas' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/2guns.gif' . '" alt="' . ':pistolas' . '" />';
 
 	$b['texts'][] = ':peleamarciano';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alienfight.gif' . '" alt="' . ':peleamarciano' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alienfight.gif' . '" alt="' . ':peleamarciano' . '" />';
 
 	$b['texts'][] = ':alfa';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alpha.png' . '" alt="' . ':alfa' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alpha.png' . '" alt="' . ':alfa' . '" />';
 
 	$b['texts'][] = ':ejército';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/army.gif' . '" alt="' . ':ejército' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/army.gif' . '" alt="' . ':ejército' . '" />';
 
 	$b['texts'][] = ':cabezaflecha';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/arrowhead.gif' . '" alt="' . ':cabezaflecha' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/arrowhead.gif' . '" alt="' . ':cabezaflecha' . '" />';
 
 	$b['texts'][] = ':bfg';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bfg.gif' . '" alt="' . ':bfg' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bfg.gif' . '" alt="' . ':bfg' . '" />';
 
 	$b['texts'][] = ':arquero';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bowman.gif' . '" alt="' . ':arquero' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bowman.gif' . '" alt="' . ':arquero' . '" />';
 
 	$b['texts'][] = ':motosierra';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/chainsaw.gif' . '" alt="' . ':motosierra' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/chainsaw.gif' . '" alt="' . ':motosierra' . '" />';
 
 	$b['texts'][] = ':ballesta';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crossbow.gif' . '" alt="' . ':ballesta' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crossbow.gif' . '" alt="' . ':ballesta' . '" />';
 
 	$b['texts'][] = ':cruzado';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crusader.gif' . '" alt="' . ':cruzado' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crusader.gif' . '" alt="' . ':cruzado' . '" />';
 
 	$b['texts'][] = ':muerto';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/dead.gif' . '" alt="' . ':muerto' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/dead.gif' . '" alt="' . ':muerto' . '" />';
 
 	$b['texts'][] = ':martillazo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/hammersplat.gif' . '" alt="' . ':martillazo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/hammersplat.gif' . '" alt="' . ':martillazo' . '" />';
 
 	$b['texts'][] = ':pistolalaser';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/lasergun.gif' . '" alt="' . ':pistolalaser' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/lasergun.gif' . '" alt="' . ':pistolalaser' . '" />';
 
 	$b['texts'][] = ':metralleta';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/machinegun.gif' . '" alt="' . ':metralleta' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/machinegun.gif' . '" alt="' . ':metralleta' . '" />';
 
 	$b['texts'][] = ':marine';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/marine.gif' . '" alt="' . ':marine' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/marine.gif' . '" alt="' . ':marine' . '" />';
 
 	$b['texts'][] = ':sable';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/sabre.gif' . '" alt="' . ':sable' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/sabre.gif' . '" alt="' . ':sable' . '" />';
 
 	$b['texts'][] = ':tanque';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/tank.gif' . '" alt="' . ':tanque' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/tank.gif' . '" alt="' . ':tanque' . '" />';
 
 	$b['texts'][] = ':vikingo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/viking.gif' . '" alt="' . ':vikingo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/viking.gif' . '" alt="' . ':vikingo' . '" />';
 
 	$b['texts'][] = ':bandas';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/gangs.gif' . '" alt="' . ':bandas' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/gangs.gif' . '" alt="' . ':bandas' . '" />';
 
 	$b['texts'][] = ':ácido';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/acid.gif' . '" alt="' . ':ácido' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/acid.gif' . '" alt="' . ':ácido' . '" />';
 
 #Fantasy smileys - monsters and dragons fantasy.  The other type of fantasy belongs in adult smileys
 
 	$b['texts'][] = ':alien';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/alienmonster.gif' . '" alt="' . ':alien' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/alienmonster.gif' . '" alt="' . ':alien' . '" />';
 
 	$b['texts'][] = ':bárbaro';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/barbarian.gif' . '" alt="' . ':bárbaro' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/barbarian.gif' . '" alt="' . ':bárbaro' . '" />';
 
 	$b['texts'][] = ':dinosaurio';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dinosaur.gif' . '" alt="' . ':dinosaurio' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dinosaur.gif' . '" alt="' . ':dinosaurio' . '" />';
 
 	$b['texts'][] = ':dragón';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragon.gif' . '" alt="' . ':dragón' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragon.gif' . '" alt="' . ':dragón' . '" />';
 
 	$b['texts'][] = ':draco';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragonwhelp.gif' . '" alt="' . ':draco' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragonwhelp.gif' . '" alt="' . ':draco' . '" />';
 
 	$b['texts'][] = ':fantasma';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/ghost.gif' . '" alt="' . ':fantasma' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/ghost.gif' . '" alt="' . ':fantasma' . '" />';
 
 	$b['texts'][] = ':momia';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/mummy.gif' . '" alt="' . ':momia' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/mummy.gif' . '" alt="' . ':momia' . '" />';
 
 #Food smileys
 
 	$b['texts'][] = ':mazana';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/apple.gif' . '" alt="' . ':mazana' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/apple.gif' . '" alt="' . ':mazana' . '" />';
 
 	$b['texts'][] = ':brócoli';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/broccoli.gif' . '" alt="' . ':brócoli' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/broccoli.gif' . '" alt="' . ':brócoli' . '" />';
 
 	$b['texts'][] = ':pastel';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/cake.gif' . '" alt="' . ':pastel' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/cake.gif' . '" alt="' . ':pastel' . '" />';
 
 	$b['texts'][] = ':zanahoria';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/carrot.gif' . '" alt="' . ':zanahoria' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/carrot.gif' . '" alt="' . ':zanahoria' . '" />';
 
 	$b['texts'][] = ':palomitas';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/popcorn.gif' . '" alt="' . ':palomitas' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/popcorn.gif' . '" alt="' . ':palomitas' . '" />';
 
 	$b['texts'][] = ':tomate';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/tomato.gif' . '" alt="' . ':tomate' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/tomato.gif' . '" alt="' . ':tomate' . '" />';
 
 	$b['texts'][] = ':plátano';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/banana.gif' . '" alt="' . ':plátano' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/banana.gif' . '" alt="' . ':plátano' . '" />';
 
 	$b['texts'][] = ':cocinar';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/cooking.gif' . '" alt="' . ':cocinar' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/cooking.gif' . '" alt="' . ':cocinar' . '" />';
 
 	$b['texts'][] = ':huevofrito';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/fryegg.gif' . '" alt="' . ':huevofrito' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/fryegg.gif' . '" alt="' . ':huevofrito' . '" />';
 
 #Happy smileys
 
 	$b['texts'][] = ':cloud9';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/happy/cloud9.gif' . '" alt="' . ':cloud9' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/happy/cloud9.gif' . '" alt="' . ':cloud9' . '" />';
 
 	$b['texts'][] = ':tearsofjoy';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/happy/tearsofjoy.gif' . '" alt="' . ':tearsofjoy' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/happy/tearsofjoy.gif' . '" alt="' . ':tearsofjoy' . '" />';
 
 #Repsect smileys
 
 	$b['texts'][] = ':reverencia';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bow.gif' . '" alt="' . ':reverencia' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bow.gif' . '" alt="' . ':reverencia' . '" />';
 
 	$b['texts'][] = ':bravo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bravo.gif' . '" alt="' . ':bravo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bravo.gif' . '" alt="' . ':bravo' . '" />';
 
 	$b['texts'][] = ':vivaelrey';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/hailking.gif' . '" alt="' . ':vivaelrey' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/hailking.gif' . '" alt="' . ':vivaelrey' . '" />';
 
 	$b['texts'][] = ':número1';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/number1.gif' . '" alt="' . ':número1' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/number1.gif' . '" alt="' . ':número1' . '" />';
 
 #Laugh smileys
 
 	$b['texts'][] = ':jajaja';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/hahaha.gif' . '" alt="' . ':jajaja' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/hahaha.gif' . '" alt="' . ':jajaja' . '" />';
 
 	$b['texts'][] = ':jajatv';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/loltv.gif' . '" alt="' . ':jajatv' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/loltv.gif' . '" alt="' . ':jajatv' . '" />';
 
 	$b['texts'][] = ':meparto';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/rofl.gif' . '" alt="' . ':meparto' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/rofl.gif' . '" alt="' . ':meparto' . '" />';
 
 #Music smileys
 
 	$b['texts'][] = ':dj';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/dj.gif' . '" alt="' . ':dj' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/dj.gif' . '" alt="' . ':dj' . '" />';
 
 	$b['texts'][] = ':batería';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/drums.gif' . '" alt="' . ':batería' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/drums.gif' . '" alt="' . ':batería' . '" />';
 
 	$b['texts'][] = ':elvis';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/elvis.gif' . '" alt="' . ':elivs' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/elvis.gif' . '" alt="' . ':elivs' . '" />';
 
 	$b['texts'][] = ':guitarra';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/guitar.gif' . '" alt="' . ':guitarra' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/guitar.gif' . '" alt="' . ':guitarra' . '" />';
 
 	$b['texts'][] = ':trompeta';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/trumpet.gif' . '" alt="' . ':trompeta' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/trumpet.gif' . '" alt="' . ':trompeta' . '" />';
 
 	$b['texts'][] = ':violín';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/violin.gif' . '" alt="' . ':violín' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/violin.gif' . '" alt="' . ':violín' . '" />';
 
 #Smileys that used to be in core
 
 	$b['texts'][] = ':cabezagolpe';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':cabezagolpe' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':cabezagolpe' . '" />';
 
 		$b['texts'][] = ':barba';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/beard.png' . '" alt="' . ':barba' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/beard.png' . '" alt="' . ':barba' . '" />';
 
 	$b['texts'][] = ':barbablanca';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/whitebeard.png' . '" alt="' . ':barbablanca' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/whitebeard.png' . '" alt="' . ':barbablanca' . '" />';
 
 	$b['texts'][] = ':saludosurf';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':saludosurf' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':saludosurf' . '" />';
 
 	$b['texts'][] = ':\\.../';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\.../' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\.../' . '" />';
 
 	$b['texts'][] = ':\\ooo/';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\ooo/' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\ooo/' . '" />';
 
 	$b['texts'][] = ':cabezamesa';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':cabezamesa' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':cabezamesa' . '" />';
 
 #These two are still in core, so oldcore isn't strictly right, but we don't want too many directories
 
 	$b['texts'][] = ':-d';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/laughing.gif' . '" alt="' . ':-d' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/laughing.gif' . '" alt="' . ':-d' . '" />';
 
 	$b['texts'][] = ':-o';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/surprised.gif' . '" alt="' . ':-o' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/surprised.gif' . '" alt="' . ':-o' . '" />';
 
 
 

--- a/smiley_pack/lang/smiley_pack_fr/smiley_pack_fr.php
+++ b/smiley_pack/lang/smiley_pack_fr/smiley_pack_fr.php
@@ -9,7 +9,7 @@
  * 
  */
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function smiley_pack_fr_install() {
 	Hook::register('smilie', 'addon/smiley_pack_fr/smiley_pack_fr.php', 'smiley_pack_fr_smilies');
@@ -33,378 +33,378 @@ function smiley_pack_fr_smilies(&$a,&$b) {
 #Animal smileys.
 
 	$b['texts'][] = ':fleurslapin';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunnyflowers.gif' . '" alt="' . ':fleurslapin' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunnyflowers.gif' . '" alt="' . ':fleurslapin' . '" />';
 
 	$b['texts'][] = ':poussin';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':poussin' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':poussin' . '" />';
 
 	$b['texts'][] = ':bourdon';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bee.gif' . '" alt="' . ':bourdon' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bee.gif' . '" alt="' . ':bourdon' . '" />';
 
 	$b['texts'][] = ':coccinelle';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/ladybird.gif' . '" alt="' . ':coccinelle' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/ladybird.gif' . '" alt="' . ':coccinelle' . '" />';
 
 	$b['texts'][] = ':araignée';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bigspider.gif' . '" alt="' . ':araignée' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bigspider.gif' . '" alt="' . ':araignée' . '" />';
 
 	$b['texts'][] = ':chat';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cat.gif' . '" alt="' . ':chat' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cat.gif' . '" alt="' . ':chat' . '" />';
 
 	$b['texts'][] = ':lapin';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunny.gif' . '" alt="' . ':lapin' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunny.gif' . '" alt="' . ':lapin' . '" />';
 
 	$b['texts'][] = ':poussin';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':poussin' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':poussin' . '" />';
 
 	$b['texts'][] = ':vache';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cow.gif' . '" alt="' . ':vache' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cow.gif' . '" alt="' . ':vache' . '" />';
     
 	$b['texts'][] = ':crabe';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/crab.gif' . '" alt="' . ':crabe' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/crab.gif' . '" alt="' . ':crabe' . '" />';
 
 	$b['texts'][] = ':dauphin';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dolphin.gif' . '" alt="' . ':dauphin' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dolphin.gif' . '" alt="' . ':dauphin' . '" />';
 
 	$b['texts'][] = ':libellule';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dragonfly.gif' . '" alt="' . ':libellule' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dragonfly.gif' . '" alt="' . ':libellule' . '" />';
 
 	$b['texts'][] = ':grenouille';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/frog.gif' . '" alt="' . ':grenouille' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/frog.gif' . '" alt="' . ':grenouille' . '" />';
 
 	$b['texts'][] = ':singe';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/monkey.gif' . '" alt="' . ':singe' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/monkey.gif' . '" alt="' . ':singe' . '" />';
 
 	$b['texts'][] = ':cheval';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/horse.gif' . '" alt="' . ':cheval' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/horse.gif' . '" alt="' . ':cheval' . '" />';
   
 	$b['texts'][] = ':perroquet';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/parrot.gif' . '" alt="' . ':perroquet' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/parrot.gif' . '" alt="' . ':perroquet' . '" />';
 
 	$b['texts'][] = ':escargot';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/snail.gif' . '" alt="' . ':escargot' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/snail.gif' . '" alt="' . ':escargot' . '" />';
 
 	$b['texts'][] = ':mouton';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/sheep.gif' . '" alt="' . ':mouton' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/sheep.gif' . '" alt="' . ':mouton' . '" />';
 
 	$b['texts'][] = ':chien';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dog.gif' . '" alt="' . ':chien' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dog.gif' . '" alt="' . ':chien' . '" />';
 
 	$b['texts'][] = ':éléphant';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/elephant.gif' . '" alt="' . ':éléphant' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/elephant.gif' . '" alt="' . ':éléphant' . '" />';
 
 	$b['texts'][] = ':poisson';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/fish.gif' . '" alt="' . ':poisson' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/fish.gif' . '" alt="' . ':poisson' . '" />';
 
 	$b['texts'][] = ':girafe';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/giraffe.gif' . '" alt="' . ':girafe' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/giraffe.gif' . '" alt="' . ':girafe' . '" />';
 
 	$b['texts'][] = ':cochon';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/pig.gif' . '" alt="' . ':cochon' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/pig.gif' . '" alt="' . ':cochon' . '" />';
 
 
 
 #Baby Smileys
 
 	$b['texts'][] = ':bébé';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/baby.gif' . '" alt="' . ':bébé' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/baby.gif' . '" alt="' . ':bébé' . '" />';
 
 	$b['texts'][] = ':litbébé';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/babycot.gif' . '" alt="' . ':litbébé' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/babycot.gif' . '" alt="' . ':litbébé' . '" />';
 	
 
 	$b['texts'][] = ':enceinte';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/pregnant.gif' . '" alt="' . ':enceinte' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/pregnant.gif' . '" alt="' . ':enceinte' . '" />';
 
 	$b['texts'][] = ':cigogne';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/stork.gif' . '" alt="' . ':cigogne' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/stork.gif' . '" alt="' . ':cigogne' . '" />';
 
 
 #Confused Smileys	
 	$b['texts'][] = ':paumé';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/confused.gif' . '" alt="' . ':paumé' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/confused.gif' . '" alt="' . ':paumé' . '" />';
     
 	$b['texts'][] = ':hausseépaules';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/shrug.gif' . '" alt="' . ':hausseépaules' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/shrug.gif' . '" alt="' . ':hausseépaules' . '" />';
 
 	$b['texts'][] = ':stupide';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/stupid.gif' . '" alt="' . ':stupide' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/stupid.gif' . '" alt="' . ':stupide' . '" />';
 
 	$b['texts'][] = ':hébété';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/dazed.gif' . '" alt="' . ':hébété' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/dazed.gif' . '" alt="' . ':hébété' . '" />';
 
 
 #Cool Smileys
 
 	$b['texts'][] = ':afro';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/cool/affro.gif' . '" alt="' . ':afro' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/cool/affro.gif' . '" alt="' . ':afro' . '" />';
 
 #Devil/Angel Smileys
 
 	$b['texts'][] = ':ange';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/angel.gif' . '" alt="' . ':ange' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/angel.gif' . '" alt="' . ':ange' . '" />';
 
 	$b['texts'][] = ':chérubin';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/cherub.gif' . '" alt="' . ':chérubin' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/cherub.gif' . '" alt="' . ':chérubin' . '" />';
 
 	$b['texts'][] = ':démonange';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/blondedevil.gif' . '" alt="' . ':démonange' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/blondedevil.gif' . '" alt="' . ':démonange' . '" />';
 
 	$b['texts'][] = ':diablechat';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/catdevil.gif' . '" alt="' . ':diablechat' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/catdevil.gif' . '" alt="' . ':diablechat' . '" />';
 
 	$b['texts'][] = ':démoniaque';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/devil.gif' . '" alt="' . ':démoniaque' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/devil.gif' . '" alt="' . ':démoniaque' . '" />';
 	
 	$b['texts'][] = ':bascule';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/daseesaw.gif' . '" alt="' . ':bascule' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/daseesaw.gif' . '" alt="' . ':bascule' . '" />';
 
 	$b['texts'][] = ':possédé';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/turnevil.gif' . '" alt="' . ':possédé' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/turnevil.gif' . '" alt="' . ':possédé' . '" />';
 	
 	$b['texts'][] = ':tombe';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/graveside.gif' . '" alt="' . ':tombe' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/graveside.gif' . '" alt="' . ':tombe' . '" />';
 
 #Unpleasent smileys.
 
 	$b['texts'][] = ':toilettes';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/toilet.gif' . '" alt="' . ':toilettes' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/toilet.gif' . '" alt="' . ':toilettes' . '" />';
 
 	$b['texts'][] = ':pèteaulit';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartinbed.gif' . '" alt="' . ':pèteaulit' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartinbed.gif' . '" alt="' . ':pèteaulit' . '" />';
 
 	$b['texts'][] = ':pet';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartblush.gif' . '" alt="' . ':pet' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartblush.gif' . '" alt="' . ':pet' . '" />';
 
 #Drinks
 
 	$b['texts'][] = ':thé';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/drink/tea.gif' . '" alt="' . ':thé' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/drink/tea.gif' . '" alt="' . ':thé' . '" />';
 
 	$b['texts'][] = ':salive';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/drool/drool.gif' . '" alt="' . ':salive' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/drool/drool.gif' . '" alt="' . ':salive' . '" />';
 
 #Sad smileys
 
 	$b['texts'][] = ':pleure';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/crying.png' . '" alt="' . ':pleure' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/crying.png' . '" alt="' . ':pleure' . '" />';
 
 	$b['texts'][] = ':prisonnier';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/prisoner.gif' . '" alt="' . ':prisonnier' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/prisoner.gif' . '" alt="' . ':prisonnier' . '" />';
 
 	$b['texts'][] = ':soupir';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/sigh.gif' . '" alt="' . ':soupir' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/sigh.gif' . '" alt="' . ':soupir' . '" />';
 
 #Smoking - only one smiley in here, maybe it needs moving elsewhere?
 
 	$b['texts'][] = ':fume';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/smoking/smoking.gif' . '" alt="' . ':fume' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/smoking/smoking.gif' . '" alt="' . ':fume' . '" />';
 
 #Sport smileys
 
 	$b['texts'][] = ':basket';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/basketball.gif' . '" alt="' . ':basket' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/basketball.gif' . '" alt="' . ':basket' . '" />';
 
 	$b['texts'][] = ':vélo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/cycling.gif' . '" alt="' . ':vélo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/cycling.gif' . '" alt="' . ':vélo' . '" />';
 
 	$b['texts'][] = ':fléchettes';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/darts.gif' . '" alt="' . ':fléchettes' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/darts.gif' . '" alt="' . ':fléchettes' . '" />';
 
 	$b['texts'][] = ':escrime';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/fencing.gif' . '" alt="' . ':escrime' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/fencing.gif' . '" alt="' . ':escrime' . '" />';
 
 	$b['texts'][] = ':jonglage';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/juggling.gif' . '" alt="' . ':jonglage' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/juggling.gif' . '" alt="' . ':jonglage' . '" />';
 
 	$b['texts'][] = ':sautàlacorde';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/skipping.gif' . '" alt="' . ':sautàlacorde' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/skipping.gif' . '" alt="' . ':sautàlacorde' . '" />';
 
 	$b['texts'][] = ':arc';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/archery.gif' . '" alt="' . ':arc' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/archery.gif' . '" alt="' . ':arc' . '" />';
 
 	$b['texts'][] = ':surf';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/surfing.gif' . '" alt="' . ':surf' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/surfing.gif' . '" alt="' . ':surf' . '" />';
 
 	$b['texts'][] = ':billard';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/snooker.gif' . '" alt="' . ':billard' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/snooker.gif' . '" alt="' . ':billard' . '" />';
   
 	$b['texts'][] = ':équitation';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/horseriding.gif' . '" alt="' . ':équitation' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/horseriding.gif' . '" alt="' . ':équitation' . '" />';
 
 #Love smileys
 
 	$b['texts'][] = ':jetaime';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/iloveyou.gif' . '" alt="' . ':jetaime' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/iloveyou.gif' . '" alt="' . ':jetaime' . '" />';
 
 	$b['texts'][] = ':amoureux';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/inlove.gif' . '" alt="' . ':amoureux' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/inlove.gif' . '" alt="' . ':amoureux' . '" />';
 
 	$b['texts'][] = ':oursamour';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebear.gif' . '" alt="' . ':oursamour' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebear.gif' . '" alt="' . ':oursamour' . '" />';
 
 	$b['texts'][] = ':amourlit';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebed.gif' . '" alt="' . ':amourlit' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebed.gif' . '" alt="' . ':amourlit' . '" />';
 
 	$b['texts'][] = ':coeur';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/loveheart.gif' . '" alt="' . ':coeur' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/loveheart.gif' . '" alt="' . ':coeur' . '" />';
 
 #Tired/Sleep smileys
 
 	$b['texts'][] = ':comptemoutons';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/countsheep.gif' . '" alt="' . ':comptemoutons' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/countsheep.gif' . '" alt="' . ':comptemoutons' . '" />';
 
 	$b['texts'][] = ':hamac';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/hammock.gif' . '" alt="' . ':hamac' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/hammock.gif' . '" alt="' . ':hamac' . '" />';
 
 	$b['texts'][] = ':oreiller';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/pillow.gif' . '" alt="' . ':oreiller' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/pillow.gif' . '" alt="' . ':oreiller' . '" />';
 
 	$b['texts'][] = ':bâille';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/yawn.gif' . '" alt="' . ':bâille' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/yawn.gif' . '" alt="' . ':bâille' . '" />';
 
 #Fight/Flame/Violent smileys
 
 	$b['texts'][] = ':2pistolets';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/2guns.gif' . '" alt="' . ':2pistolets' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/2guns.gif' . '" alt="' . ':2pistolets' . '" />';
 
 	$b['texts'][] = ':combatalien';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alienfight.gif' . '" alt="' . ':combatalien' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alienfight.gif' . '" alt="' . ':combatalien' . '" />';
 
 	$b['texts'][] = ':armée';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/army.gif' . '" alt="' . ':armée' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/army.gif' . '" alt="' . ':armée' . '" />';
 
 	$b['texts'][] = ':flèche';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/arrowhead.gif' . '" alt="' . ':flèche' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/arrowhead.gif' . '" alt="' . ':flèche' . '" />';
 
 	$b['texts'][] = ':bfg';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bfg.gif' . '" alt="' . ':bfg' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bfg.gif' . '" alt="' . ':bfg' . '" />';
 
 	$b['texts'][] = ':archer';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bowman.gif' . '" alt="' . ':archer' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bowman.gif' . '" alt="' . ':archer' . '" />';
 
 	$b['texts'][] = ':tronçonneuse';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/chainsaw.gif' . '" alt="' . ':tronçonneuse' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/chainsaw.gif' . '" alt="' . ':tronçonneuse' . '" />';
 
 	$b['texts'][] = ':arbalète';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crossbow.gif' . '" alt="' . ':arbalète' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crossbow.gif' . '" alt="' . ':arbalète' . '" />';
 
 	$b['texts'][] = ':croisé';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crusader.gif' . '" alt="' . ':croisé' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crusader.gif' . '" alt="' . ':croisé' . '" />';
 
 	$b['texts'][] = ':mort';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/dead.gif' . '" alt="' . ':mort' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/dead.gif' . '" alt="' . ':mort' . '" />';
 
 	$b['texts'][] = ':marteau';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/hammersplat.gif' . '" alt="' . ':marteau' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/hammersplat.gif' . '" alt="' . ':marteau' . '" />';
 
 	$b['texts'][] = ':pistoletlaser';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/lasergun.gif' . '" alt="' . ':pistoletlaser' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/lasergun.gif' . '" alt="' . ':pistoletlaser' . '" />';
 
 	$b['texts'][] = ':mitrailleuse';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/machinegun.gif' . '" alt="' . ':mitrailleuse' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/machinegun.gif' . '" alt="' . ':mitrailleuse' . '" />';
 
 	$b['texts'][] = ':acide';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/acid.gif' . '" alt="' . ':acide' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/acid.gif' . '" alt="' . ':acide' . '" />';
 
 #Fantasy smileys - monsters and dragons fantasy.  The other type of fantasy belongs in adult smileys
 
 	$b['texts'][] = ':monstrealien';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/alienmonster.gif' . '" alt="' . ':monstrealien' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/alienmonster.gif' . '" alt="' . ':monstrealien' . '" />';
 
 	$b['texts'][] = ':barbare';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/barbarian.gif' . '" alt="' . ':barbare' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/barbarian.gif' . '" alt="' . ':barbare' . '" />';
 
 	$b['texts'][] = ':dinosaure';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dinosaur.gif' . '" alt="' . ':dinosaure' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dinosaur.gif' . '" alt="' . ':dinosaure' . '" />';
 
 	$b['texts'][] = ':petitdragon';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragonwhelp.gif' . '" alt="' . ':petitdragon' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragonwhelp.gif' . '" alt="' . ':petitdragon' . '" />';
 
 	$b['texts'][] = ':fantôme';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/ghost.gif' . '" alt="' . ':fantôme' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/ghost.gif' . '" alt="' . ':fantôme' . '" />';
 
 	$b['texts'][] = ':momie';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/mummy.gif' . '" alt="' . ':momie' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/mummy.gif' . '" alt="' . ':momie' . '" />';
 
 #Food smileys
 
 	$b['texts'][] = ':pomme';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/apple.gif' . '" alt="' . ':pomme' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/apple.gif' . '" alt="' . ':pomme' . '" />';
 
 	$b['texts'][] = ':brocoli';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/broccoli.gif' . '" alt="' . ':brocoli' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/broccoli.gif' . '" alt="' . ':brocoli' . '" />';
 
 	$b['texts'][] = ':gâteau';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/cake.gif' . '" alt="' . ':gâteau' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/cake.gif' . '" alt="' . ':gâteau' . '" />';
 
 	$b['texts'][] = ':carotte';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/carrot.gif' . '" alt="' . ':carotte' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/carrot.gif' . '" alt="' . ':carotte' . '" />';
 
 	$b['texts'][] = '~popcorn';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/popcorn.gif' . '" alt="' . '~popcorn' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/popcorn.gif' . '" alt="' . '~popcorn' . '" />';
 
 	$b['texts'][] = ':tomate';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/tomato.gif' . '" alt="' . ':tomate' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/tomato.gif' . '" alt="' . ':tomate' . '" />';
 
 	$b['texts'][] = ':banane';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/banana.gif' . '" alt="' . ':banane' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/banana.gif' . '" alt="' . ':banane' . '" />';
 
 	$b['texts'][] = ':cuisine';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/cooking.gif' . '" alt="' . ':cuisine' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/cooking.gif' . '" alt="' . ':cuisine' . '" />';
 
 	$b['texts'][] = ':oeufauplat';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/fryegg.gif' . '" alt="' . ':oeufauplat' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/fryegg.gif' . '" alt="' . ':oeufauplat' . '" />';
 
 #Happy smileys
 
 	$b['texts'][] = ':nuage';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/happy/cloud9.gif' . '" alt="' . ':nuage' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/happy/cloud9.gif' . '" alt="' . ':nuage' . '" />';
 
 	$b['texts'][] = ':larmesdejoie';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/happy/tearsofjoy.gif' . '" alt="' . ':larmesdejoie' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/happy/tearsofjoy.gif' . '" alt="' . ':larmesdejoie' . '" />';
 
 #Repsect smileys
 
 	$b['texts'][] = ':courbette';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bow.gif' . '" alt="' . ':courbette' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bow.gif' . '" alt="' . ':courbette' . '" />';
 
 	$b['texts'][] = ':bravo';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bravo.gif' . '" alt="' . ':bravo' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bravo.gif' . '" alt="' . ':bravo' . '" />';
 
 	$b['texts'][] = ':viveleroi';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/hailking.gif' . '" alt="' . ':viveleroi' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/hailking.gif' . '" alt="' . ':viveleroi' . '" />';
 
 	$b['texts'][] = ':numéro1';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/number1.gif' . '" alt="' . ':numéro1' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/number1.gif' . '" alt="' . ':numéro1' . '" />';
 
 #Laugh smileys
 
 #Music smileys
 
 	$b['texts'][] = ':batterie';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/drums.gif' . '" alt="' . ':batterie' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/drums.gif' . '" alt="' . ':batterie' . '" />';
 
 	$b['texts'][] = ':guitare';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/guitar.gif' . '" alt="' . ':guitare' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/guitar.gif' . '" alt="' . ':guitare' . '" />';
 
 	$b['texts'][] = ':trompette';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/trumpet.gif' . '" alt="' . ':trompette' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/trumpet.gif' . '" alt="' . ':trompette' . '" />';
 
 	$b['texts'][] = ':violon';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/violin.gif' . '" alt="' . ':violon' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/violin.gif' . '" alt="' . ':violon' . '" />';
 
 #Smileys that used to be in core
 
 	$b['texts'][] = ':cognetête';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':cognetête' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':cognetête' . '" />';
 
 		$b['texts'][] = ':barbu';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/beard.png' . '" alt="' . ':barbu' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/beard.png' . '" alt="' . ':barbu' . '" />';
 
 	$b['texts'][] = ':barbeblanche';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/whitebeard.png' . '" alt="' . ':barbeblanche' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/whitebeard.png' . '" alt="' . ':barbeblanche' . '" />';
 
 	$b['texts'][] = ':tête';
-	$b['icons'][] = '<img src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':tête' . '" />';
+	$b['icons'][] = '<img src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':tête' . '" />';
 
 }

--- a/smiley_pack/smiley_pack.php
+++ b/smiley_pack/smiley_pack.php
@@ -8,7 +8,7 @@
  */
 
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function smiley_pack_install() {
 	Hook::register('smilie', 'addon/smiley_pack/smiley_pack.php', 'smiley_pack_smilies');
@@ -32,466 +32,466 @@ function smiley_pack_smilies(&$a,&$b) {
 #Animal smileys.
 
 	$b['texts'][] = ':bunnyflowers';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunnyflowers.gif' . '" alt="' . ':bunnyflowers' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunnyflowers.gif' . '" alt="' . ':bunnyflowers' . '" />';
 
 	$b['texts'][] = ':chick';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':chick' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/chick.gif' . '" alt="' . ':chick' . '" />';
 
 	$b['texts'][] = ':bumblebee';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bee.gif' . '" alt="' . ':bee' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bee.gif' . '" alt="' . ':bee' . '" />';
 
 	$b['texts'][] = ':ladybird';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/ladybird.gif' . '" alt="' . ':ladybird' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/ladybird.gif' . '" alt="' . ':ladybird' . '" />';
 
 	$b['texts'][] = ':bigspider';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bigspider.gif' . '" alt="' . ':bigspider' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bigspider.gif' . '" alt="' . ':bigspider' . '" />';
 
 	$b['texts'][] = ':cat';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cat.gif' . '" alt="' . ':cat' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cat.gif' . '" alt="' . ':cat' . '" />';
 
 	$b['texts'][] = ':bunny';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunny.gif' . '" alt="' . ':bunny' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/bunny.gif' . '" alt="' . ':bunny' . '" />';
 
 	$b['texts'][] = ':cow';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cow.gif' . '" alt="' . ':cow' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/cow.gif' . '" alt="' . ':cow' . '" />';
     
 	$b['texts'][] = ':crab';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/crab.gif' . '" alt="' . ':crab' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/crab.gif' . '" alt="' . ':crab' . '" />';
 
 	$b['texts'][] = ':dolphin';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dolphin.gif' . '" alt="' . ':dolphin' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dolphin.gif' . '" alt="' . ':dolphin' . '" />';
 
 	$b['texts'][] = ':dragonfly';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dragonfly.gif' . '" alt="' . ':dragonfly' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dragonfly.gif' . '" alt="' . ':dragonfly' . '" />';
 
 	$b['texts'][] = ':frog';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/frog.gif' . '" alt="' . ':frog' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/frog.gif' . '" alt="' . ':frog' . '" />';
 
 	$b['texts'][] = ':hamster';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/hamster.gif' . '" alt="' . ':hamster' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/hamster.gif' . '" alt="' . ':hamster' . '" />';
 
 	$b['texts'][] = ':monkey';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/monkey.gif' . '" alt="' . ':monkey' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/monkey.gif' . '" alt="' . ':monkey' . '" />';
 
 	$b['texts'][] = ':horse';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/horse.gif' . '" alt="' . ':horse' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/horse.gif' . '" alt="' . ':horse' . '" />';
   
 	$b['texts'][] = ':parrot';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/parrot.gif' . '" alt="' . ':parrot' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/parrot.gif' . '" alt="' . ':parrot' . '" />';
 
 	$b['texts'][] = ':tux';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/tux.gif' . '" alt="' . ':tux' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/tux.gif' . '" alt="' . ':tux' . '" />';
 
 	$b['texts'][] = ':snail';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/snail.gif' . '" alt="' . ':snail' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/snail.gif' . '" alt="' . ':snail' . '" />';
 
 	$b['texts'][] = ':sheep';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/sheep.gif' . '" alt="' . ':sheep' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/sheep.gif' . '" alt="' . ':sheep' . '" />';
 
 	$b['texts'][] = ':dog';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dog.gif' . '" alt="' . ':dog' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/dog.gif' . '" alt="' . ':dog' . '" />';
 
 	$b['texts'][] = ':elephant';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/elephant.gif' . '" alt="' . ':elephant' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/elephant.gif' . '" alt="' . ':elephant' . '" />';
 
 	$b['texts'][] = ':fish';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/fish.gif' . '" alt="' . ':fish' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/fish.gif' . '" alt="' . ':fish' . '" />';
 
 	$b['texts'][] = ':giraffe';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/giraffe.gif' . '" alt="' . ':giraffe' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/giraffe.gif' . '" alt="' . ':giraffe' . '" />';
 
 	$b['texts'][] = ':pig';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/animals/pig.gif' . '" alt="' . ':pig' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/animals/pig.gif' . '" alt="' . ':pig' . '" />';
 
 
 
 #Baby Smileys
 
 	$b['texts'][] = ':baby';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/baby.gif' . '" alt="' . ':baby' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/baby.gif' . '" alt="' . ':baby' . '" />';
 
 	$b['texts'][] = ':babycot';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/babycot.gif' . '" alt="' . ':babycot' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/babycot.gif' . '" alt="' . ':babycot' . '" />';
 	
 
 	$b['texts'][] = ':pregnant';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/pregnant.gif' . '" alt="' . ':pregnant' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/pregnant.gif' . '" alt="' . ':pregnant' . '" />';
 
 	$b['texts'][] = ':stork';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/babies/stork.gif' . '" alt="' . ':stork' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/babies/stork.gif' . '" alt="' . ':stork' . '" />';
 
 
 #Confused Smileys	
 	$b['texts'][] = ':confused';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/confused.gif' . '" alt="' . ':confused' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/confused.gif' . '" alt="' . ':confused' . '" />';
     
 	$b['texts'][] = ':shrug';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/shrug.gif' . '" alt="' . ':shrug' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/shrug.gif' . '" alt="' . ':shrug' . '" />';
 
 	$b['texts'][] = ':stupid';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/stupid.gif' . '" alt="' . ':stupid' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/stupid.gif' . '" alt="' . ':stupid' . '" />';
 
 	$b['texts'][] = ':dazed';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/confused/dazed.gif' . '" alt="' . ':dazed' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/confused/dazed.gif' . '" alt="' . ':dazed' . '" />';
 
 
 #Cool Smileys
 
 	$b['texts'][] = ':affro';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/cool/affro.gif' . '" alt="' . ':affro' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/cool/affro.gif' . '" alt="' . ':affro' . '" />';
 
 #Devil/Angel Smileys
 
 	$b['texts'][] = ':angel';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/angel.gif' . '" alt="' . ':angel' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/angel.gif' . '" alt="' . ':angel' . '" />';
 
 	$b['texts'][] = ':cherub';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/cherub.gif' . '" alt="' . ':cherub' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/cherub.gif' . '" alt="' . ':cherub' . '" />';
 
 	$b['texts'][] = ':devilangel';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/blondedevil.gif' . '" alt="' . ':devilangel' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/blondedevil.gif' . '" alt="' . ':devilangel' . '" />';
 
 	$b['texts'][] = ':catdevil';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/catdevil.gif' . '" alt="' . ':catdevil' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/catdevil.gif' . '" alt="' . ':catdevil' . '" />';
 
 	$b['texts'][] = ':devillish';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/devil.gif' . '" alt="' . ':devillish' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/devil.gif' . '" alt="' . ':devillish' . '" />';
 	
 	$b['texts'][] = ':daseesaw';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/daseesaw.gif' . '" alt="' . ':daseesaw' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/daseesaw.gif' . '" alt="' . ':daseesaw' . '" />';
 
 	$b['texts'][] = ':turnevil';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/turnevil.gif' . '" alt="' . ':turnevil' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/turnevil.gif' . '" alt="' . ':turnevil' . '" />';
 	
 	$b['texts'][] = ':saint';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/saint.gif' . '" alt="' . ':saint' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/saint.gif' . '" alt="' . ':saint' . '" />';
 
 	$b['texts'][] = ':graveside';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/graveside.gif' . '" alt="' . ':graveside' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/devilangel/graveside.gif' . '" alt="' . ':graveside' . '" />';
 
 #Unpleasent smileys.
 
 	$b['texts'][] = ':toilet';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/toilet.gif' . '" alt="' . ':toilet' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/toilet.gif' . '" alt="' . ':toilet' . '" />';
 
 	$b['texts'][] = ':fartinbed';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartinbed.gif' . '" alt="' . ':fartinbed' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartinbed.gif' . '" alt="' . ':fartinbed' . '" />';
 
 	$b['texts'][] = ':fartblush';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartblush.gif' . '" alt="' . ':fartblush' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/fartblush.gif' . '" alt="' . ':fartblush' . '" />';
 
 #Drinks
 
 	$b['texts'][] = ':tea';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/drink/tea.gif' . '" alt="' . ':tea' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/drink/tea.gif' . '" alt="' . ':tea' . '" />';
 
 	$b['texts'][] = ':drool';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/drool/drool.gif' . '" alt="' . ':drool' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/drool/drool.gif' . '" alt="' . ':drool' . '" />';
 
 #Sad smileys
 
 	$b['texts'][] = ':crying';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/crying.png' . '" alt="' . ':crying' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/crying.png' . '" alt="' . ':crying' . '" />';
 
 	$b['texts'][] = ':prisoner';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/prisoner.gif' . '" alt="' . ':prisoner' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/prisoner.gif' . '" alt="' . ':prisoner' . '" />';
 
 	$b['texts'][] = ':sigh';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sad/sigh.gif' . '" alt="' . ':sigh' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sad/sigh.gif' . '" alt="' . ':sigh' . '" />';
 
 #Smoking - only one smiley in here, maybe it needs moving elsewhere?
 
 	$b['texts'][] = ':smoking';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/smoking/smoking.gif' . '" alt="' . ':smoking' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/smoking/smoking.gif' . '" alt="' . ':smoking' . '" />';
 
 #Sport smileys
 
 	$b['texts'][] = ':basketball';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/basketball.gif' . '" alt="' . ':basketball' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/basketball.gif' . '" alt="' . ':basketball' . '" />';
 
 	$b['texts'][] = '~bowling';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/bowling.gif' . '" alt="' . '~bowling' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/bowling.gif' . '" alt="' . '~bowling' . '" />';
 
 	$b['texts'][] = ':cycling';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/cycling.gif' . '" alt="' . ':cycling' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/cycling.gif' . '" alt="' . ':cycling' . '" />';
 
 	$b['texts'][] = ':darts';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/darts.gif' . '" alt="' . ':darts' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/darts.gif' . '" alt="' . ':darts' . '" />';
 
 	$b['texts'][] = ':fencing';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/fencing.gif' . '" alt="' . ':fencing' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/fencing.gif' . '" alt="' . ':fencing' . '" />';
 
 	$b['texts'][] = ':juggling';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/juggling.gif' . '" alt="' . ':juggling' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/juggling.gif' . '" alt="' . ':juggling' . '" />';
 
 	$b['texts'][] = ':skipping';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/skipping.gif' . '" alt="' . ':skipping' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/skipping.gif' . '" alt="' . ':skipping' . '" />';
 
 	$b['texts'][] = ':archery';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/archery.gif' . '" alt="' . ':archery' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/archery.gif' . '" alt="' . ':archery' . '" />';
 
 	$b['texts'][] = ':surfing';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/surfing.gif' . '" alt="' . ':surfing' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/surfing.gif' . '" alt="' . ':surfing' . '" />';
 
 	$b['texts'][] = ':snooker';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/snooker.gif' . '" alt="' . ':snooker' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/snooker.gif' . '" alt="' . ':snooker' . '" />';
   
 	$b['texts'][] = ':horseriding';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/horseriding.gif' . '" alt="' . ':horseriding' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/horseriding.gif' . '" alt="' . ':horseriding' . '" />';
 
 #Love smileys
 
 	$b['texts'][] = ':iloveyou';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/iloveyou.gif' . '" alt="' . ':iloveyou' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/iloveyou.gif' . '" alt="' . ':iloveyou' . '" />';
 
 	$b['texts'][] = ':inlove';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/inlove.gif' . '" alt="' . ':inlove' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/inlove.gif' . '" alt="' . ':inlove' . '" />';
 
 	$b['texts'][] = '~love';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/love.gif' . '" alt="' . ':love' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/love.gif' . '" alt="' . ':love' . '" />';
 
 	$b['texts'][] = ':lovebear';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebear.gif' . '" alt="' . ':lovebear' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebear.gif' . '" alt="' . ':lovebear' . '" />';
 
 	$b['texts'][] = ':lovebed';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebed.gif' . '" alt="' . ':lovebed' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/lovebed.gif' . '" alt="' . ':lovebed' . '" />';
 
 	$b['texts'][] = ':loveheart';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/love/loveheart.gif' . '" alt="' . ':loveheart' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/love/loveheart.gif' . '" alt="' . ':loveheart' . '" />';
 
 #Tired/Sleep smileys
 
 	$b['texts'][] = ':countsheep';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/countsheep.gif' . '" alt="' . ':countsheep' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/countsheep.gif' . '" alt="' . ':countsheep' . '" />';
 
 	$b['texts'][] = ':hammock';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/hammock.gif' . '" alt="' . ':hammock' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/hammock.gif' . '" alt="' . ':hammock' . '" />';
 
 	$b['texts'][] = ':pillow';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/pillow.gif' . '" alt="' . ':pillow' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/pillow.gif' . '" alt="' . ':pillow' . '" />';
 
 	$b['texts'][] = ':yawn';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/tired/yawn.gif' . '" alt="' . ':yawn' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/tired/yawn.gif' . '" alt="' . ':yawn' . '" />';
 
 #Fight/Flame/Violent smileys
 
 	$b['texts'][] = ':2guns';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/2guns.gif' . '" alt="' . ':2guns' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/2guns.gif' . '" alt="' . ':2guns' . '" />';
 
 	$b['texts'][] = ':alienfight';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alienfight.gif' . '" alt="' . ':alienfight' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alienfight.gif' . '" alt="' . ':alienfight' . '" />';
 
 	$b['texts'][] = ':army';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/army.gif' . '" alt="' . ':army' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/army.gif' . '" alt="' . ':army' . '" />';
 
 	$b['texts'][] = ':arrowhead';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/arrowhead.gif' . '" alt="' . ':arrowhead' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/arrowhead.gif' . '" alt="' . ':arrowhead' . '" />';
 
 	$b['texts'][] = ':bfg';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bfg.gif' . '" alt="' . ':bfg' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bfg.gif' . '" alt="' . ':bfg' . '" />';
 
 	$b['texts'][] = ':bowman';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bowman.gif' . '" alt="' . ':bowman' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/bowman.gif' . '" alt="' . ':bowman' . '" />';
 
 	$b['texts'][] = ':chainsaw';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/chainsaw.gif' . '" alt="' . ':chainsaw' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/chainsaw.gif' . '" alt="' . ':chainsaw' . '" />';
 
 	$b['texts'][] = ':crossbow';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crossbow.gif' . '" alt="' . ':crossbow' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crossbow.gif' . '" alt="' . ':crossbow' . '" />';
 
 	$b['texts'][] = ':crusader';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crusader.gif' . '" alt="' . ':crusader' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/crusader.gif' . '" alt="' . ':crusader' . '" />';
 
 	$b['texts'][] = ':dead';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/dead.gif' . '" alt="' . ':dead' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/dead.gif' . '" alt="' . ':dead' . '" />';
 
 	$b['texts'][] = ':hammersplat';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/hammersplat.gif' . '" alt="' . ':hammersplat' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/hammersplat.gif' . '" alt="' . ':hammersplat' . '" />';
 
 	$b['texts'][] = ':lasergun';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/lasergun.gif' . '" alt="' . ':lasergun' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/lasergun.gif' . '" alt="' . ':lasergun' . '" />';
 
 	$b['texts'][] = ':machinegun';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/machinegun.gif' . '" alt="' . ':machinegun' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/machinegun.gif' . '" alt="' . ':machinegun' . '" />';
 
 	$b['texts'][] = ':acid';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/acid.gif' . '" alt="' . ':acid' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/acid.gif' . '" alt="' . ':acid' . '" />';
 
 #Fantasy smileys - monsters and dragons fantasy.  The other type of fantasy belongs in adult smileys
 
 	$b['texts'][] = ':alienmonster';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/alienmonster.gif' . '" alt="' . ':alienmonster' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/alienmonster.gif' . '" alt="' . ':alienmonster' . '" />';
 
 	$b['texts'][] = ':barbarian';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/barbarian.gif' . '" alt="' . ':barbarian' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/barbarian.gif' . '" alt="' . ':barbarian' . '" />';
 
 	$b['texts'][] = ':dinosaur';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dinosaur.gif' . '" alt="' . ':dinosaur' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dinosaur.gif' . '" alt="' . ':dinosaur' . '" />';
 
 	$b['texts'][] = ':dragon';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragon.gif' . '" alt="' . ':dragon' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragon.gif' . '" alt="' . ':dragon' . '" />';
 
 	$b['texts'][] = ':draco';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragonwhelp.gif' . '" alt="' . ':draco' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/dragonwhelp.gif' . '" alt="' . ':draco' . '" />';
 
 	$b['texts'][] = ':ghost';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/ghost.gif' . '" alt="' . ':ghost' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/ghost.gif' . '" alt="' . ':ghost' . '" />';
 
 	$b['texts'][] = ':mummy';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/mummy.gif' . '" alt="' . ':mummy' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fantasy/mummy.gif' . '" alt="' . ':mummy' . '" />';
 
 #Food smileys
 
 	$b['texts'][] = ':apple';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/apple.gif' . '" alt="' . ':apple' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/apple.gif' . '" alt="' . ':apple' . '" />';
 
 	$b['texts'][] = ':broccoli';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/broccoli.gif' . '" alt="' . ':brocolli' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/broccoli.gif' . '" alt="' . ':brocolli' . '" />';
 
 	$b['texts'][] = ':cake';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/cake.gif' . '" alt="' . ':cake' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/cake.gif' . '" alt="' . ':cake' . '" />';
 
 	$b['texts'][] = ':carrot';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/carrot.gif' . '" alt="' . ':carrot' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/carrot.gif' . '" alt="' . ':carrot' . '" />';
 
 	$b['texts'][] = ':popcorn';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/popcorn.gif' . '" alt="' . ':popcorn' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/popcorn.gif' . '" alt="' . ':popcorn' . '" />';
 
 	$b['texts'][] = ':tomato';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/tomato.gif' . '" alt="' . ':tomato' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/tomato.gif' . '" alt="' . ':tomato' . '" />';
 
 	$b['texts'][] = ':banana';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/banana.gif' . '" alt="' . ':banana' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/banana.gif' . '" alt="' . ':banana' . '" />';
 
 	$b['texts'][] = ':cooking';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/cooking.gif' . '" alt="' . ':cooking' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/cooking.gif' . '" alt="' . ':cooking' . '" />';
 
 	$b['texts'][] = ':fryegg';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/fryegg.gif' . '" alt="' . ':fryegg' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/fryegg.gif' . '" alt="' . ':fryegg' . '" />';
 
 	$b['texts'][] = ':birthdaycake';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/food/birthdaycake.gif' . '" alt="' . ':birthdaycake' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/food/birthdaycake.gif' . '" alt="' . ':birthdaycake' . '" />';
 
 #Happy smileys
 
 	$b['texts'][] = ':cloud9';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/happy/cloud9.gif' . '" alt="' . ':cloud9' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/happy/cloud9.gif' . '" alt="' . ':cloud9' . '" />';
 
 	$b['texts'][] = ':tearsofjoy';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/happy/tearsofjoy.gif' . '" alt="' . ':tearsofjoy' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/happy/tearsofjoy.gif' . '" alt="' . ':tearsofjoy' . '" />';
 
 #Repsect smileys
 
 	$b['texts'][] = ':bow';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bow.gif' . '" alt="' . ':bow' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bow.gif' . '" alt="' . ':bow' . '" />';
 
 	$b['texts'][] = ':bravo';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bravo.gif' . '" alt="' . ':bravo' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/bravo.gif' . '" alt="' . ':bravo' . '" />';
 
 	$b['texts'][] = ':hailking';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/hailking.gif' . '" alt="' . ':hailking' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/hailking.gif' . '" alt="' . ':hailking' . '" />';
 
 	$b['texts'][] = ':number1';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/respect/number1.gif' . '" alt="' . ':number1' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/respect/number1.gif' . '" alt="' . ':number1' . '" />';
 
 #Laugh smileys
 
 	$b['texts'][] = ':hahaha';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/hahaha.gif' . '" alt="' . ':hahaha' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/hahaha.gif' . '" alt="' . ':hahaha' . '" />';
 
 	$b['texts'][] = ':loltv';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/loltv.gif' . '" alt="' . ':loltv' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/loltv.gif' . '" alt="' . ':loltv' . '" />';
 
 	$b['texts'][] = ':rofl';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/rofl.gif' . '" alt="' . ':rofl' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/laugh/rofl.gif' . '" alt="' . ':rofl' . '" />';
 
 #Music smileys
 
 	$b['texts'][] = ':drums';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/drums.gif' . '" alt="' . ':drums' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/drums.gif' . '" alt="' . ':drums' . '" />';
 
 
 	$b['texts'][] = ':guitar';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/guitar.gif' . '" alt="' . ':guitar' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/guitar.gif' . '" alt="' . ':guitar' . '" />';
 
 	$b['texts'][] = ':trumpet';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/trumpet.gif' . '" alt="' . ':trumpet' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/trumpet.gif' . '" alt="' . ':trumpet' . '" />';
 
 #Smileys that used to be in core
 
 	$b['texts'][] = ':headbang';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':headbang' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':headbang' . '" />';
 
 		$b['texts'][] = ':beard';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/beard.png' . '" alt="' . ':beard' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/beard.png' . '" alt="' . ':beard' . '" />';
 
 	$b['texts'][] = ':whitebeard';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/whitebeard.png' . '" alt="' . ':whitebeard' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/whitebeard.png' . '" alt="' . ':whitebeard' . '" />';
 
 	$b['texts'][] = ':shaka';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':shaka' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':shaka' . '" />';
 
 	$b['texts'][] = ':\\.../';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\.../' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\.../' . '" />';
 
 	$b['texts'][] = ':\\ooo/';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\ooo/' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/shaka.gif' . '" alt="' . ':\\ooo/' . '" />';
 
 	$b['texts'][] = ':headdesk';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':headdesk' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/headbang.gif' . '" alt="' . ':headdesk' . '" />';
 
 #These two are still in core, so oldcore isn't strictly right, but we don't want too many directories
 
 	$b['texts'][] = ':-d';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/laughing.gif' . '" alt="' . ':-d' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/laughing.gif' . '" alt="' . ':-d' . '" />';
 
 	$b['texts'][] = ':-o';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/surprised.gif' . '" alt="' . ':-o' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/oldcore/surprised.gif' . '" alt="' . ':-o' . '" />';
 
 # Regex killers - stick these at the bottom so they appear at the end of the English and 
 # at the start of $OtherLanguage.
 
 	$b['texts'][] = ':cool';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/cool/cool.gif' . '" alt="' . ':cool' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/cool/cool.gif' . '" alt="' . ':cool' . '" />';
 
 	$b['texts'][] = ':vomit';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/vomit.gif' . '" alt="' . ':vomit' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/disgust/vomit.gif' . '" alt="' . ':vomit' . '" />';
 
 	$b['texts'][] = ':golf';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/golf.gif' . '" alt="' . ':golf' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/golf.gif' . '" alt="' . ':golf' . '" />';
 	
 	$b['texts'][] = ':football';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/football.gif' . '" alt="' . ':football' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/football.gif' . '" alt="' . ':football' . '" />';
 
 	$b['texts'][] = ':tennis';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/sport/tennis.gif' . '" alt="' . ':tennis' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/sport/tennis.gif' . '" alt="' . ':tennis' . '" />';
 
 	$b['texts'][] = ':alpha';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alpha.png' . '" alt="' . ':alpha' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/alpha.png' . '" alt="' . ':alpha' . '" />';
 
 	$b['texts'][] = ':marine';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/marine.gif' . '" alt="' . ':marine' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/marine.gif' . '" alt="' . ':marine' . '" />';
 
 	$b['texts'][] = ':sabre';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/sabre.gif' . '" alt="' . ':sabre' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/sabre.gif' . '" alt="' . ':sabre' . '" />';
 
 	$b['texts'][] = ':tank';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/tank.gif' . '" alt="' . ':tank' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/tank.gif' . '" alt="' . ':tank' . '" />';
 
 	$b['texts'][] = ':viking';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/viking.gif' . '" alt="' . ':viking' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/viking.gif' . '" alt="' . ':viking' . '" />';
 
 	$b['texts'][] = ':gangs';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/fight/gangs.gif' . '" alt="' . ':gangs' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/fight/gangs.gif' . '" alt="' . ':gangs' . '" />';
 
 
 	$b['texts'][] = ':dj';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/dj.gif' . '" alt="' . ':dj' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/dj.gif' . '" alt="' . ':dj' . '" />';
 
 
 	$b['texts'][] = ':elvis';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/elvis.gif' . '" alt="' . ':elivs' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/elvis.gif' . '" alt="' . ':elivs' . '" />';
 
 	$b['texts'][] = ':violin';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smiley_pack/icons/music/violin.gif' . '" alt="' . ':violin' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smiley_pack/icons/music/violin.gif' . '" alt="' . ':violin' . '" />';
 }

--- a/smileybutton/smileybutton.php
+++ b/smileybutton/smileybutton.php
@@ -7,7 +7,7 @@
  */
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function smileybutton_install() {
 	//Register hooks
@@ -33,7 +33,7 @@ function show_button(Friendica\App $a, &$b) {
 		return;
 
 	// Disable for mobile because most mobiles have a smiley key for ther own
-	if (DI::mode()->isMobile() || DI::mode()->isMobile())
+	if (App::mode()->isMobile() || App::mode()->isMobile())
 		return;
 
 	/**
@@ -71,29 +71,29 @@ function show_button(Friendica\App $a, &$b) {
 	];
 
 	$icons = [
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-heart.gif" alt="<3" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-brokenheart.gif" alt="</3" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-smile.gif" alt=":-)" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-wink.gif" alt=";-)" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-frown.gif" alt=":-(" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-tongue-out.gif" alt=":-P" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-kiss.gif" alt=":-X" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-laughing.gif" alt=":-D" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-surprised.gif" alt=":-O" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-thumbsup.gif" alt="\\o/" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-Oo.gif" alt="O_o" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-cry.gif" alt=":\'(" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-foot-in-mouth.gif" alt=":-!" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-undecided.gif" alt=":-/" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-embarassed.gif" alt=":-[" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-cool.gif" alt="8-)" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/beer_mug.gif" alt=":beer" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/coffee.gif" alt=":coffee" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/smiley-facepalm.gif" alt=":facepalm" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/like.gif" alt=":like" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/dislike.gif" alt=":dislike" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/friendica-16.png" alt="~friendica" />',
-		'<img class="smiley" src="' . DI::baseUrl()->get() . '/images/rhash-16.png" alt="red" />'
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-heart.gif" alt="<3" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-brokenheart.gif" alt="</3" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-smile.gif" alt=":-)" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-wink.gif" alt=";-)" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-frown.gif" alt=":-(" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-tongue-out.gif" alt=":-P" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-kiss.gif" alt=":-X" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-laughing.gif" alt=":-D" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-surprised.gif" alt=":-O" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-thumbsup.gif" alt="\\o/" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-Oo.gif" alt="O_o" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-cry.gif" alt=":\'(" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-foot-in-mouth.gif" alt=":-!" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-undecided.gif" alt=":-/" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-embarassed.gif" alt=":-[" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-cool.gif" alt="8-)" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/beer_mug.gif" alt=":beer" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/coffee.gif" alt=":coffee" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/smiley-facepalm.gif" alt=":facepalm" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/like.gif" alt=":like" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/dislike.gif" alt=":dislike" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/friendica-16.png" alt="~friendica" />',
+		'<img class="smiley" src="' . App::baseUrl()->get() . '/images/rhash-16.png" alt="red" />'
 	];
 
 	// Call hooks to get aditional smileies from other addons
@@ -117,16 +117,16 @@ function show_button(Friendica\App $a, &$b) {
 	$css_file = 'addon/smileybutton/view/' . $a->getCurrentTheme() . '.css';
 	if (! file_exists($css_file))
 		$css_file = 'addon/smileybutton/view/default.css';
-	$css_url = DI::baseUrl()->get().'/'.$css_file;
+	$css_url = App::baseUrl()->get() . '/' . $css_file;
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="'.$css_url.'" media="all" />'."\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet" type="text/css" href="' . $css_url . '" media="all" />' . "\r\n";
 
 
 	//Get the correct image for the theme
 	$image = 'addon/smileybutton/view/' . $a->getCurrentTheme() . '.png';
 	if (! file_exists($image))
 		$image = 'addon/smileybutton/view/default.png';
-	$image_url = DI::baseUrl()->get().'/'.$image;
+	$image_url = App::baseUrl()->get() . '/' . $image;
 
 	//Add the hmtl and script to the page
 	$b = <<< EOT

--- a/smilies_adult/smilies_adult.php
+++ b/smilies_adult/smilies_adult.php
@@ -9,7 +9,7 @@
  * 
  */
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function smilies_adult_install() {
 	Hook::register('smilie', 'addon/smilies_adult/smilies_adult.php', 'smilies_adult_smilies');
@@ -24,21 +24,21 @@ function smilies_adult_uninstall() {
 function smilies_adult_smilies(&$a,&$b) {
 
 	$b['texts'][] = '(o)(o)';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smilies_adult/icons/tits.gif' . '" alt="' . '(o)(o)' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smilies_adult/icons/tits.gif' . '" alt="' . '(o)(o)' . '" />';
 
 	$b['texts'][] = '(.)(.)';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smilies_adult/icons/tits.gif' . '" alt="' . '(.)(.)' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smilies_adult/icons/tits.gif' . '" alt="' . '(.)(.)' . '" />';
 
 	$b['texts'][] = ':bong';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smilies_adult/icons/bong.gif' . '" alt="' . ':bong' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smilies_adult/icons/bong.gif' . '" alt="' . ':bong' . '" />';
 
 	$b['texts'][] = ':sperm';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smilies_adult/icons/sperm.gif' . '" alt="' . ':sperm' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smilies_adult/icons/sperm.gif' . '" alt="' . ':sperm' . '" />';
 
 	$b['texts'][] = ':drunk';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smilies_adult/icons/drunk.gif' . '" alt="' . ':drunk' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smilies_adult/icons/drunk.gif' . '" alt="' . ':drunk' . '" />';
 
 	$b['texts'][] = ':finger';
-	$b['icons'][] = '<img class="smiley" src="' . DI::baseUrl()->get() . '/addon/smilies_adult/icons/finger.gif' . '" alt="' . ':finger' . '" />';
+	$b['icons'][] = '<img class="smiley" src="' . App::baseUrl()->get() . '/addon/smilies_adult/icons/finger.gif' . '" alt="' . ':finger' . '" />';
 
 }

--- a/sniper/sniper.php
+++ b/sniper/sniper.php
@@ -10,7 +10,7 @@
  * Author: Mike Macgirvin <http://macgirvin.com/profile/mike>
  */
 use Friendica\Core\Hook;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function sniper_install() {
     Hook::register('app_menu', 'addon/sniper/sniper.php', 'sniper_app_menu');
@@ -30,7 +30,7 @@ function sniper_module() {}
 
 function sniper_content(&$a) {
 
-$baseurl = DI::baseUrl()->get() . '/addon/sniper';
+$baseurl = App::baseUrl()->get() . '/addon/sniper';
 
 $o .= <<< EOT
 <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://fpdownload.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=8,0,0,0" width="620" height="480" id="hotshotsniper" align="middle">

--- a/startpage/startpage.php
+++ b/startpage/startpage.php
@@ -9,8 +9,7 @@
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\Core\System;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function startpage_install() {
 	Hook::register('home_init', 'addon/startpage/startpage.php', 'startpage_home_init');
@@ -33,7 +32,7 @@ function startpage_home_init($a, $b)
 
 	$page = PConfig::get(local_user(), 'startpage', 'startpage');
 	if (strlen($page)) {
-		DI::baseUrl()->redirect($page);
+		App::baseUrl()->redirect($page);
 	}
 	return;
 }
@@ -72,7 +71,7 @@ function startpage_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/startpage/startpage.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/startpage/startpage.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -50,7 +50,6 @@ use Friendica\Core\PConfig;
 use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Group;
 use Friendica\Model\Item;
@@ -58,6 +57,7 @@ use Friendica\Model\ItemContent;
 use Friendica\Model\Photo;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
+use Friendica\Registry\App as A;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
@@ -168,7 +168,7 @@ function statusnet_settings_post(App $a, $post)
 					}
 				}
 			}
-			DI::baseUrl()->redirect('settings/connectors');
+			A::baseUrl()->redirect('settings/connectors');
 		} else {
 			if (isset($_POST['statusnet-consumersecret'])) {
 				//  check if we can reach the API of the GNU Social server
@@ -196,7 +196,7 @@ function statusnet_settings_post(App $a, $post)
 						notice(L10n::t('We could not contact the GNU Social API with the Path you entered.') . EOL);
 					}
 				}
-				DI::baseUrl()->redirect('settings/connectors');
+				A::baseUrl()->redirect('settings/connectors');
 			} else {
 				if (isset($_POST['statusnet-pin'])) {
 					//  if the user supplied us with a PIN from GNU Social, let the magic of OAuth happen
@@ -214,7 +214,7 @@ function statusnet_settings_post(App $a, $post)
 					PConfig::set(local_user(), 'statusnet', 'post', 1);
 					PConfig::set(local_user(), 'statusnet', 'post_taglinks', 1);
 					//  reload the Addon Settings page, if we don't do it see Bug #42
-					DI::baseUrl()->redirect('settings/connectors');
+					A::baseUrl()->redirect('settings/connectors');
 				} else {
 					//  if no PIN is supplied in the POST variables, the user has changed the setting
 					//  to post a dent for every new __public__ posting to the wall
@@ -239,7 +239,7 @@ function statusnet_settings(App $a, &$s)
 	if (!local_user()) {
 		return;
 	}
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/statusnet/statusnet.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/statusnet/statusnet.css' . '" media="all" />' . "\r\n";
 	/*	 * *
 	 * 1) Check that we have a base api url and a consumer key & secret
 	 * 2) If no OAuthtoken & stuff is present, generate button to get some
@@ -736,7 +736,7 @@ function statusnet_prepare_body(App $a, &$b)
 		}
 
 		$item = $b["item"];
-		$item["plink"] = DI::baseUrl()->get() . "/display/" . $item["guid"];
+		$item["plink"] = A::baseUrl()->get() . "/display/" . $item["guid"];
 
 		$condition = ['uri' => $item["thr-parent"], 'uid' => local_user()];
 		$orig_post = Item::selectFirst(['author-link', 'uri'], $condition);
@@ -838,7 +838,7 @@ function statusnet_fetchtimeline(App $a, $uid)
 		$application_name = Config::get('statusnet', 'application_name');
 	}
 	if ($application_name == "") {
-		$application_name = DI::baseUrl()->getHostname();
+		$application_name = A::baseUrl()->getHostname();
 	}
 
 	$connection = new StatusNetOAuth($api, $ckey, $csecret, $otoken, $osecret);
@@ -1529,7 +1529,7 @@ function statusnet_convertmsg(App $a, $body, $no_tags = false)
 			if ($mtch[1] == "#") {
 				// Replacing the hash tags that are directed to the GNU Social server with internal links
 				$snhash = "#[url=" . $mtch[2] . "]" . $mtch[3] . "[/url]";
-				$frdchash = '#[url=' . DI::baseUrl()->get() . '/search?tag=' . $mtch[3] . ']' . $mtch[3] . '[/url]';
+				$frdchash = '#[url=' . A::baseUrl()->get() . '/search?tag=' . $mtch[3] . ']' . $mtch[3] . '[/url]';
 				$body = str_replace($snhash, $frdchash, $body);
 
 				$str_tags .= $frdchash;

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -57,7 +57,7 @@ use Friendica\Model\ItemContent;
 use Friendica\Model\Photo;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
@@ -168,7 +168,7 @@ function statusnet_settings_post(App $a, $post)
 					}
 				}
 			}
-			A::baseUrl()->redirect('settings/connectors');
+			AppR::baseUrl()->redirect('settings/connectors');
 		} else {
 			if (isset($_POST['statusnet-consumersecret'])) {
 				//  check if we can reach the API of the GNU Social server
@@ -196,7 +196,7 @@ function statusnet_settings_post(App $a, $post)
 						notice(L10n::t('We could not contact the GNU Social API with the Path you entered.') . EOL);
 					}
 				}
-				A::baseUrl()->redirect('settings/connectors');
+				AppR::baseUrl()->redirect('settings/connectors');
 			} else {
 				if (isset($_POST['statusnet-pin'])) {
 					//  if the user supplied us with a PIN from GNU Social, let the magic of OAuth happen
@@ -214,7 +214,7 @@ function statusnet_settings_post(App $a, $post)
 					PConfig::set(local_user(), 'statusnet', 'post', 1);
 					PConfig::set(local_user(), 'statusnet', 'post_taglinks', 1);
 					//  reload the Addon Settings page, if we don't do it see Bug #42
-					A::baseUrl()->redirect('settings/connectors');
+					AppR::baseUrl()->redirect('settings/connectors');
 				} else {
 					//  if no PIN is supplied in the POST variables, the user has changed the setting
 					//  to post a dent for every new __public__ posting to the wall
@@ -239,7 +239,7 @@ function statusnet_settings(App $a, &$s)
 	if (!local_user()) {
 		return;
 	}
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/statusnet/statusnet.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/statusnet/statusnet.css' . '" media="all" />' . "\r\n";
 	/*	 * *
 	 * 1) Check that we have a base api url and a consumer key & secret
 	 * 2) If no OAuthtoken & stuff is present, generate button to get some
@@ -736,7 +736,7 @@ function statusnet_prepare_body(App $a, &$b)
 		}
 
 		$item = $b["item"];
-		$item["plink"] = A::baseUrl()->get() . "/display/" . $item["guid"];
+		$item["plink"] = AppR::baseUrl()->get() . "/display/" . $item["guid"];
 
 		$condition = ['uri' => $item["thr-parent"], 'uid' => local_user()];
 		$orig_post = Item::selectFirst(['author-link', 'uri'], $condition);
@@ -838,7 +838,7 @@ function statusnet_fetchtimeline(App $a, $uid)
 		$application_name = Config::get('statusnet', 'application_name');
 	}
 	if ($application_name == "") {
-		$application_name = A::baseUrl()->getHostname();
+		$application_name = AppR::baseUrl()->getHostname();
 	}
 
 	$connection = new StatusNetOAuth($api, $ckey, $csecret, $otoken, $osecret);
@@ -1529,7 +1529,7 @@ function statusnet_convertmsg(App $a, $body, $no_tags = false)
 			if ($mtch[1] == "#") {
 				// Replacing the hash tags that are directed to the GNU Social server with internal links
 				$snhash = "#[url=" . $mtch[2] . "]" . $mtch[3] . "[/url]";
-				$frdchash = '#[url=' . A::baseUrl()->get() . '/search?tag=' . $mtch[3] . ']' . $mtch[3] . '[/url]';
+				$frdchash = '#[url=' . AppR::baseUrl()->get() . '/search?tag=' . $mtch[3] . ']' . $mtch[3] . '[/url]';
 				$body = str_replace($snhash, $frdchash, $body);
 
 				$str_tags .= $frdchash;

--- a/superblock/superblock.php
+++ b/superblock/superblock.php
@@ -9,7 +9,7 @@
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\Strings;
 
 function superblock_install()
@@ -38,7 +38,7 @@ function superblock_addon_settings(&$a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/superblock/superblock.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/superblock/superblock.css' . '" media="all" />' . "\r\n";
 
 	$words = PConfig::get(local_user(), 'system', 'blocked');
 	if (!$words) {
@@ -112,7 +112,7 @@ function superblock_conversation_start(&$a, &$b)
 	if ($words) {
 		$a->data['superblock'] = explode(',', $words);
 	}
-	DI::page()['htmlhead'] .= <<< EOT
+	App::page()['htmlhead'] .= <<< EOT
 
 <script>
 function superblockBlock(author) {

--- a/testdrive/testdrive.php
+++ b/testdrive/testdrive.php
@@ -12,8 +12,8 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\Search;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\User;
+use Friendica\Registry\App as A;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 
@@ -77,8 +77,8 @@ function testdrive_cron($a,$b) {
 				'to_name'      => $rr['username'],
 				'to_email'     => $rr['email'],
 				'source_name'  => L10n::t('Administrator'),
-				'source_link'  => DI::baseUrl()->get(),
-				'source_photo' => DI::baseUrl()->get() . '/images/person-80.jpg',
+				'source_link'  => A::baseUrl()->get(),
+				'source_photo' => A::baseUrl()->get() . '/images/person-80.jpg',
 			]);
 
 			q("update user set expire_notification_sent = '%s' where uid = %d",
@@ -100,7 +100,7 @@ function testdrive_cron($a,$b) {
 function testdrive_enotify(&$a, &$b) {
     if (!empty($b['params']) && $b['params']['type'] == NOTIFY_SYSTEM
 		&& !empty($b['params']['system_type']) && $b['params']['system_type'] === 'testdrive_expire') {
-        $b['itemlink'] = DI::baseUrl()->get();
+        $b['itemlink'] = A::baseUrl()->get();
         $b['epreamble'] = $b['preamble'] = L10n::t('Your account on %s will expire in a few days.', Config::get('system', 'sitename'));
         $b['subject'] = L10n::t('Your Friendica test account is about to expire.');
         $b['body'] = L10n::t("Hi %1\$s,\n\nYour test account on %2\$s will expire in less than five days. We hope you enjoyed this test drive and use this opportunity to find a permanent Friendica website for your integrated social communications. A list of public sites is available at %s/siteinfo - and for more information on setting up your own Friendica server please see the Friendica project website at https://friendi.ca.", $b['params']['to_name'], "[url=".Config::get('system', 'url')."]".Config::get('config', 'sitename')."[/url]", Search::getGlobalDirectory());

--- a/testdrive/testdrive.php
+++ b/testdrive/testdrive.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Search;
 use Friendica\Database\DBA;
 use Friendica\Model\User;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 
@@ -77,8 +77,8 @@ function testdrive_cron($a,$b) {
 				'to_name'      => $rr['username'],
 				'to_email'     => $rr['email'],
 				'source_name'  => L10n::t('Administrator'),
-				'source_link'  => A::baseUrl()->get(),
-				'source_photo' => A::baseUrl()->get() . '/images/person-80.jpg',
+				'source_link'  => AppR::baseUrl()->get(),
+				'source_photo' => AppR::baseUrl()->get() . '/images/person-80.jpg',
 			]);
 
 			q("update user set expire_notification_sent = '%s' where uid = %d",
@@ -100,7 +100,7 @@ function testdrive_cron($a,$b) {
 function testdrive_enotify(&$a, &$b) {
     if (!empty($b['params']) && $b['params']['type'] == NOTIFY_SYSTEM
 		&& !empty($b['params']['system_type']) && $b['params']['system_type'] === 'testdrive_expire') {
-        $b['itemlink'] = A::baseUrl()->get();
+        $b['itemlink'] = AppR::baseUrl()->get();
         $b['epreamble'] = $b['preamble'] = L10n::t('Your account on %s will expire in a few days.', Config::get('system', 'sitename'));
         $b['subject'] = L10n::t('Your Friendica test account is about to expire.');
         $b['body'] = L10n::t("Hi %1\$s,\n\nYour test account on %2\$s will expire in less than five days. We hope you enjoyed this test drive and use this opportunity to find a permanent Friendica website for your integrated social communications. A list of public sites is available at %s/siteinfo - and for more information on setting up your own Friendica server please see the Friendica project website at https://friendi.ca.", $b['params']['to_name'], "[url=".Config::get('system', 'url')."]".Config::get('config', 'sitename')."[/url]", Search::getGlobalDirectory());

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -18,7 +18,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Strings;
 
 function tumblr_install()
@@ -110,7 +110,7 @@ function tumblr_connect(App $a)
 
 	// The callback URL is the script that gets called after the user authenticates with tumblr
 	// In this example, it would be the included callback.php
-	$callback_url = A::baseUrl()->get() . "/tumblr/callback";
+	$callback_url = AppR::baseUrl()->get() . "/tumblr/callback";
 
 	// Let's begin.  First we need a Request Token.  The request token is required to send the user
 	// to Tumblr's login page.
@@ -189,7 +189,7 @@ function tumblr_callback(App $a)
 	PConfig::set(local_user(), "tumblr", "oauth_token_secret", $access_token['oauth_token_secret']);
 
 	$o = L10n::t("You are now authenticated to tumblr.");
-	$o .= '<br /><a href="' . A::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
+	$o .= '<br /><a href="' . AppR::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
 
 	return $o;
 }
@@ -220,7 +220,7 @@ function tumblr_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/tumblr/tumblr.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/tumblr/tumblr.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -243,7 +243,7 @@ function tumblr_settings(App $a, &$s)
 	$s .= '</span>';
 
 	$s .= '<div id="tumblr-username-wrapper">';
-	$s .= '<a href="' . A::baseUrl()->get() . '/tumblr/connect">' . L10n::t("(Re-)Authenticate your tumblr page") . '</a>';
+	$s .= '<a href="' . AppR::baseUrl()->get() . '/tumblr/connect">' . L10n::t("(Re-)Authenticate your tumblr page") . '</a>';
 	$s .= '</div><div class="clear"></div>';
 
 	$s .= '<div id="tumblr-enable-wrapper">';

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -18,7 +18,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Strings;
 
 function tumblr_install()
@@ -110,7 +110,7 @@ function tumblr_connect(App $a)
 
 	// The callback URL is the script that gets called after the user authenticates with tumblr
 	// In this example, it would be the included callback.php
-	$callback_url = DI::baseUrl()->get()."/tumblr/callback";
+	$callback_url = A::baseUrl()->get() . "/tumblr/callback";
 
 	// Let's begin.  First we need a Request Token.  The request token is required to send the user
 	// to Tumblr's login page.
@@ -189,7 +189,7 @@ function tumblr_callback(App $a)
 	PConfig::set(local_user(), "tumblr", "oauth_token_secret", $access_token['oauth_token_secret']);
 
 	$o = L10n::t("You are now authenticated to tumblr.");
-	$o .= '<br /><a href="' . DI::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
+	$o .= '<br /><a href="' . A::baseUrl()->get() . '/settings/connectors">' . L10n::t("return to the connector page") . '</a>';
 
 	return $o;
 }
@@ -220,7 +220,7 @@ function tumblr_settings(App $a, &$s)
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/tumblr/tumblr.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/tumblr/tumblr.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 
@@ -243,7 +243,7 @@ function tumblr_settings(App $a, &$s)
 	$s .= '</span>';
 
 	$s .= '<div id="tumblr-username-wrapper">';
-	$s .= '<a href="'.DI::baseUrl()->get().'/tumblr/connect">'.L10n::t("(Re-)Authenticate your tumblr page").'</a>';
+	$s .= '<a href="' . A::baseUrl()->get() . '/tumblr/connect">' . L10n::t("(Re-)Authenticate your tumblr page") . '</a>';
 	$s .= '</div><div class="clear"></div>';
 
 	$s .= '<div id="tumblr-enable-wrapper">';

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -78,7 +78,6 @@ use Friendica\Core\Protocol;
 use Friendica\Core\Renderer;
 use Friendica\Core\Worker;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\Contact;
 use Friendica\Model\Conversation;
 use Friendica\Model\Group;
@@ -86,6 +85,7 @@ use Friendica\Model\Item;
 use Friendica\Model\ItemContent;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
+use Friendica\Registry\App as A;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
@@ -264,7 +264,7 @@ function twitter_settings_post(App $a)
 				info($e->getMessage());
 			}
 			//  reload the Addon Settings page, if we don't do it see Bug #42
-			DI::baseUrl()->redirect('settings/connectors');
+			A::baseUrl()->redirect('settings/connectors');
 		} else {
 			//  if no PIN is supplied in the POST variables, the user has changed the setting
 			//  to post a tweet for every new __public__ posting to the wall
@@ -288,7 +288,7 @@ function twitter_settings(App $a, &$s)
 	if (!local_user()) {
 		return;
 	}
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/twitter/twitter.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/twitter/twitter.css' . '" media="all" />' . "\r\n";
 	/*	 * *
 	 * 1) Check that we have global consumer key & secret
 	 * 2) If no OAuthtoken & stuff is present, generate button to get some
@@ -839,7 +839,7 @@ function twitter_prepare_body(App $a, array &$b)
 	if ($b["preview"]) {
 		$max_char = 280;
 		$item = $b["item"];
-		$item["plink"] = DI::baseUrl()->get() . "/display/" . $item["guid"];
+		$item["plink"] = A::baseUrl()->get() . "/display/" . $item["guid"];
 
 		$condition = ['uri' => $item["thr-parent"], 'uid' => local_user()];
 		$orig_post = Item::selectFirst(['author-link'], $condition);
@@ -940,7 +940,7 @@ function twitter_fetchtimeline(App $a, $uid)
 	$application_name = Config::get('twitter', 'application_name');
 
 	if ($application_name == "") {
-		$application_name = DI::baseUrl()->getHostname();
+		$application_name = A::baseUrl()->getHostname();
 	}
 
 	$has_picture = false;
@@ -1146,7 +1146,7 @@ function twitter_expand_entities(App $a, $body, $item, $picture)
 	$tags_arr = [];
 
 	foreach ($item->entities->hashtags AS $hashtag) {
-		$url = '#[url=' . DI::baseUrl()->get() . '/search?tag=' . $hashtag->text . ']' . $hashtag->text . '[/url]';
+		$url = '#[url=' . A::baseUrl()->get() . '/search?tag=' . $hashtag->text . ']' . $hashtag->text . '[/url]';
 		$tags_arr['#' . $hashtag->text] = $url;
 		$body = str_replace('#' . $hashtag->text, $url, $body);
 	}
@@ -1279,7 +1279,7 @@ function twitter_expand_entities(App $a, $body, $item, $picture)
 				}
 
 				$basetag = str_replace('_', ' ', substr($tag, 1));
-				$url = '#[url=' . DI::baseUrl()->get() . '/search?tag=' . $basetag . ']' . $basetag . '[/url]';
+				$url = '#[url=' . A::baseUrl()->get() . '/search?tag=' . $basetag . ']' . $basetag . '[/url]';
 				$body = str_replace($tag, $url, $body);
 				$tags_arr['#' . $basetag] = $url;
 			} elseif (strpos($tag, '@') === 0) {
@@ -1633,7 +1633,7 @@ function twitter_fetchhometimeline(App $a, $uid)
 	$application_name = Config::get('twitter', 'application_name');
 
 	if ($application_name == "") {
-		$application_name = DI::baseUrl()->getHostname();
+		$application_name = A::baseUrl()->getHostname();
 	}
 
 	$connection = new TwitterOAuth($ckey, $csecret, $otoken, $osecret);

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -85,7 +85,7 @@ use Friendica\Model\Item;
 use Friendica\Model\ItemContent;
 use Friendica\Model\User;
 use Friendica\Protocol\Activity;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\Images;
@@ -264,7 +264,7 @@ function twitter_settings_post(App $a)
 				info($e->getMessage());
 			}
 			//  reload the Addon Settings page, if we don't do it see Bug #42
-			A::baseUrl()->redirect('settings/connectors');
+			AppR::baseUrl()->redirect('settings/connectors');
 		} else {
 			//  if no PIN is supplied in the POST variables, the user has changed the setting
 			//  to post a tweet for every new __public__ posting to the wall
@@ -288,7 +288,7 @@ function twitter_settings(App $a, &$s)
 	if (!local_user()) {
 		return;
 	}
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/twitter/twitter.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/twitter/twitter.css' . '" media="all" />' . "\r\n";
 	/*	 * *
 	 * 1) Check that we have global consumer key & secret
 	 * 2) If no OAuthtoken & stuff is present, generate button to get some
@@ -839,7 +839,7 @@ function twitter_prepare_body(App $a, array &$b)
 	if ($b["preview"]) {
 		$max_char = 280;
 		$item = $b["item"];
-		$item["plink"] = A::baseUrl()->get() . "/display/" . $item["guid"];
+		$item["plink"] = AppR::baseUrl()->get() . "/display/" . $item["guid"];
 
 		$condition = ['uri' => $item["thr-parent"], 'uid' => local_user()];
 		$orig_post = Item::selectFirst(['author-link'], $condition);
@@ -940,7 +940,7 @@ function twitter_fetchtimeline(App $a, $uid)
 	$application_name = Config::get('twitter', 'application_name');
 
 	if ($application_name == "") {
-		$application_name = A::baseUrl()->getHostname();
+		$application_name = AppR::baseUrl()->getHostname();
 	}
 
 	$has_picture = false;
@@ -1146,7 +1146,7 @@ function twitter_expand_entities(App $a, $body, $item, $picture)
 	$tags_arr = [];
 
 	foreach ($item->entities->hashtags AS $hashtag) {
-		$url = '#[url=' . A::baseUrl()->get() . '/search?tag=' . $hashtag->text . ']' . $hashtag->text . '[/url]';
+		$url = '#[url=' . AppR::baseUrl()->get() . '/search?tag=' . $hashtag->text . ']' . $hashtag->text . '[/url]';
 		$tags_arr['#' . $hashtag->text] = $url;
 		$body = str_replace('#' . $hashtag->text, $url, $body);
 	}
@@ -1279,7 +1279,7 @@ function twitter_expand_entities(App $a, $body, $item, $picture)
 				}
 
 				$basetag = str_replace('_', ' ', substr($tag, 1));
-				$url = '#[url=' . A::baseUrl()->get() . '/search?tag=' . $basetag . ']' . $basetag . '[/url]';
+				$url = '#[url=' . AppR::baseUrl()->get() . '/search?tag=' . $basetag . ']' . $basetag . '[/url]';
 				$body = str_replace($tag, $url, $body);
 				$tags_arr['#' . $basetag] = $url;
 			} elseif (strpos($tag, '@') === 0) {
@@ -1633,7 +1633,7 @@ function twitter_fetchhometimeline(App $a, $uid)
 	$application_name = Config::get('twitter', 'application_name');
 
 	if ($application_name == "") {
-		$application_name = A::baseUrl()->getHostname();
+		$application_name = AppR::baseUrl()->getHostname();
 	}
 
 	$connection = new TwitterOAuth($ckey, $csecret, $otoken, $osecret);

--- a/twitter/twitter_sync.php
+++ b/twitter/twitter_sync.php
@@ -2,10 +2,11 @@
 
 use Friendica\Core\Config;
 use Friendica\Core\Logger;
+use Friendica\Registry\DI;
 
 function twitter_sync_run($argv, $argc)
 {
-	$a = Friendica\DI::app();
+	$a = DI::app();
 
 	require_once 'addon/twitter/twitter.php';
 

--- a/viewsrc/viewsrc.php
+++ b/viewsrc/viewsrc.php
@@ -8,9 +8,9 @@
  */
 use Friendica\Core\Hook;
 use Friendica\Core\L10n;
-use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Database\DBA;
+use Friendica\Registry\App;
 
 function viewsrc_install() {
 	Hook::register('item_photo_menu', 'addon/viewsrc/viewsrc.php', 'viewsrc_item_photo_menu');
@@ -25,7 +25,7 @@ function viewsrc_uninstall() {
 }
 
 function viewsrc_page_end(&$a, &$o){
-	DI::page()['htmlhead'] .= <<< EOS
+	App::page()['htmlhead'] .= <<< EOS
 	<script>
 		$(function(){
 			$('a[href*="/viewsrc/"]').each(function() {
@@ -53,7 +53,7 @@ function viewsrc_item_photo_menu(&$a, &$b)
 		$item_id = $b['item']['id'];
 	}
 
-	$b['menu'] = array_merge([L10n::t('View Source') => DI::baseUrl()->get() . '/viewsrc/'. $item_id], $b['menu']);
+	$b['menu'] = array_merge([L10n::t('View Source') => App::baseUrl()->get() . '/viewsrc/' . $item_id], $b['menu']);
 
 	//if((! local_user()) || (local_user() != $b['item']['uid']))
 	//	return;

--- a/widgets/widget_friendheader.php
+++ b/widgets/widget_friendheader.php
@@ -2,7 +2,7 @@
 
 use Friendica\Content\Text\HTML;
 use Friendica\Core\L10n;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function friendheader_widget_name()
 {
@@ -48,7 +48,7 @@ function friendheader_widget_content(&$a, $conf)
 
 	</style>";
 	$o .= _abs_url(HTML::contactBlock());
-	$o .= "<a href='".DI::baseUrl()->get().'/profile/'.$a->profile['nickname']."' target=new>". L10n::t('Get added to this list!') ."</a>";
+	$o .= "<a href='" . App::baseUrl()->get() . '/profile/' . $a->profile['nickname'] . "' target=new>" . L10n::t('Get added to this list!') . "</a>";
 
 	return $o;
 }

--- a/widgets/widget_friends.php
+++ b/widgets/widget_friends.php
@@ -2,7 +2,7 @@
 
 use Friendica\Content\Text\HTML;
 use Friendica\Core\L10n;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function friends_widget_name()
 {
@@ -50,6 +50,6 @@ function friends_widget_content(&$a, $conf)
 
 	</style>";
 	$o .= _abs_url(HTML::contactBlock());
-	$o .= "<a href='".DI::baseUrl()->get().'/profile/'.$a->profile['nickname']."'>". L10n::t('Connect on Friendica!') ."</a>";
+	$o .= "<a href='" . App::baseUrl()->get() . '/profile/' . $a->profile['nickname'] . "'>" . L10n::t('Connect on Friendica!') . "</a>";
 	return $o;
 }

--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -13,7 +13,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Registry\App;
 
 function widgets_install() {
 	Hook::register('addon_settings', 'addon/widgets/widgets.php', 'widgets_settings');
@@ -77,7 +77,7 @@ function widgets_module() {
 }
 
 function _abs_url($s){
-	return preg_replace("|href=(['\"])([^h][^t][^t][^p])|", "href=\$1" . DI::baseUrl()->get() . "/\$2", $s);
+	return preg_replace("|href=(['\"])([^h][^t][^t][^p])|", "href=\$1" . App::baseUrl()->get() . "/\$2", $s);
 }
 
 function _randomAlphaNum($length){
@@ -127,7 +127,7 @@ function widgets_content(&$a) {
 		if (isset($_GET['p']) && local_user()==$conf['uid'] ) {
 			$o .= "<style>.f9k_widget { float: left;border:1px solid black; }</style>";
 			$o .= "<h1>Preview Widget</h1>";
-			$o .= '<a href="'.DI::baseUrl()->get().'/settings/addon">'. L10n::t("Addon Settings") .'</a>';
+			$o .= '<a href="' . App::baseUrl()->get() . '/settings/addon">' . L10n::t("Addon Settings") . '</a>';
 
 			$o .=  "<h4>".call_user_func($a->argv[1].'_widget_name')."</h4>";
 			$o .=  call_user_func($a->argv[1].'_widget_help');
@@ -143,10 +143,10 @@ function widgets_content(&$a) {
 
 		$script = file_get_contents(dirname(__file__)."/widgets.js");
 		$o .= Renderer::replaceMacros($script, [
-			'$entrypoint' => DI::baseUrl()->get()."/widgets/".$a->argv[1]."/cb/",
+			'$entrypoint' => App::baseUrl()->get() . "/widgets/" . $a->argv[1] . "/cb/",
 			'$key' => $conf['key'],
 			'$widget_id' => 'f9a_'.$a->argv[1]."_"._randomAlphaNum(6),
-			'$loader' => DI::baseUrl()->get()."/images/rotator.gif",
+			'$loader' => App::baseUrl()->get() . "/images/rotator.gif",
 			'$args' => (isset($_GET['a'])?$_GET['a']:''),
 			'$width' => $widget_size[0],
 			'$height' => $widget_size[1],
@@ -164,7 +164,7 @@ function widgets_content(&$a) {
 			<h4>Copy and paste this code</h4>
 			<code>"
 
-			.htmlspecialchars('<script src="'.DI::baseUrl()->get().'/widgets/'.$a->argv[1].'?k='.$conf['key'])
+			.htmlspecialchars('<script src="' . App::baseUrl()->get() . '/widgets/' . $a->argv[1] . '?k=' . $conf['key'])
 			.$jsargs
 			.htmlspecialchars('"></script>')
 			."</code>";

--- a/windowsphonepush/windowsphonepush.php
+++ b/windowsphonepush/windowsphonepush.php
@@ -474,7 +474,7 @@ function windowsphonepush_login(App $a)
 		die('This api requires login');
 	}
 
-	A::auth()->setForUser($a, $record);
+	AppR::auth()->setForUser($a, $record);
 	Core::session()->set('allow_api', true);
 	Hook::callAll('logged_in', $a->user);
 }

--- a/windowsphonepush/windowsphonepush.php
+++ b/windowsphonepush/windowsphonepush.php
@@ -34,9 +34,10 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
-use Friendica\DI;
 use Friendica\Model\Item;
 use Friendica\Model\User;
+use Friendica\Registry\App as A;
+use Friendica\Registry\Core;
 
 function windowsphonepush_install()
 {
@@ -107,7 +108,7 @@ function windowsphonepush_settings(&$a, &$s)
 	}
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/windowsphonepush/windowsphonepush.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/windowsphonepush/windowsphonepush.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 	$enabled = PConfig::get(local_user(), 'windowsphonepush', 'enable');
@@ -473,7 +474,7 @@ function windowsphonepush_login(App $a)
 		die('This api requires login');
 	}
 
-	DI::auth()->setForUser($a, $record);
-	DI::session()->set('allow_api', true);
+	A::auth()->setForUser($a, $record);
+	Core::session()->set('allow_api', true);
 	Hook::callAll('logged_in', $a->user);
 }

--- a/windowsphonepush/windowsphonepush.php
+++ b/windowsphonepush/windowsphonepush.php
@@ -36,7 +36,7 @@ use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
 use Friendica\Model\Item;
 use Friendica\Model\User;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Registry\Core;
 
 function windowsphonepush_install()
@@ -108,7 +108,7 @@ function windowsphonepush_settings(&$a, &$s)
 	}
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/windowsphonepush/windowsphonepush.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/windowsphonepush/windowsphonepush.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 	$enabled = PConfig::get(local_user(), 'windowsphonepush', 'enable');

--- a/wppost/wppost.php
+++ b/wppost/wppost.php
@@ -13,7 +13,7 @@ use Friendica\Core\L10n;
 use Friendica\Core\Logger;
 use Friendica\Core\PConfig;
 use Friendica\Database\DBA;
-use Friendica\DI;
+use Friendica\Registry\App;
 use Friendica\Util\Network;
 use Friendica\Util\Strings;
 use Friendica\Util\XML;
@@ -70,7 +70,7 @@ function wppost_settings(&$a,&$s) {
 
 	/* Add our stylesheet to the page so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/wppost/wppost.css' . '" media="all" />' . "\r\n";
+	App::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . App::baseUrl()->get() . '/addon/wppost/wppost.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variables */
 

--- a/xmpp/xmpp.php
+++ b/xmpp/xmpp.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\DI;
+use Friendica\Registry\App as A;
 use Friendica\Util\Strings;
 
 function xmpp_install()
@@ -53,7 +53,7 @@ function xmpp_addon_settings(App $a, &$s)
 
 	/* Add our stylesheet to the xmpp so we can make our settings look nice */
 
-	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/xmpp/xmpp.css' . '" media="all" />' . "\r\n";
+	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/xmpp/xmpp.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 
@@ -143,7 +143,7 @@ function xmpp_converse(App $a)
 		return;
 	}
 
-	if (DI::mode()->isMobile() || DI::mode()->isMobile()) {
+	if (A::mode()->isMobile() || A::mode()->isMobile()) {
 		return;
 	}
 
@@ -151,12 +151,12 @@ function xmpp_converse(App $a)
 		return;
 	}
 
-	if (in_array(DI::args()->getQueryString(), ["admin/federation/"])) {
+	if (in_array(A::args()->getQueryString(), ["admin/federation/"])) {
 		return;
 	}
 
-	DI::page()['htmlhead'] .= '<link type="text/css" rel="stylesheet" media="screen" href="addon/xmpp/converse/css/converse.css" />' . "\n";
-	DI::page()['htmlhead'] .= '<script src="addon/xmpp/converse/builds/converse.min.js"></script>' . "\n";
+	A::page()['htmlhead'] .= '<link type="text/css" rel="stylesheet" media="screen" href="addon/xmpp/converse/css/converse.css" />' . "\n";
+	A::page()['htmlhead'] .= '<script src="addon/xmpp/converse/builds/converse.min.js"></script>' . "\n";
 
 	if (Config::get("xmpp", "central_userbase") && !PConfig::get(local_user(), "xmpp", "individual")) {
 		$bosh_proxy = Config::get("xmpp", "bosh_proxy");
@@ -168,7 +168,7 @@ function xmpp_converse(App $a)
 			PConfig::set(local_user(), "xmpp", "password", $password);
 		}
 
-		$jid = $a->user["nickname"] . "@" . DI::baseUrl()->getHostname() . "/converse-" . Strings::getRandomHex(5);
+		$jid = $a->user["nickname"] . "@" . A::baseUrl()->getHostname() . "/converse-" . Strings::getRandomHex(5);
 
 		$auto_login = "auto_login: true,
 			authentication: 'login',
@@ -216,7 +216,7 @@ function xmpp_converse(App $a)
 					xhr_user_search: false
 				});\n";
 
-	DI::page()['htmlhead'] .= "<script>
+	A::page()['htmlhead'] .= "<script>
 					require(['converse'], function (converse) {
 						$initialize
 						converse.listen.on('ready', function (event) {

--- a/xmpp/xmpp.php
+++ b/xmpp/xmpp.php
@@ -13,7 +13,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\L10n;
 use Friendica\Core\PConfig;
 use Friendica\Core\Renderer;
-use Friendica\Registry\App as A;
+use Friendica\Registry\App as AppR;
 use Friendica\Util\Strings;
 
 function xmpp_install()
@@ -53,7 +53,7 @@ function xmpp_addon_settings(App $a, &$s)
 
 	/* Add our stylesheet to the xmpp so we can make our settings look nice */
 
-	A::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . A::baseUrl()->get() . '/addon/xmpp/xmpp.css' . '" media="all" />' . "\r\n";
+	AppR::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . AppR::baseUrl()->get() . '/addon/xmpp/xmpp.css' . '" media="all" />' . "\r\n";
 
 	/* Get the current state of our config variable */
 
@@ -143,7 +143,7 @@ function xmpp_converse(App $a)
 		return;
 	}
 
-	if (A::mode()->isMobile() || A::mode()->isMobile()) {
+	if (AppR::mode()->isMobile() || AppR::mode()->isMobile()) {
 		return;
 	}
 
@@ -151,12 +151,12 @@ function xmpp_converse(App $a)
 		return;
 	}
 
-	if (in_array(A::args()->getQueryString(), ["admin/federation/"])) {
+	if (in_array(AppR::args()->getQueryString(), ["admin/federation/"])) {
 		return;
 	}
 
-	A::page()['htmlhead'] .= '<link type="text/css" rel="stylesheet" media="screen" href="addon/xmpp/converse/css/converse.css" />' . "\n";
-	A::page()['htmlhead'] .= '<script src="addon/xmpp/converse/builds/converse.min.js"></script>' . "\n";
+	AppR::page()['htmlhead'] .= '<link type="text/css" rel="stylesheet" media="screen" href="addon/xmpp/converse/css/converse.css" />' . "\n";
+	AppR::page()['htmlhead'] .= '<script src="addon/xmpp/converse/builds/converse.min.js"></script>' . "\n";
 
 	if (Config::get("xmpp", "central_userbase") && !PConfig::get(local_user(), "xmpp", "individual")) {
 		$bosh_proxy = Config::get("xmpp", "bosh_proxy");
@@ -168,7 +168,7 @@ function xmpp_converse(App $a)
 			PConfig::set(local_user(), "xmpp", "password", $password);
 		}
 
-		$jid = $a->user["nickname"] . "@" . A::baseUrl()->getHostname() . "/converse-" . Strings::getRandomHex(5);
+		$jid = $a->user["nickname"] . "@" . AppR::baseUrl()->getHostname() . "/converse-" . Strings::getRandomHex(5);
 
 		$auto_login = "auto_login: true,
 			authentication: 'login',
@@ -216,7 +216,7 @@ function xmpp_converse(App $a)
 					xhr_user_search: false
 				});\n";
 
-	A::page()['htmlhead'] .= "<script>
+	AppR::page()['htmlhead'] .= "<script>
 					require(['converse'], function (converse) {
 						$initialize
 						converse.listen.on('ready', function (event) {


### PR DESCRIPTION
- Replaces all `@method static` annotations with concrete methods
- Split the methods based on their namespace in different Registry (sub-)classes for better finding
- Rework some tests, which weren't working the "right way"
- Fixing some places in the code where `Cache` namespace was missing