### PR TITLE
Fixing some notices

### DIFF
--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -672,7 +672,7 @@ function pumpio_action(App $a, $uid, $uri, $action, $content = "")
 	if ($success) {
 		Logger::log('pumpio_action '.$username.' '.$action.': success '.$uri);
 	} else {
-		Logger::log('pumpio_action '.$username.' '.$action.': general error: '.$uri.' '.print_r($user, true));
+		Logger::log('pumpio_action '.$username.' '.$action.': general error: '.$uri);
 		Worker::defer();
 	}
 }

--- a/statusnet/library/statusnetoauth.php
+++ b/statusnet/library/statusnetoauth.php
@@ -15,6 +15,9 @@ class StatusNetOAuth extends TwitterOAuth
 	function get_maxlength()
 	{
 		$config = $this->get($this->host . 'statusnet/config.json');
+		if (empty($config)) {
+			return 0;
+		}
 		return $config->site->textlimit;
 	}
 

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1978,6 +1978,10 @@ function twitter_update_mentions($body)
 
 function twitter_convert_share(array $attributes, array $author_contact, $content, $is_quote_share)
 {
+	if (empty($contact)) {
+		return $content . "\n\n" . $attributes['link'];
+	}
+
 	if ($author_contact['network'] == Protocol::TWITTER) {
 		$mention = '@' . $author_contact['nick'];
 	} else {


### PR DESCRIPTION
- Pumpio: The variable `$user` hadn't existed at all
- Statusnet: Avoid a notice when the maximum length couldn't be fetched
- Twitter: Prevent a notice when the contact entry is empty