### PR TITLE
[various] Move optional token parameter at the end of OAuthRequest::from_consumer_and_token() function definition

### DIFF
--- a/statusnet/library/twitteroauth.php
+++ b/statusnet/library/twitteroauth.php
@@ -236,7 +236,7 @@ class TwitterOAuth
 			$url = "{$this->host}{$url}.{$this->format}";
 		}
 
-		$request = OAuthRequest::from_consumer_and_token($this->consumer, $this->token, $method, $url, $parameters);
+		$request = OAuthRequest::from_consumer_and_token($this->consumer, $method, $url, $parameters, $this->token);
 		$request->sign_request($this->sha1_method, $this->consumer, $this->token);
 		switch ($method) {
 			case 'GET':

--- a/tumblr/library/tumblroauth.php
+++ b/tumblr/library/tumblroauth.php
@@ -234,7 +234,7 @@ class TumblrOAuth
 			$url = "{$this->host}{$url}";
 		}
 
-		$request = OAuthRequest::from_consumer_and_token($this->consumer, $this->token, $method, $url, $parameters);
+		$request = OAuthRequest::from_consumer_and_token($this->consumer, $method, $url, $parameters, $this->token);
 		$request->sign_request($this->sha1_method, $this->consumer, $this->token);
 		switch ($method) {
 			case 'GET':


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/8511 (statusnet)
Fixes https://github.com/friendica/friendica/issues/8527 (tumblr)

Depends on https://github.com/friendica/friendica/pull/8541