### PR TITLE
[various] Template Engine with Subdirectory

### DIFF
--- a/cookienotice/cookienotice.php
+++ b/cookienotice/cookienotice.php
@@ -42,7 +42,7 @@ function cookienotice_addon_admin(App $a, &$s)
 	$text = DI::config()->get('cookienotice', 'text', DI::l10n()->t('This website uses cookies. If you continue browsing this website, you agree to the usage of cookies.'));
 	$oktext = DI::config()->get('cookienotice', 'oktext', DI::l10n()->t('OK'));
 
-	$t = Renderer::getMarkupTemplate('admin.tpl', __DIR__);
+	$t = Renderer::getMarkupTemplate('admin.tpl', 'addon/cookienotice/');
 	$s .= Renderer::replaceMacros($t, [
 		'$description' => DI::l10n()->t('<b>Configure your cookie usage notice.</b> It should just be a notice, saying that the website uses cookies. It is shown as long as a user didnt confirm clicking the OK button.'),
 		'$text' => ['cookienotice-text', DI::l10n()->t('Cookie Usage Notice'), $text],
@@ -108,7 +108,7 @@ function cookienotice_page_end(App $a, &$b)
 	$text = (string)DI::config()->get('cookienotice', 'text', DI::l10n()->t('This website uses cookies to recognize revisiting and logged in users. You accept the usage of these cookies by continue browsing this website.'));
 	$oktext = (string)DI::config()->get('cookienotice', 'oktext', DI::l10n()->t('OK'));
 
-	$page_end_tpl = Renderer::getMarkupTemplate('cookienotice.tpl', __DIR__);
+	$page_end_tpl = Renderer::getMarkupTemplate('cookienotice.tpl', 'addon/cookienotice/');
 
 	$page_end = Renderer::replaceMacros($page_end_tpl, [
 		'$text' => $text,

--- a/geonames/geonames.php
+++ b/geonames/geonames.php
@@ -139,7 +139,7 @@ function geonames_addon_settings(App $a, &$s)
 	/* Get the current state of our config variable */
 	$enabled = intval(DI::pConfig()->get(local_user(), 'geonames', 'enable'));
 
-	$t = Renderer::getMarkupTemplate('settings.tpl', __DIR__);
+	$t = Renderer::getMarkupTemplate('settings.tpl', 'addon/geonames/');
 	$s .= Renderer::replaceMacros($t, [
 		'$title' => DI::l10n()->t('Geonames Settings'),
 		'$description' => DI::l10n()->t('Replace numerical coordinates by the nearest populated location name in your posts.'),

--- a/mathjax/mathjax.php
+++ b/mathjax/mathjax.php
@@ -49,7 +49,7 @@ function mathjax_settings(App $a, &$s)
 
 	$use = DI::pConfig()->get(local_user(), 'mathjax', 'use', false);
 
-	$tpl = Renderer::getMarkupTemplate('settings.tpl', __DIR__);
+	$tpl = Renderer::getMarkupTemplate('settings.tpl', 'addon/mathjax');
 	$s .= Renderer::replaceMacros($tpl, [
 		'$title'        => 'MathJax',
 		'$description'  => DI::l10n()->t('The MathJax addon renders mathematical formulae written using the LaTeX syntax surrounded by the usual $$ or an eqnarray block in the postings of your wall,network tab and private mail.'),

--- a/pageheader/pageheader.php
+++ b/pageheader/pageheader.php
@@ -31,7 +31,7 @@ function pageheader_addon_admin(App &$a, &$s)
 	if(! $words)
 		$words = '';
 
-	$t = Renderer::getMarkupTemplate('admin.tpl', __DIR__);
+	$t = Renderer::getMarkupTemplate('admin.tpl', 'addon/pageheader');
 	$s .= Renderer::replaceMacros($t, [
 		'$title' => DI::l10n()->t('"pageheader" Settings'),
 		'$phwords' => ['pageheader-words', DI::l10n()->t('Message'), $words, DI::l10n()->t('Message to display on every page on this server (or put a pageheader.html file in your docroot)')],


### PR DESCRIPTION
- Use explicit root path for template engine
- Replace `__DIR__` parameters in addons with subdirectories
- Fixes local tests, where call is made out of '/' and not '/vagrant/'

Part  of https://github.com/friendica/friendica/pull/8545