### PR TITLE
[various] Replace share_header calls with BBCode::getShareOpeningTag

### DIFF
--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -1277,7 +1277,7 @@ function pumpio_dopost(App $a, $client, $uid, $self, $post, $own_id, $threadcomp
 			$created = '';
 		}
 
-		$postarray['body'] = share_header($share_author, $post->object->author->url,
+		$postarray['body'] = Friendica\Content\Text\BBCode::getShareOpeningTag($share_author, $post->object->author->url,
 						$post->object->author->image->url, "",
 						$created, $post->links->self->href).
 					$postarray['body']."[/share]";

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -904,7 +904,7 @@ function twitter_do_mirrorpost(App $a, $uid, $post)
 			return [];
 		}
 
-		$datarray['body'] = "\n" . share_header(
+		$datarray['body'] = "\n" . BBCode::getShareOpeningTag(
 			$item['author-name'],
 			$item['author-link'],
 			$item['author-avatar'],
@@ -1627,7 +1627,7 @@ function twitter_createpost(App $a, $uid, $post, array $self, $create_user, $onl
 		} else {
 			$quoted = twitter_createpost($a, $uid, $post->quoted_status, $self, false, false, true, $uriid);
 			if (!empty($quoted['body'])) {
-				$postarray['body'] .= "\n" . share_header(
+				$postarray['body'] .= "\n" . BBCode::getShareOpeningTag(
 						$quoted['author-name'],
 						$quoted['author-link'],
 						$quoted['author-avatar'],


### PR DESCRIPTION
Address https://github.com/friendica/friendica/issues/8473#issuecomment-645914650
Depends on https://github.com/friendica/friendica/pull/8787