### PR TITLE
Unneeded "info" messages removed

### DIFF
--- a/blockbot/blockbot.php
+++ b/blockbot/blockbot.php
@@ -42,7 +42,6 @@ function blockbot_addon_admin_post(&$a) {
 	DI::config()->set('blockbot', 'good_crawlers', $_POST['good_crawlers'] ?? false);
 	DI::config()->set('blockbot', 'block_gab', $_POST['block_gab'] ?? false);
 	DI::config()->set('blockbot', 'training', $_POST['training'] ?? false);
-	info(DI::l10n()->t('Settings updated.'). EOL);
 }
 
 function blockbot_init_1(App $a) {

--- a/blockem/blockem.php
+++ b/blockem/blockem.php
@@ -78,7 +78,6 @@ function blockem_addon_settings_post(App $a, array &$b)
 
 	if (!empty($_POST['blockem-submit'])) {
 		DI::pConfig()->set(local_user(), 'blockem', 'words', trim($_POST['blockem-words']));
-		info(DI::l10n()->t('BLOCKEM Settings saved.') . EOL);
 	}
 }
 
@@ -242,6 +241,5 @@ function blockem_init(App $a)
 	}
 
 	DI::pConfig()->set(local_user(), 'blockem', 'words', $words);
-	info(DI::l10n()->t('blockem settings updated') . EOL);
 	exit();
 }

--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -89,8 +89,6 @@ function buffer_addon_admin_post(App $a)
 
 	DI::config()->set('buffer', 'client_id'    , $client_id);
 	DI::config()->set('buffer', 'client_secret', $client_secret);
-
-	info(DI::l10n()->t('Settings updated.'). EOL);
 }
 
 function buffer_connect(App $a)

--- a/cookienotice/cookienotice.php
+++ b/cookienotice/cookienotice.php
@@ -70,7 +70,6 @@ function cookienotice_addon_admin_post(App $a)
 	if ($_POST['cookienotice-submit']) {
 		DI::config()->set('cookienotice', 'text', trim(strip_tags($_POST['cookienotice-text'])));
 		DI::config()->set('cookienotice', 'oktext', trim(strip_tags($_POST['cookienotice-oktext'])));
-		info(DI::l10n()->t('cookienotice Settings saved.'));
 	}
 }
 

--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -52,7 +52,7 @@ function getWeather($loc, $units = 'metric', $lang = 'en', $appid = '', $cacheti
 		$res = new SimpleXMLElement(Network::fetchUrl($url));
 	} catch (Exception $e) {
 		if (empty($_SESSION['curweather_notice_shown'])) {
-			info(DI::l10n()->t('Error fetching weather data. Error was: '.$e->getMessage()));
+			notice(DI::l10n()->t('Error fetching weather data. Error was: '.$e->getMessage()));
 			$_SESSION['curweather_notice_shown'] = true;
 		}
 
@@ -170,8 +170,6 @@ function curweather_addon_settings_post(App $a, $post)
 	DI::pConfig()->set(local_user(), 'curweather', 'curweather_loc'   , trim($_POST['curweather_loc']));
 	DI::pConfig()->set(local_user(), 'curweather', 'curweather_enable', intval($_POST['curweather_enable']));
 	DI::pConfig()->set(local_user(), 'curweather', 'curweather_units' , trim($_POST['curweather_units']));
-
-	info(DI::l10n()->t('Current Weather settings updated.') . EOL);
 }
 
 function curweather_addon_settings(App $a, &$s)
@@ -221,8 +219,6 @@ function curweather_addon_admin_post(App $a)
 	if (!empty($_POST['curweather-submit'])) {
 		DI::config()->set('curweather', 'appid',     trim($_POST['appid']));
 		DI::config()->set('curweather', 'cachetime', trim($_POST['cachetime']));
-
-		info(DI::l10n()->t('Curweather settings saved.' . PHP_EOL));
 	}
 }
 

--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -52,7 +52,7 @@ function getWeather($loc, $units = 'metric', $lang = 'en', $appid = '', $cacheti
 		$res = new SimpleXMLElement(Network::fetchUrl($url));
 	} catch (Exception $e) {
 		if (empty($_SESSION['curweather_notice_shown'])) {
-			notice(DI::l10n()->t('Error fetching weather data. Error was: '.$e->getMessage()));
+			notice(DI::l10n()->t('Error fetching weather data. Error was: ' . $e->getMessage()));
 			$_SESSION['curweather_notice_shown'] = true;
 		}
 

--- a/diaspora/diaspora.php
+++ b/diaspora/diaspora.php
@@ -135,10 +135,8 @@ function diaspora_settings_post(App $a, &$b)
 				DI::pConfig()->set(local_user(),'diaspora', 'aspect'         , trim($_POST['aspect']));
 				DI::pConfig()->set(local_user(),'diaspora', 'post_by_default', intval($_POST['post_by_default']));
 			}
-			notice(DI::l10n()->t('Diaspora settings updated.'));
 		} else {
 			DI::pConfig()->delete(local_user(), 'diaspora', 'password');
-			notice(DI::l10n()->t('Diaspora connector disabled.'));
 		}
 	}
 }

--- a/forumdirectory/forumdirectory.php
+++ b/forumdirectory/forumdirectory.php
@@ -127,7 +127,7 @@ function forumdirectory_content(App $a)
 		}
 		DBA::close($r);
 	} else {
-		info(DI::l10n()->t("No entries \x28some entries may be hidden\x29.") . EOL);
+		notice(DI::l10n()->t("No entries \x28some entries may be hidden\x29.") . EOL);
 	}
 
 	$tpl = Renderer::getMarkupTemplate('directory_header.tpl');

--- a/forumdirectory/forumdirectory.php
+++ b/forumdirectory/forumdirectory.php
@@ -127,7 +127,7 @@ function forumdirectory_content(App $a)
 		}
 		DBA::close($r);
 	} else {
-		notice(DI::l10n()->t("No entries \x28some entries may be hidden\x29.") . EOL);
+		notice(DI::l10n()->t("No entries \x28some entries may be hidden\x29."));
 	}
 
 	$tpl = Renderer::getMarkupTemplate('directory_header.tpl');

--- a/fromapp/fromapp.php
+++ b/fromapp/fromapp.php
@@ -35,8 +35,6 @@ function fromapp_settings_post($a, $post)
 
 	DI::pConfig()->set(local_user(), 'fromapp', 'app', $_POST['fromapp-input']);
 	DI::pConfig()->set(local_user(), 'fromapp', 'force', intval($_POST['fromapp-force']));
-
-	info(DI::l10n()->t('Fromapp settings updated.') . EOL);
 }
 
 function fromapp_settings(&$a, &$s)

--- a/geocoordinates/geocoordinates.php
+++ b/geocoordinates/geocoordinates.php
@@ -103,5 +103,4 @@ function geocoordinates_addon_admin_post(&$a)
 
 	$language  = (!empty($_POST['language']) ? Strings::escapeTags(trim($_POST['language']))   : '');
 	DI::config()->set('geocoordinates', 'language', $language);
-	info(DI::l10n()->t('Settings updated.') . EOL);
 }

--- a/geonames/geonames.php
+++ b/geonames/geonames.php
@@ -108,8 +108,6 @@ function geonames_addon_settings_post(App $a, array $post)
 	}
 
 	DI::pConfig()->set(local_user(), 'geonames', 'enable', intval($_POST['geonames-enable']));
-
-	info(DI::l10n()->t('Geonames settings updated.'));
 }
 
 /**

--- a/gnot/gnot.php
+++ b/gnot/gnot.php
@@ -49,7 +49,6 @@ function gnot_settings_post($a,$post) {
 		return;
 
 	DI::pConfig()->set(local_user(),'gnot','enable',intval($_POST['gnot']));
-	info(DI::l10n()->t('Gnot settings updated.') . EOL);
 }
 
 

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -125,5 +125,4 @@ function gravatar_addon_admin_post (&$a) {
 	$rating = (!empty($_POST['rating']) ? Strings::escapeTags(trim($_POST['rating'])) : 'g');
 	DI::config()->set('gravatar', 'default_avatar', $default_avatar);
 	DI::config()->set('gravatar', 'rating', $rating);
-	info(DI::l10n()->t('Gravatar settings updated.') .EOL);
 }

--- a/group_text/group_text.php
+++ b/group_text/group_text.php
@@ -42,8 +42,6 @@ function group_text_settings_post($a,$post) {
 	if(! local_user() || empty($_POST['group_text-submit']))
 		return;
 	DI::pConfig()->set(local_user(),'system','groupedit_image_limit',intval($_POST['group_text']));
-
-	info(DI::l10n()->t('Group Text settings updated.') . EOL);
 }
 
 

--- a/impressum/impressum.php
+++ b/impressum/impressum.php
@@ -98,7 +98,6 @@ function impressum_addon_admin_post (&$a) {
     DI::config()->set('impressum','email',strip_tags($email));
     DI::config()->set('impressum','notes',strip_tags($notes));
     DI::config()->set('impressum','footer_text',strip_tags($footer_text));
-    info(DI::l10n()->t('Settings updated.'). EOL );
 }
 function impressum_addon_admin (&$a, &$o) {
     $t = Renderer::getMarkupTemplate( "admin.tpl", "addon/impressum/" );

--- a/irc/irc.php
+++ b/irc/irc.php
@@ -62,7 +62,6 @@ function irc_addon_settings_post(&$a, &$b) {
 			DI::pConfig()->set(local_user(), 'irc', 'sitechats', trim($_POST['sitechats']));
 		}
 		/* upid pop-up thing */
-		info(DI::l10n()->t('IRC settings saved.') . EOL);
 	}
 }
 
@@ -132,8 +131,6 @@ function irc_addon_admin_post (&$a) {
 	if($_POST['irc-submit']) {
 		DI::config()->set('irc','autochans',trim($_POST['autochans']));
 		DI::config()->set('irc','sitechats',trim($_POST['sitechats']));
-		/* stupid pop-up thing */
-		info(DI::l10n()->t('IRC settings saved.') . EOL);
 	}
 }
 function irc_addon_admin (&$a, &$o) {

--- a/jappixmini/jappixmini.php
+++ b/jappixmini/jappixmini.php
@@ -434,7 +434,7 @@ function jappixmini_settings_post(App $a, &$b)
 			// check that Jabber password was encrypted with correct Friendica password
 			$friendica_password = trim($b['jappixmini-friendica-password']);
 			if (!User::authenticate((int) $uid, $friendica_password)) {
-				info("Wrong friendica password!");
+				notice("Wrong friendica password!");
 				return;
 			}
 		}
@@ -462,11 +462,9 @@ function jappixmini_settings_post(App $a, &$b)
 		DI::pConfig()->set($uid, 'jappixmini', 'activate'      , intval($b['jappixmini-activate']));
 		DI::pConfig()->set($uid, 'jappixmini', 'dontinsertchat', intval($b['jappixmini-dont-insertchat']));
 		DI::pConfig()->set($uid, 'jappixmini', 'encrypt'       , $encrypt);
-		info('Jappix Mini settings saved.');
 
 		if ($purge) {
 			q("DELETE FROM `pconfig` WHERE `uid`=$uid AND `cat`='jappixmini' AND `k` LIKE 'id:%%'");
-			info('List of addresses purged.');
 		}
 	}
 }

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -92,8 +92,6 @@ function langfilter_addon_settings_post(App $a, &$b)
 		DI::pConfig()->set(local_user(), 'langfilter', 'languages'    , $languages);
 		DI::pConfig()->set(local_user(), 'langfilter', 'minconfidence', $minconfidence);
 		DI::pConfig()->set(local_user(), 'langfilter', 'minlength'    , $minlength);
-
-		info(DI::l10n()->t('Language Filter Settings saved.'));
 	}
 }
 

--- a/libravatar/libravatar.php
+++ b/libravatar/libravatar.php
@@ -126,5 +126,4 @@ function libravatar_addon_admin_post(&$a)
 
 	$default_avatar = (!empty($_POST['avatar']) ? Strings::escapeTags(trim($_POST['avatar'])) : 'identicon');
 	DI::config()->set('libravatar', 'default_avatar', $default_avatar);
-	info(DI::l10n()->t('Libravatar settings updated.') .EOL);
 }

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -66,7 +66,7 @@ function notifyall_post(App $a)
 		DI::emailer()->send($notifyEmail->withRecipient($recipient['email']));
 	}
 
-	notice(DI::l10n()->t('Emails sent'));
+	info(DI::l10n()->t('Emails sent'));
 	DI::baseUrl()->redirect('admin');
 }
 

--- a/notimeline/notimeline.php
+++ b/notimeline/notimeline.php
@@ -29,7 +29,6 @@ function notimeline_settings_post($a, $post)
 	}
 
 	DI::pConfig()->set(local_user(), 'system', 'no_wall_archive_widget', intval($_POST['notimeline']));
-	info(DI::l10n()->t('No Timeline settings updated.') . EOL);
 }
 
 function notimeline_settings(&$a, &$s)

--- a/nsfw/nsfw.php
+++ b/nsfw/nsfw.php
@@ -105,7 +105,6 @@ function nsfw_addon_settings_post(&$a, &$b)
 		$enable = (!empty($_POST['nsfw-enable']) ? intval($_POST['nsfw-enable']) : 0);
 		$disable = 1 - $enable;
 		DI::pConfig()->set(local_user(), 'nsfw', 'disable', $disable);
-		info(DI::l10n()->t('NSFW Settings saved.') . EOL);
 	}
 }
 

--- a/numfriends/numfriends.php
+++ b/numfriends/numfriends.php
@@ -40,7 +40,6 @@ function numfriends_settings_post($a,$post) {
 		return;
 
 	DI::pConfig()->set(local_user(),'system','display_friend_count',intval($_POST['numfriends']));
-	info( DI::l10n()->t('Numfriends settings updated.') . EOL);
 }
 
 

--- a/openstreetmap/openstreetmap.php
+++ b/openstreetmap/openstreetmap.php
@@ -223,6 +223,4 @@ function openstreetmap_addon_admin_post(&$a)
 	DI::config()->set('openstreetmap', 'nomserver', $urlnom);
 	DI::config()->set('openstreetmap', 'zoom', $zoom);
 	DI::config()->set('openstreetmap', 'marker', $marker);
-
-	info(DI::l10n()->t('Settings updated.') . EOL);
 }

--- a/pageheader/pageheader.php
+++ b/pageheader/pageheader.php
@@ -51,7 +51,6 @@ function pageheader_addon_admin_post(App $a)
 		if (isset($_POST['pageheader-words'])) {
 			DI::config()->set('pageheader', 'text', trim(strip_tags($_POST['pageheader-words'])));
 		}
-		info(DI::l10n()->t('pageheader Settings saved.'));
 	}
 }
 

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -117,5 +117,4 @@ function piwik_addon_admin_post (&$a) {
 	DI::config()->set('piwik', 'siteid', $id);
 	DI::config()->set('piwik', 'optout', $optout);
 	DI::config()->set('piwik', 'async', $async);
-	info(DI::l10n()->t('Settings updated.'). EOL);
 }

--- a/public_server/public_server.php
+++ b/public_server/public_server.php
@@ -160,7 +160,6 @@ function public_server_addon_admin_post(&$a)
 	DI::config()->set('public_server', 'flagusers', $flagusers);
 	DI::config()->set('public_server', 'flagposts', $flagposts);
 	DI::config()->set('public_server', 'flagpostsexpire', $flagpostsexpire);
-	info(DI::l10n()->t('Settings saved').EOL);
 }
 
 function public_server_addon_admin(&$a, &$o)

--- a/qcomment/qcomment.php
+++ b/qcomment/qcomment.php
@@ -67,6 +67,5 @@ function qcomment_addon_settings_post(&$a, &$b)
 
 	if ($_POST['qcomment-submit']) {
 		DI::pConfig()->set(local_user(), 'qcomment', 'words', XML::escape($_POST['qcomment-words']));
-		info(DI::l10n()->t('Quick Comment settings saved.') . EOL);
 	}
 }

--- a/remote_permissions/remote_permissions.php
+++ b/remote_permissions/remote_permissions.php
@@ -60,7 +60,6 @@ function remote_permissions_settings_post($a,$post) {
 		return;
 
 	DI::pConfig()->set(local_user(),'remote_perms','show',intval($_POST['remote-perms']));
-	info(DI::l10n()->t('Remote Permissions settings updated.') . EOL);
 }
 
 function remote_permissions_content($a, $item_copy) {
@@ -209,5 +208,4 @@ function remote_permissions_addon_admin(&$a, &$o){
 function remote_permissions_addon_admin_post(&$a){
 	$choice	=	(!empty($_POST['remotepermschoice'])		? Strings::escapeTags(trim($_POST['remotepermschoice']))	: '');
 	DI::config()->set('remote_perms','global',($choice == 1 ? 1 : 0));
-	info(DI::l10n()->t('Settings updated.'). EOL);
 }

--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -86,7 +86,6 @@ function securemail_settings_post(App &$a, array &$b)
 		DI::pConfig()->set(local_user(), 'securemail', 'pkey', trim($_POST['securemail-pkey']));
 		$enable = (!empty($_POST['securemail-enable']) ? 1 : 0);
 		DI::pConfig()->set(local_user(), 'securemail', 'enable', $enable);
-		info(DI::l10n()->t('Secure Mail Settings saved.') . EOL);
 
 		if ($_POST['securemail-submit'] == DI::l10n()->t('Save and send test')) {
 

--- a/showmore/showmore.php
+++ b/showmore/showmore.php
@@ -73,7 +73,6 @@ function showmore_addon_settings_post(&$a, &$b)
 		$enable = (!empty($_POST['showmore-enable']) ? intval($_POST['showmore-enable']) : 0);
 		$disable = 1-$enable;
 		DI::pConfig()->set(local_user(), 'showmore', 'disable', $disable);
-		info(DI::l10n()->t('Show More Settings saved.') . EOL);
 	}
 }
 

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -224,8 +224,6 @@ function statusnet_settings_post(App $a, $post)
 
 					if (!intval($_POST['statusnet-mirror']))
 						DI::pConfig()->delete(local_user(), 'statusnet', 'lastid');
-
-					info(DI::l10n()->t('GNU Social settings updated.') . EOL);
 				}
 			}
 		}

--- a/superblock/superblock.php
+++ b/superblock/superblock.php
@@ -68,7 +68,6 @@ function superblock_addon_settings_post(&$a, &$b)
 
 	if (!empty($_POST['superblock-submit'])) {
 		DI::pConfig()->set(local_user(), 'system', 'blocked',trim($_POST['superblock-words']));
-		info(DI::l10n()->t('SUPERBLOCK Settings saved.') . EOL);
 	}
 }
 
@@ -163,6 +162,5 @@ function superblock_init(&$a)
 	}
 
 	DI::pConfig()->set(local_user(), 'system', 'blocked', $words);
-	info(DI::l10n()->t('superblock settings updated') . EOL );
 	exit();
 }

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -90,8 +90,6 @@ function tumblr_addon_admin_post(App $a)
 
 	DI::config()->set('tumblr', 'consumer_key',$consumer_key);
 	DI::config()->set('tumblr', 'consumer_secret',$consumer_secret);
-
-	info(DI::l10n()->t('Settings updated.'). EOL);
 }
 
 function tumblr_connect(App $a)

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -241,9 +241,9 @@ function twitter_settings_post(App $a)
 				DI::pConfig()->set(local_user(), 'twitter', 'oauthsecret', $token['oauth_token_secret']);
 				DI::pConfig()->set(local_user(), 'twitter', 'post', 1);
 			} catch(Exception $e) {
-				info($e->getMessage());
+				notice($e->getMessage());
 			} catch(TwitterOAuthException $e) {
-				info($e->getMessage());
+				notice($e->getMessage());
 			}
 			//  reload the Addon Settings page, if we don't do it see Bug #42
 			DI::baseUrl()->redirect('settings/connectors');
@@ -259,8 +259,6 @@ function twitter_settings_post(App $a)
 			if (!intval($_POST['twitter-mirror'])) {
 				DI::pConfig()->delete(local_user(), 'twitter', 'lastid');
 			}
-
-			info(DI::l10n()->t('Twitter settings updated.') . EOL);
 		}
 	}
 }
@@ -737,7 +735,6 @@ function twitter_addon_admin_post(App $a)
 	$consumersecret = !empty($_POST['consumersecret']) ? Strings::escapeTags(trim($_POST['consumersecret'])) : '';
 	DI::config()->set('twitter', 'consumerkey', $consumerkey);
 	DI::config()->set('twitter', 'consumersecret', $consumersecret);
-	info(DI::l10n()->t('Settings updated.') . EOL);
 }
 
 function twitter_addon_admin(App $a, &$o)

--- a/webrtc/webrtc.php
+++ b/webrtc/webrtc.php
@@ -34,7 +34,6 @@ function webrtc_addon_admin (&$a, &$o) {
 function webrtc_addon_admin_post (&$a) {
         $url = (!empty($_POST['webrtcurl']) ? Strings::escapeTags(trim($_POST['webrtcurl'])) : '');
 	    DI::config()->set('webrtc', 'webrtcurl', $url);
-	    info(DI::l10n()->t('Settings updated.'). EOL);
 }
 
 function webrtc_module() {

--- a/windowsphonepush/windowsphonepush.php
+++ b/windowsphonepush/windowsphonepush.php
@@ -91,8 +91,6 @@ function windowsphonepush_settings_post($a, $post)
 	}
 
 	DI::pConfig()->set(local_user(), 'windowsphonepush', 'senditemtext', intval($_POST['windowsphonepush-senditemtext']));
-
-	info(DI::l10n()->t('WindowsPhonePush settings updated.') . EOL);
 }
 
 /* Called from the Addon Setting form.

--- a/xmpp/xmpp.php
+++ b/xmpp/xmpp.php
@@ -38,8 +38,6 @@ function xmpp_addon_settings_post()
 	DI::pConfig()->set(local_user(), 'xmpp', 'enabled', $_POST['xmpp_enabled'] ?? false);
 	DI::pConfig()->set(local_user(), 'xmpp', 'individual', $_POST['xmpp_individual'] ?? false);
 	DI::pConfig()->set(local_user(), 'xmpp', 'bosh_proxy', $_POST['xmpp_bosh_proxy'] ?? '');
-
-	info(DI::l10n()->t('XMPP settings updated.') . EOL);
 }
 
 function xmpp_addon_settings(App $a, &$s)
@@ -121,8 +119,6 @@ function xmpp_addon_admin_post()
 
 	DI::config()->set('xmpp', 'bosh_proxy', $bosh_proxy);
 	DI::config()->set('xmpp', 'central_userbase', $central_userbase);
-
-	info(DI::l10n()->t('Settings updated.') . EOL);
 }
 
 function xmpp_script(App $a)


### PR DESCRIPTION
Many unneeded "info" messages had been removed. Also some "notice" messages are converted to "info" or vice versa, depending on their content.

"info" had been kept when the result of the action isn't obvious (like when a mail had been sent) and removed when the result is obvious (the settings are updated). The "notice" is kept at most places since this indicates an error.