### PR TITLE
[various] Remove redundant uninstall functions

### DIFF
--- a/advancedcontentfilter/advancedcontentfilter.php
+++ b/advancedcontentfilter/advancedcontentfilter.php
@@ -65,13 +65,6 @@ function advancedcontentfilter_install(App $a)
 	Logger::log("installed advancedcontentfilter");
 }
 
-function advancedcontentfilter_uninstall()
-{
-	Hook::unregister('dbstructure_definition'     , __FILE__, 'advancedcontentfilter_dbstructure_definition');
-	Hook::unregister('prepare_body_content_filter', __FILE__, 'advancedcontentfilter_prepare_body_content_filter');
-	Hook::unregister('addon_settings'             , __FILE__, 'advancedcontentfilter_addon_settings');
-}
-
 /*
  * Hooks
  */

--- a/blackout/blackout.php
+++ b/blackout/blackout.php
@@ -54,9 +54,6 @@ function blackout_install() {
 	Hook::register('page_header', 'addon/blackout/blackout.php', 'blackout_redirect');
 }
 
-function blackout_uninstall() {
-	Hook::unregister('page_header', 'addon/blackout/blackout.php', 'blackout_redirect');
-}
 function blackout_redirect ($a, $b) {
 	// if we have a logged in user, don't throw her out
 	if (local_user()) {

--- a/blockbot/blockbot.php
+++ b/blockbot/blockbot.php
@@ -22,11 +22,6 @@ function blockbot_install() {
 	Hook::register('init_1', __FILE__, 'blockbot_init_1');
 }
 
-
-function blockbot_uninstall() {
-	Hook::unregister('init_1', __FILE__, 'blockbot_init_1');
-}
-
 function blockbot_addon_admin(&$a, &$o) {
 	$t = Renderer::getMarkupTemplate("admin.tpl", "addon/blockbot/");
 

--- a/blockem/blockem.php
+++ b/blockem/blockem.php
@@ -23,18 +23,6 @@ function blockem_install()
 	Hook::register('enotify_store'              , 'addon/blockem/blockem.php', 'blockem_enotify_store');
 }
 
-function blockem_uninstall()
-{
-	Hook::unregister('prepare_body_content_filter', 'addon/blockem/blockem.php', 'blockem_prepare_body_content_filter');
-	Hook::unregister('prepare_body'               , 'addon/blockem/blockem.php', 'blockem_prepare_body');
-	Hook::unregister('display_item'               , 'addon/blockem/blockem.php', 'blockem_display_item');
-	Hook::unregister('addon_settings'             , 'addon/blockem/blockem.php', 'blockem_addon_settings');
-	Hook::unregister('addon_settings_post'        , 'addon/blockem/blockem.php', 'blockem_addon_settings_post');
-	Hook::unregister('conversation_start'         , 'addon/blockem/blockem.php', 'blockem_conversation_start');
-	Hook::unregister('item_photo_menu'            , 'addon/blockem/blockem.php', 'blockem_item_photo_menu');
-	Hook::unregister('enotify_store'              , 'addon/blockem/blockem.php', 'blockem_enotify_store');
-}
-
 function blockem_addon_settings (App $a, &$s)
 {
 	if (!local_user()) {

--- a/blogger/blogger.php
+++ b/blogger/blogger.php
@@ -23,22 +23,6 @@ function blogger_install()
 	Hook::register('connector_settings_post', 'addon/blogger/blogger.php', 'blogger_settings_post');
 }
 
-function blogger_uninstall()
-{
-	Hook::unregister('hook_fork',               'addon/blogger/blogger.php', 'blogger_hook_fork');
-	Hook::unregister('post_local',              'addon/blogger/blogger.php', 'blogger_post_local');
-	Hook::unregister('notifier_normal',         'addon/blogger/blogger.php', 'blogger_send');
-	Hook::unregister('jot_networks',            'addon/blogger/blogger.php', 'blogger_jot_nets');
-	Hook::unregister('connector_settings',      'addon/blogger/blogger.php', 'blogger_settings');
-	Hook::unregister('connector_settings_post', 'addon/blogger/blogger.php', 'blogger_settings_post');
-
-	// obsolete - remove
-	Hook::unregister('post_local_end',      'addon/blogger/blogger.php', 'blogger_send');
-	Hook::unregister('addon_settings',      'addon/blogger/blogger.php', 'blogger_settings');
-	Hook::unregister('addon_settings_post', 'addon/blogger/blogger.php', 'blogger_settings_post');
-}
-
-
 function blogger_jot_nets(App $a, array &$jotnets_fields)
 {
 	if (!local_user()) {

--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -29,16 +29,6 @@ function buffer_install()
 	Hook::register('connector_settings_post', 'addon/buffer/buffer.php', 'buffer_settings_post');
 }
 
-function buffer_uninstall()
-{
-	Hook::unregister('hook_fork',               'addon/buffer/buffer.php', 'buffer_hook_fork');
-	Hook::unregister('post_local',              'addon/buffer/buffer.php', 'buffer_post_local');
-	Hook::unregister('notifier_normal',         'addon/buffer/buffer.php', 'buffer_send');
-	Hook::unregister('jot_networks',            'addon/buffer/buffer.php', 'buffer_jot_nets');
-	Hook::unregister('connector_settings',      'addon/buffer/buffer.php', 'buffer_settings');
-	Hook::unregister('connector_settings_post', 'addon/buffer/buffer.php', 'buffer_settings_post');
-}
-
 function buffer_module()
 {
 }

--- a/buglink/buglink.php
+++ b/buglink/buglink.php
@@ -15,11 +15,6 @@ function buglink_install()
 	Hook::register('page_end', 'addon/buglink/buglink.php', 'buglink_active');
 }
 
-function buglink_uninstall()
-{
-	Hook::unregister('page_end', 'addon/buglink/buglink.php', 'buglink_active');
-}
-
 function buglink_active(App $a, &$b)
 {
 	$b .= '<div id="buglink_wrapper" style="position: fixed; bottom: 5px; left: 5px;"><a href="https://github.com/friendica/friendica/issues" target="_blank" rel="noopener noreferrer" title="' . DI::l10n()->t('Report Bug') . '"><img src="addon/buglink/bug-x.gif" alt="' . DI::l10n()->t('Report Bug') . '" /></a></div>';

--- a/calc/calc.php
+++ b/calc/calc.php
@@ -12,11 +12,6 @@ function calc_install() {
 	Hook::register('app_menu', 'addon/calc/calc.php', 'calc_app_menu');
 }
 
-function calc_uninstall() {
-	Hook::unregister('app_menu', 'addon/calc/calc.php', 'calc_app_menu');
-
-}
-
 function calc_app_menu($a,&$b) {
 	$b['app_menu'][] = '<div class="app-title"><a href="calc">Calculator</a></div>'; 
 }

--- a/catavatar/catavatar.php
+++ b/catavatar/catavatar.php
@@ -32,18 +32,6 @@ function catavatar_install()
 }
 
 /**
- * Removes the addon hook
- */
-function catavatar_uninstall()
-{
-	Hook::unregister('avatar_lookup', 'addon/catavatar/catavatar.php', 'catavatar_lookup');
-	Hook::unregister('addon_settings', 'addon/catavatar/catavatar.php', 'catavatar_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/catavatar/catavatar.php', 'catavatar_addon_settings_post');
-
-	Logger::log('unregistered catavatar');
-}
-
-/**
  * Cat avatar user settings page
  */
 function catavatar_addon_settings(App $a, &$s)

--- a/convert/convert.php
+++ b/convert/convert.php
@@ -11,10 +11,6 @@ function convert_install() {
 	Hook::register('app_menu', 'addon/convert/convert.php', 'convert_app_menu');
 }
 
-function convert_uninstall() {
-	Hook::unregister('app_menu', 'addon/convert/convert.php', 'convert_app_menu');
-}
-
 function convert_app_menu($a,&$b) {
 	$b['app_menu'][] = '<div class="app-title"><a href="convert">Units Conversion</a></div>';
 }

--- a/curweather/curweather.php
+++ b/curweather/curweather.php
@@ -24,13 +24,6 @@ function curweather_install()
 	Hook::register('addon_settings_post', 'addon/curweather/curweather.php', 'curweather_addon_settings_post');
 }
 
-function curweather_uninstall()
-{
-	Hook::unregister('network_mod_init'   , 'addon/curweather/curweather.php', 'curweather_network_mod_init');
-	Hook::unregister('addon_settings'     , 'addon/curweather/curweather.php', 'curweather_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/curweather/curweather.php', 'curweather_addon_settings_post');
-}
-
 //  get the weather data from OpenWeatherMap
 function getWeather($loc, $units = 'metric', $lang = 'en', $appid = '', $cachetime = 0)
 {

--- a/diaspora/diaspora.php
+++ b/diaspora/diaspora.php
@@ -29,16 +29,6 @@ function diaspora_install()
 	Hook::register('connector_settings_post', 'addon/diaspora/diaspora.php', 'diaspora_settings_post');
 }
 
-function diaspora_uninstall()
-{
-	Hook::unregister('hook_fork',               'addon/diaspora/diaspora.php', 'diaspora_hook_fork');
-	Hook::unregister('post_local',              'addon/diaspora/diaspora.php', 'diaspora_post_local');
-	Hook::unregister('notifier_normal',         'addon/diaspora/diaspora.php', 'diaspora_send');
-	Hook::unregister('jot_networks',            'addon/diaspora/diaspora.php', 'diaspora_jot_nets');
-	Hook::unregister('connector_settings',      'addon/diaspora/diaspora.php', 'diaspora_settings');
-	Hook::unregister('connector_settings_post', 'addon/diaspora/diaspora.php', 'diaspora_settings_post');
-}
-
 function diaspora_jot_nets(App $a, array &$jotnets_fields)
 {
 	if (!local_user()) {

--- a/dwpost/dwpost.php
+++ b/dwpost/dwpost.php
@@ -27,15 +27,6 @@ function dwpost_install()
 	Hook::register('connector_settings_post', 'addon/dwpost/dwpost.php', 'dwpost_settings_post');
 }
 
-function dwpost_uninstall()
-{
-	Hook::unregister('post_local',              'addon/dwpost/dwpost.php', 'dwpost_post_local');
-	Hook::unregister('notifier_normal',         'addon/dwpost/dwpost.php', 'dwpost_send');
-	Hook::unregister('jot_networks',            'addon/dwpost/dwpost.php', 'dwpost_jot_nets');
-	Hook::unregister('connector_settings',      'addon/dwpost/dwpost.php', 'dwpost_settings');
-	Hook::unregister('connector_settings_post', 'addon/dwpost/dwpost.php', 'dwpost_settings_post');
-}
-
 function dwpost_jot_nets(App $a, array &$jotnets_fields)
 {
 	if (!local_user()) {

--- a/forumdirectory/forumdirectory.php
+++ b/forumdirectory/forumdirectory.php
@@ -23,11 +23,6 @@ function forumdirectory_install()
 	Hook::register('app_menu', 'addon/forumdirectory/forumdirectory.php', 'forumdirectory_app_menu');
 }
 
-function forumdirectory_uninstall()
-{
-	Hook::unregister('app_menu', 'addon/forumdirectory/forumdirectory.php', 'forumdirectory_app_menu');
-}
-
 function forumdirectory_module()
 {
 	return;

--- a/fromapp/fromapp.php
+++ b/fromapp/fromapp.php
@@ -18,15 +18,6 @@ function fromapp_install()
 	Logger::log("installed fromapp");
 }
 
-
-function fromapp_uninstall()
-{
-	Hook::unregister('post_local', 'addon/fromapp/fromapp.php', 'fromapp_post_hook');
-	Hook::unregister('addon_settings', 'addon/fromapp/fromapp.php', 'fromapp_settings');
-	Hook::unregister('addon_settings_post', 'addon/fromapp/fromapp.php', 'fromapp_settings_post');
-	Logger::log("removed fromapp");
-}
-
 function fromapp_settings_post($a, $post)
 {
 	if (!local_user() || empty($_POST['fromapp-submit'])) {

--- a/geocoordinates/geocoordinates.php
+++ b/geocoordinates/geocoordinates.php
@@ -18,13 +18,6 @@ function geocoordinates_install()
 	Hook::register('post_remote', 'addon/geocoordinates/geocoordinates.php', 'geocoordinates_post_hook');
 }
 
-
-function geocoordinates_uninstall()
-{
-	Hook::unregister('post_local',    'addon/geocoordinates/geocoordinates.php', 'geocoordinates_post_hook');
-	Hook::unregister('post_remote',    'addon/geocoordinates/geocoordinates.php', 'geocoordinates_post_hook');
-}
-
 function geocoordinates_resolve_item(&$item)
 {
 	if((!$item["coord"]) || ($item["location"]))

--- a/gnot/gnot.php
+++ b/gnot/gnot.php
@@ -22,19 +22,6 @@ function gnot_install() {
 	Logger::log("installed gnot");
 }
 
-
-function gnot_uninstall() {
-
-	Hook::unregister('addon_settings', 'addon/gnot/gnot.php', 'gnot_settings');
-	Hook::unregister('addon_settings_post', 'addon/gnot/gnot.php', 'gnot_settings_post');
-	Hook::unregister('enotify_mail', 'addon/gnot/gnot.php', 'gnot_enotify_mail');
-
-
-	Logger::log("removed gnot");
-}
-
-
-
 /**
  *
  * Callback from the settings post function.

--- a/googlemaps/googlemaps.php
+++ b/googlemaps/googlemaps.php
@@ -16,13 +16,6 @@ function googlemaps_install()
 	Logger::log("installed googlemaps");
 }
 
-function googlemaps_uninstall()
-{
-	Hook::unregister('render_location', 'addon/googlemaps/googlemaps.php', 'googlemaps_location');
-
-	Logger::log("removed googlemaps");
-}
-
 function googlemaps_location($a, &$item)
 {
 

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -26,16 +26,6 @@ function gravatar_install() {
 	Logger::log("registered gravatar in avatar_lookup hook");
 }
 
-/**
- * Removes the addon hook
- */
-function gravatar_uninstall() {
-	Hook::unregister('load_config',   'addon/gravatar/gravatar.php', 'gravatar_load_config');
-	Hook::unregister('avatar_lookup', 'addon/gravatar/gravatar.php', 'gravatar_lookup');
-
-	Logger::log("unregistered gravatar in avatar_lookup hook");
-}
-
 function gravatar_load_config(App $a, ConfigFileLoader $loader)
 {
 	$a->getConfigCache()->load($loader->loadAddonConfig('gravatar'));

--- a/group_text/group_text.php
+++ b/group_text/group_text.php
@@ -17,18 +17,6 @@ function group_text_install() {
 	Logger::log("installed group_text");
 }
 
-
-function group_text_uninstall() {
-
-	Hook::unregister('addon_settings', 'addon/group_text/group_text.php', 'group_text_settings');
-	Hook::unregister('addon_settings_post', 'addon/group_text/group_text.php', 'group_text_settings_post');
-
-
-	Logger::log("removed group_text");
-}
-
-
-
 /**
  *
  * Callback from the settings post function.

--- a/highlightjs/highlightjs.php
+++ b/highlightjs/highlightjs.php
@@ -16,12 +16,6 @@ function highlightjs_install()
 	Hook::register('footer', __FILE__, 'highlightjs_footer');
 }
 
-function highlightjs_uninstall()
-{
-	Hook::unregister('head'  , __FILE__, 'highlightjs_head');
-	Hook::unregister('footer', __FILE__, 'highlightjs_footer');
-}
-
 function highlightjs_head(App $a, &$b)
 {
 	if ($a->getCurrentTheme() == 'frio') {

--- a/ifttt/ifttt.php
+++ b/ifttt/ifttt.php
@@ -23,12 +23,6 @@ function ifttt_install()
 	Hook::register('connector_settings_post', 'addon/ifttt/ifttt.php', 'ifttt_settings_post');
 }
 
-function ifttt_uninstall()
-{
-	Hook::unregister('connector_settings', 'addon/ifttt/ifttt.php', 'ifttt_settings');
-	Hook::unregister('connector_settings_post', 'addon/ifttt/ifttt.php', 'ifttt_settings_post');
-}
-
 function ifttt_module()
 {
 

--- a/ijpost/ijpost.php
+++ b/ijpost/ijpost.php
@@ -25,15 +25,6 @@ function ijpost_install()
 	Hook::register('connector_settings_post', 'addon/ijpost/ijpost.php', 'ijpost_settings_post');
 }
 
-function ijpost_uninstall()
-{
-	Hook::unregister('post_local',       'addon/ijpost/ijpost.php', 'ijpost_post_local');
-	Hook::unregister('notifier_normal',  'addon/ijpost/ijpost.php', 'ijpost_send');
-	Hook::unregister('jot_networks',     'addon/ijpost/ijpost.php', 'ijpost_jot_nets');
-	Hook::unregister('connector_settings',      'addon/ijpost/ijpost.php', 'ijpost_settings');
-	Hook::unregister('connector_settings_post', 'addon/ijpost/ijpost.php', 'ijpost_settings_post');
-}
-
 function ijpost_jot_nets(\Friendica\App &$a, array &$jotnets_fields)
 {
 	if (!local_user()) {

--- a/impressum/impressum.php
+++ b/impressum/impressum.php
@@ -23,13 +23,6 @@ function impressum_install() {
     Logger::log("installed impressum Addon");
 }
 
-function impressum_uninstall() {
-	Hook::unregister('load_config', 'addon/impressum/impressum.php', 'impressum_load_config');
-    Hook::unregister('about_hook', 'addon/impressum/impressum.php', 'impressum_show');
-    Hook::unregister('page_end', 'addon/impressum/impressum.php', 'impressum_footer');
-    Logger::log("uninstalled impressum Addon");
-}
-
 function impressum_module() {
 }
 function impressum_content() {

--- a/infiniteimprobabilitydrive/infiniteimprobabilitydrive.php
+++ b/infiniteimprobabilitydrive/infiniteimprobabilitydrive.php
@@ -13,11 +13,6 @@ function infiniteimprobabilitydrive_install()
 	Hook::register('app_menu', 'addon/infiniteimprobabilitydrive/infiniteimprobabilitydrive.php', 'infiniteimprobabilitydrive_app_menu');
 }
 
-function infiniteimprobabilitydrive_uninstall()
-{
-	Hook::unregister('app_menu', 'addon/infiniteimprobabilitydrive/infiniteimprobabilitydrive.php', 'infiniteimprobabilitydrive_app_menu');
-}
-
 function infiniteimprobabilitydrive_app_menu($a, &$b)
 {
 	$b['app_menu'][] = '<div class="app-title"><a href="infiniteimprobabilitydrive">' . DI::l10n()->t('Infinite Improbability Drive') . '</a></div>';

--- a/irc/irc.php
+++ b/irc/irc.php
@@ -17,13 +17,6 @@ function irc_install() {
 	Hook::register('addon_settings_post', 'addon/irc/irc.php', 'irc_addon_settings_post');
 }
 
-function irc_uninstall() {
-	Hook::unregister('app_menu', 'addon/irc/irc.php', 'irc_app_menu');
-	Hook::unregister('addon_settings', 'addon/irc/irc.php', 'irc_addon_settings');
-
-}
-
-
 function irc_addon_settings(&$a,&$s) {
 	if(! local_user())
 		return;

--- a/jappixmini/jappixmini.php
+++ b/jappixmini/jappixmini.php
@@ -104,19 +104,6 @@ function jappixmini_install()
 	}
 }
 
-function jappixmini_uninstall()
-{
-	Hook::unregister('addon_settings', 'addon/jappixmini/jappixmini.php', 'jappixmini_settings');
-	Hook::unregister('addon_settings_post', 'addon/jappixmini/jappixmini.php', 'jappixmini_settings_post');
-
-	Hook::unregister('page_end', 'addon/jappixmini/jappixmini.php', 'jappixmini_script');
-	Hook::unregister('authenticate', 'addon/jappixmini/jappixmini.php', 'jappixmini_login');
-
-	Hook::unregister('cron', 'addon/jappixmini/jappixmini.php', 'jappixmini_cron');
-
-	Hook::unregister('about_hook', 'addon/jappixmini/jappixmini.php', 'jappixmini_download_source');
-}
-
 function jappixmini_addon_admin(App $a, &$o)
 {
 	// display instructions and warnings on addon settings page for admin

--- a/krynn/krynn.php
+++ b/krynn/krynn.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Name: Dragonlance Krynn locales
- * Description: Set a random locale from the Dragonlance Realm of Krynn when posting. Based on the planets frindica addon by Mike Macgirvin and Tony Baldwin
+ * Description: Set a random locale from the Dragonlance Realm of Krynn when posting. Based on the planets friendica addon by Mike Macgirvin and Tony Baldwin
  * Version: 1.0
  * Planets Author: Mike Macgirvin <http://macgirvin.com/profile/mike>
  * Planets Author: Tony Baldwin <https://free-haven.org/profile/tony>
@@ -38,27 +38,6 @@ function krynn_install() {
 	Logger::log("installed krynn");
 }
 
-
-function krynn_uninstall() {
-
-	/**
-	 *
-	 * uninstall unregisters any hooks created with register_hook
-	 * during install. It may also delete configuration settings
-	 * and any other cleanup.
-	 *
-	 */
-
-	Hook::unregister('post_local',    'addon/krynn/krynn.php', 'krynn_post_hook');
-	Hook::unregister('addon_settings', 'addon/krynn/krynn.php', 'krynn_settings');
-	Hook::unregister('addon_settings_post', 'addon/krynn/krynn.php', 'krynn_settings_post');
-
-
-	Logger::log("removed krynn");
-}
-
-
-
 function krynn_post_hook($a, &$item) {
 
 	/**
@@ -69,8 +48,6 @@ function krynn_post_hook($a, &$item) {
 	 *      - The profile owner must have allowed our addon
 	 *
 	 */
-
-	Logger::log('krynn invoked');
 
 	if(! local_user())   /* non-zero if this is a logged in user of this system */
 		return;

--- a/langfilter/langfilter.php
+++ b/langfilter/langfilter.php
@@ -25,14 +25,6 @@ function langfilter_install()
 	Hook::register('addon_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
 }
 
-function langfilter_uninstall()
-{
-	Hook::unregister('prepare_body_content_filter', 'addon/langfilter/langfilter.php', 'langfilter_prepare_body_content_filter');
-	Hook::unregister('prepare_body', 'addon/langfilter/langfilter.php', 'langfilter_prepare_body');
-	Hook::unregister('addon_settings', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/langfilter/langfilter.php', 'langfilter_addon_settings_post');
-}
-
 /* The settings
  * 1st check if somebody logged in is calling
  * 2nd get the current settings

--- a/ldapauth/ldapauth.php
+++ b/ldapauth/ldapauth.php
@@ -66,12 +66,6 @@ function ldapauth_install()
 	Hook::register('authenticate', 'addon/ldapauth/ldapauth.php', 'ldapauth_hook_authenticate');
 }
 
-function ldapauth_uninstall()
-{
-	Hook::unregister('load_config',  'addon/ldapauth/ldapauth.php', 'ldapauth_load_config');
-	Hook::unregister('authenticate', 'addon/ldapauth/ldapauth.php', 'ldapauth_hook_authenticate');
-}
-
 function ldapauth_load_config(\Friendica\App $a, ConfigFileLoader $loader)
 {
 	$a->getConfigCache()->load($loader->loadAddonConfig('ldapauth'));

--- a/leistungsschutzrecht/leistungsschutzrecht.php
+++ b/leistungsschutzrecht/leistungsschutzrecht.php
@@ -16,13 +16,6 @@ function leistungsschutzrecht_install() {
 	Hook::register('page_info_data', 'addon/leistungsschutzrecht/leistungsschutzrecht.php', 'leistungsschutzrecht_getsiteinfo');
 }
 
-
-function leistungsschutzrecht_uninstall() {
-	Hook::unregister('cron', 'addon/leistungsschutzrecht/leistungsschutzrecht.php', 'leistungsschutzrecht_cron');
-	Hook::unregister('getsiteinfo', 'addon/leistungsschutzrecht/leistungsschutzrecht.php', 'leistungsschutzrecht_getsiteinfo');
-	Hook::unregister('page_info_data', 'addon/leistungsschutzrecht/leistungsschutzrecht.php', 'leistungsschutzrecht_getsiteinfo');
-}
-
 function leistungsschutzrecht_getsiteinfo($a, &$siteinfo) {
 	if (!isset($siteinfo["url"]) || empty($siteinfo['type'])) {
 		return;

--- a/libertree/libertree.php
+++ b/libertree/libertree.php
@@ -23,16 +23,6 @@ function libertree_install()
 	Hook::register('connector_settings_post', 'addon/libertree/libertree.php', 'libertree_settings_post');
 }
 
-function libertree_uninstall()
-{
-	Hook::unregister('hook_fork',        'addon/libertree/libertree.php', 'libertree_hook_fork');
-	Hook::unregister('post_local',       'addon/libertree/libertree.php', 'libertree_post_local');
-	Hook::unregister('notifier_normal',  'addon/libertree/libertree.php', 'libertree_send');
-	Hook::unregister('jot_networks',     'addon/libertree/libertree.php', 'libertree_jot_nets');
-	Hook::unregister('connector_settings',      'addon/libertree/libertree.php', 'libertree_settings');
-	Hook::unregister('connector_settings_post', 'addon/libertree/libertree.php', 'libertree_settings_post');
-}
-
 function libertree_jot_nets(App &$a, array &$jotnets_fields)
 {
     if(! local_user()) {

--- a/libravatar/libravatar.php
+++ b/libravatar/libravatar.php
@@ -26,16 +26,6 @@ function libravatar_install()
 	Logger::log("registered libravatar in avatar_lookup hook");
 }
 
-/**
- * Removes the addon hook
- */
-function libravatar_uninstall()
-{
-	Hook::unregister('load_config',   'addon/libravatar/libravatar.php', 'libravatar_load_config');
-	Hook::unregister('avatar_lookup', 'addon/libravatar/libravatar.php', 'libravatar_lookup');
-	Logger::log("unregistered libravatar in avatar_lookup hook");
-}
-
 function libravatar_load_config(App $a, ConfigFileLoader $loader)
 {
 	$a->getConfigCache()->load($loader->loadAddonConfig('libravatar'));

--- a/ljpost/ljpost.php
+++ b/ljpost/ljpost.php
@@ -24,15 +24,6 @@ function ljpost_install() {
     Hook::register('connector_settings_post', 'addon/ljpost/ljpost.php', 'ljpost_settings_post');
 
 }
-function ljpost_uninstall() {
-    Hook::unregister('post_local',       'addon/ljpost/ljpost.php', 'ljpost_post_local');
-    Hook::unregister('notifier_normal',  'addon/ljpost/ljpost.php', 'ljpost_send');
-    Hook::unregister('jot_networks',     'addon/ljpost/ljpost.php', 'ljpost_jot_nets');
-    Hook::unregister('connector_settings',      'addon/ljpost/ljpost.php', 'ljpost_settings');
-    Hook::unregister('connector_settings_post', 'addon/ljpost/ljpost.php', 'ljpost_settings_post');
-
-}
-
 
 function ljpost_jot_nets(\Friendica\App &$a, array &$jotnets_fields)
 {

--- a/mahjongg/mahjongg.php
+++ b/mahjongg/mahjongg.php
@@ -12,11 +12,6 @@ function mahjongg_install() {
     Hook::register('app_menu', 'addon/mahjongg/mahjongg.php', 'mahjongg_app_menu');
 }
 
-function mahjongg_uninstall() {
-    Hook::unregister('app_menu', 'addon/mahjongg/mahjongg.php', 'mahjongg_app_menu');
-
-}
-
 function mahjongg_app_menu($a,&$b) {
     $b['app_menu'][] = '<div class="app-title"><a href="mahjongg">Mahjongg</a></div>';
 }

--- a/mailstream/mailstream.php
+++ b/mailstream/mailstream.php
@@ -56,19 +56,6 @@ function mailstream_install() {
 	}
 }
 
-function mailstream_uninstall() {
-	Hook::unregister('addon_settings', 'addon/mailstream/mailstream.php', 'mailstream_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/mailstream/mailstream.php', 'mailstream_addon_settings_post');
-	Hook::unregister('post_local', 'addon/mailstream/mailstream.php', 'mailstream_post_local_hook');
-	Hook::unregister('post_remote', 'addon/mailstream/mailstream.php', 'mailstream_post_remote_hook');
-	Hook::unregister('post_local_end', 'addon/mailstream/mailstream.php', 'mailstream_post_local_hook');
-	Hook::unregister('post_remote_end', 'addon/mailstream/mailstream.php', 'mailstream_post_remote_hook');
-	Hook::unregister('post_local_end', 'addon/mailstream/mailstream.php', 'mailstream_post_hook');
-	Hook::unregister('post_remote_end', 'addon/mailstream/mailstream.php', 'mailstream_post_hook');
-	Hook::unregister('cron', 'addon/mailstream/mailstream.php', 'mailstream_cron');
-	Hook::unregister('incoming_mail', 'addon/mailstream/mailstream.php', 'mailstream_incoming_mail');
-}
-
 function mailstream_module() {}
 
 function mailstream_addon_admin(&$a,&$o) {

--- a/mastodoncustomemojis/mastodoncustomemojis.php
+++ b/mastodoncustomemojis/mastodoncustomemojis.php
@@ -27,16 +27,6 @@ function mastodoncustomemojis_install()
 	Hook::register('contacts_mod_init',  __FILE__, 'mastodoncustomemojis_css_hook');
 }
 
-function mastodoncustomemojis_uninstall()
-{
-	Hook::unregister('put_item_in_cache',  __FILE__, 'mastodoncustomemojis_put_item_in_cache');
-	Hook::unregister('network_mod_init',   __FILE__, 'mastodoncustomemojis_css_hook');
-	Hook::unregister('display_mod_init',   __FILE__, 'mastodoncustomemojis_css_hook');
-	Hook::unregister('search_mod_init',    __FILE__, 'mastodoncustomemojis_css_hook');
-	Hook::unregister('community_mod_init', __FILE__, 'mastodoncustomemojis_css_hook');
-	Hook::unregister('contacts_mod_init',  __FILE__, 'mastodoncustomemojis_css_hook');
-}
-
 function mastodoncustomemojis_css_hook(App $a)
 {
 	DI::page()['htmlhead'] .= <<<HTML

--- a/mathjax/mathjax.php
+++ b/mathjax/mathjax.php
@@ -20,18 +20,6 @@ function mathjax_install()
 	Hook::register('addon_settings_post', __FILE__, 'mathjax_settings_post');
 }
 
-function mathjax_uninstall()
-{
-	Hook::unregister('footer'             , __FILE__, 'mathjax_footer');
-	Hook::unregister('addon_settings'     , __FILE__, 'mathjax_settings');
-	Hook::unregister('addon_settings_post', __FILE__, 'mathjax_settings_post');
-
-	// Legacy hooks
-	Hook::unregister('load_config'        , __FILE__, 'mathjax_load_config');
-	Hook::unregister('page_header'        , __FILE__, 'mathjax_page_header');
-	Hook::unregister('template_vars'      , __FILE__, 'mathjax_template_vars');
-}
-
 function mathjax_settings_post($a)
 {
 	if (!local_user() || empty($_POST['mathjax-submit'])) {

--- a/membersince/membersince.php
+++ b/membersince/membersince.php
@@ -16,11 +16,6 @@ function membersince_install()
 	Hook::register('profile_advanced', 'addon/membersince/membersince.php', 'membersince_display');
 }
 
-function membersince_uninstall()
-{
-	Hook::unregister('profile_advanced', 'addon/membersince/membersince.php', 'membersince_display');
-}
-
 function membersince_display(Friendica\App $a, &$b)
 {
 	if ($a->getCurrentTheme() == 'frio') {

--- a/morechoice/morechoice.php
+++ b/morechoice/morechoice.php
@@ -18,18 +18,6 @@ function morechoice_install() {
 	Hook::register('marital_selector', 'addon/morechoice/morechoice.php', 'morechoice_marital_selector');
 }
 
-
-function morechoice_uninstall() {
-
-	Hook::unregister('gender_selector', 'addon/morechoice/morechoice.php', 'morechoice_gender_selector');
-	Hook::unregister('sexpref_selector', 'addon/morechoice/morechoice.php', 'morechoice_sexpref_selector');
-	Hook::unregister('marital_selector', 'addon/morechoice/morechoice.php', 'morechoice_marital_selector');
-
-// We need to leave this here for a while, because we now have a situation where people can end up with an orphaned hook.
-	Hook::unregister('poke_verbs', 'addon/morechoice/morechoice.php', 'morechoice_poke_verbs');
-
-}
-
 function morechoice_gender_selector($a,&$b) {
 	$b['Androgyne'] = DI::l10n()->t('Androgyne');
 	$b['Bear'] = DI::l10n()->t('Bear');

--- a/morepokes/morepokes.php
+++ b/morepokes/morepokes.php
@@ -14,11 +14,6 @@ function morepokes_install()
 	  Hook::register('poke_verbs', 'addon/morepokes/morepokes.php', 'morepokes_poke_verbs');
 }
 
-function morepokes_uninstall()
-{
-	  Hook::unregister('poke_verbs', 'addon/morepokes/morepokes.php', 'morepokes_poke_verbs');
-}
-
 function morepokes_poke_verbs($a, &$b)
 {
 	$b['bitchslap'] = ['bitchslapped', DI::l10n()->t('bitchslap'), DI::l10n()->t('bitchslapped')];

--- a/namethingy/namethingy.php
+++ b/namethingy/namethingy.php
@@ -14,11 +14,6 @@ function namethingy_install() {
     Hook::register('app_menu', 'addon/namethingy/namethingy.php', 'namethingy_app_menu');
 }
 
-function namethingy_uninstall() {
-    Hook::unregister('app_menu', 'addon/namethingy/namethingy.php', 'namethingy_app_menu');
-
-}
-
 function namethingy_app_menu($a,&$b) {
     $b['app_menu'][] = '<div class="app-title"><a href="namethingy">NameThingy</a></div>';
 }

--- a/newmemberwidget/newmemberwidget.php
+++ b/newmemberwidget/newmemberwidget.php
@@ -19,11 +19,6 @@ function newmemberwidget_install()
 	Logger::log('newmemberwidget installed');
 }
 
-function newmemberwidget_uninstall()
-{
-	Hook::unregister( 'network_mod_init', 'addon/newmemberwidget/newmemberwidget.php', 'newmemberwidget_network_mod_init');
-}
-
 function newmemberwidget_network_mod_init ($a, $b)
 {
 	if (empty($_SESSION['new_member'])) {

--- a/notifyall/notifyall.php
+++ b/notifyall/notifyall.php
@@ -15,16 +15,6 @@ use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\DI;
 
-function notifyall_install()
-{
-	Logger::log("installed notifyall");
-}
-
-function notifyall_uninstall()
-{
-	Logger::log("removed notifyall");
-}
-
 function notifyall_module() {}
 
 function notifyall_addon_admin(App $a, &$o)

--- a/notimeline/notimeline.php
+++ b/notimeline/notimeline.php
@@ -16,12 +16,6 @@ function notimeline_install()
 	Hook::register('addon_settings_post', 'addon/notimeline/notimeline.php', 'notimeline_settings_post');
 }
 
-function notimeline_uninstall()
-{
-	Hook::unregister('addon_settings', 'addon/notimeline/notimeline.php', 'notimeline_settings');
-	Hook::unregister('addon_settings_post', 'addon/notimeline/notimeline.php', 'notimeline_settings_post');
-}
-
 function notimeline_settings_post($a, $post)
 {
 	if (!local_user() || empty($_POST['notimeline-submit'])) {

--- a/nsfw/nsfw.php
+++ b/nsfw/nsfw.php
@@ -17,14 +17,6 @@ function nsfw_install()
 	Hook::register('addon_settings_post', 'addon/nsfw/nsfw.php', 'nsfw_addon_settings_post');
 }
 
-function nsfw_uninstall()
-{
-	Hook::unregister('prepare_body_content_filter', 'addon/nsfw/nsfw.php', 'nsfw_prepare_body_content_filter');
-	Hook::unregister('prepare_body', 'addon/nsfw/nsfw.php', 'nsfw_prepare_body');
-	Hook::unregister('addon_settings', 'addon/nsfw/nsfw.php', 'nsfw_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/nsfw/nsfw.php', 'nsfw_addon_settings_post');
-}
-
 // This function isn't perfect and isn't trying to preserve the html structure - it's just a
 // quick and dirty filter to pull out embedded photo blobs because 'nsfw' seems to come up
 // inside them quite often. We don't need anything fancy, just pull out the data blob so we can

--- a/numfriends/numfriends.php
+++ b/numfriends/numfriends.php
@@ -17,16 +17,6 @@ function numfriends_install() {
 	Logger::log("installed numfriends");
 }
 
-
-function numfriends_uninstall() {
-
-	Hook::unregister('addon_settings', 'addon/numfriends/numfriends.php', 'numfriends_settings');
-	Hook::unregister('addon_settings_post', 'addon/numfriends/numfriends.php', 'numfriends_settings_post');
-
-
-	Logger::log("removed numfriends");
-}
-
 /**
  *
  * Callback from the settings post function.

--- a/openstreetmap/openstreetmap.php
+++ b/openstreetmap/openstreetmap.php
@@ -34,18 +34,6 @@ function openstreetmap_install()
 	Logger::log("installed openstreetmap");
 }
 
-function openstreetmap_uninstall()
-{
-	Hook::unregister('load_config',     'addon/openstreetmap/openstreetmap.php', 'openstreetmap_load_config');
-	Hook::unregister('render_location', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_location');
-	Hook::unregister('generate_map', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_generate_map');
-	Hook::unregister('generate_named_map', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_generate_named_map');
-	Hook::unregister('Map::getCoordinates', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_get_coordinates');
-	Hook::unregister('page_header', 'addon/openstreetmap/openstreetmap.php', 'openstreetmap_alterheader');
-
-	Logger::log("removed openstreetmap");
-}
-
 function openstreetmap_load_config(\Friendica\App $a, ConfigFileLoader $loader)
 {
 	$a->getConfigCache()->load($loader->loadAddonConfig('openstreetmap'));

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -45,13 +45,6 @@ function piwik_install() {
 	Logger::log("installed piwik addon");
 }
 
-function piwik_uninstall() {
-	Hook::unregister('load_config', 'addon/piwik/piwik.php', 'piwik_load_config');
-	Hook::unregister('page_end', 'addon/piwik/piwik.php', 'piwik_analytics');
-
-	Logger::log("uninstalled piwik addon");
-}
-
 function piwik_load_config(\Friendica\App $a, ConfigFileLoader $loader)
 {
 	$a->getConfigCache()->load($loader->loadAddonConfig('piwik'));

--- a/planets/planets.php
+++ b/planets/planets.php
@@ -35,27 +35,6 @@ function planets_install() {
 	Logger::log("installed planets");
 }
 
-
-function planets_uninstall() {
-
-	/**
-	 *
-	 * uninstall unregisters any hooks created with register_hook
-	 * during install. It may also delete configuration settings
-	 * and any other cleanup.
-	 *
-	 */
-
-	Hook::unregister('post_local',    'addon/planets/planets.php', 'planets_post_hook');
-	Hook::unregister('addon_settings', 'addon/planets/planets.php', 'planets_settings');
-	Hook::unregister('addon_settings_post', 'addon/planets/planets.php', 'planets_settings_post');
-
-
-	Logger::log("removed planets");
-}
-
-
-
 function planets_post_hook($a, &$item) {
 
 	/**

--- a/public_server/public_server.php
+++ b/public_server/public_server.php
@@ -27,15 +27,6 @@ function public_server_install()
 	Hook::register('logged_in', 'addon/public_server/public_server.php', 'public_server_login');
 }
 
-function public_server_uninstall()
-{
-	Hook::unregister('load_config',      'addon/public_server/public_server.php', 'public_server_load_config');
-	Hook::unregister('register_account', 'addon/public_server/public_server.php', 'public_server_register_account');
-	Hook::unregister('cron', 'addon/public_server/public_server.php', 'public_server_cron');
-	Hook::unregister('enotify', 'addon/public_server/public_server.php', 'public_server_enotify');
-	Hook::unregister('logged_in', 'addon/public_server/public_server.php', 'public_server_login');
-}
-
 function public_server_load_config(App $a, ConfigFileLoader $loader)
 {
 	$a->getConfigCache()->load($loader->loadAddonConfig('public_server'));

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -45,19 +45,6 @@ function pumpio_install()
 	Hook::register('check_item_notification', 'addon/pumpio/pumpio.php', 'pumpio_check_item_notification');
 }
 
-function pumpio_uninstall()
-{
-	Hook::unregister('load_config',      'addon/pumpio/pumpio.php', 'pumpio_load_config');
-	Hook::unregister('hook_fork',        'addon/pumpio/pumpio.php', 'pumpio_hook_fork');
-	Hook::unregister('post_local',       'addon/pumpio/pumpio.php', 'pumpio_post_local');
-	Hook::unregister('notifier_normal',  'addon/pumpio/pumpio.php', 'pumpio_send');
-	Hook::unregister('jot_networks',     'addon/pumpio/pumpio.php', 'pumpio_jot_nets');
-	Hook::unregister('connector_settings',      'addon/pumpio/pumpio.php', 'pumpio_settings');
-	Hook::unregister('connector_settings_post', 'addon/pumpio/pumpio.php', 'pumpio_settings_post');
-	Hook::unregister('cron', 'addon/pumpio/pumpio.php', 'pumpio_cron');
-	Hook::unregister('check_item_notification', 'addon/pumpio/pumpio.php', 'pumpio_check_item_notification');
-}
-
 function pumpio_module() {}
 
 function pumpio_content(App $a)

--- a/qcomment/qcomment.php
+++ b/qcomment/qcomment.php
@@ -27,12 +27,6 @@ function qcomment_install() {
 
 }
 
-function qcomment_uninstall() {
-	Hook::unregister('addon_settings', 'addon/qcomment/qcomment.php', 'qcomment_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/qcomment/qcomment.php', 'qcomment_addon_settings_post');
-
-}
-
 function qcomment_addon_settings(&$a, &$s)
 {
 	if (! local_user()) {

--- a/randplace/randplace.php
+++ b/randplace/randplace.php
@@ -52,16 +52,11 @@ function randplace_uninstall() {
 
 	/**
 	 *
-	 * uninstall unregisters any hooks created with register_hook
-	 * during install. It may also delete configuration settings
-	 * and any other cleanup.
+	 * This function should undo anything that was done in name_install()
+	 *
+	 * Except hooks, they are all unregistered automatically and don't need to be unregistered manually.
 	 *
 	 */
-
-	Hook::unregister('post_local',    'addon/randplace/randplace.php', 'randplace_post_hook');
-	Hook::unregister('addon_settings', 'addon/randplace/randplace.php', 'randplace_settings');
-	Hook::unregister('addon_settings_post', 'addon/randplace/randplace.php', 'randplace_settings_post');
-
 
 	Logger::log("removed randplace");
 }

--- a/remote_permissions/remote_permissions.php
+++ b/remote_permissions/remote_permissions.php
@@ -19,12 +19,6 @@ function remote_permissions_install() {
 	Hook::register('addon_settings_post', 'addon/remote_permissions/remote_permissions.php', 'remote_permissions_settings_post');
 }
 
-function remote_permissions_uninstall() {
-	Hook::unregister('lockview_content', 'addon/remote_permissions/remote_permissions.php', 'remote_permissions_content');
-	Hook::unregister('addon_settings', 'addon/remote_permissions/remote_permissions.php', 'remote_permissions_settings');
-	Hook::unregister('addon_settings_post', 'addon/remote_permissions/remote_permissions.php', 'remote_permissions_settings_post');
-}
-
 function remote_permissions_settings(&$a,&$o) {
 
 	if(! local_user())

--- a/rendertime/rendertime.php
+++ b/rendertime/rendertime.php
@@ -14,12 +14,6 @@ function rendertime_install() {
 	Hook::register('page_end', 'addon/rendertime/rendertime.php', 'rendertime_page_end');
 }
 
-
-function rendertime_uninstall() {
-	Hook::unregister('init_1', 'addon/rendertime/rendertime.php', 'rendertime_init_1');
-	Hook::unregister('page_end', 'addon/rendertime/rendertime.php', 'rendertime_page_end');
-}
-
 function rendertime_init_1(&$a) {
 }
 

--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -26,16 +26,6 @@ function securemail_install()
 	Logger::log('installed securemail');
 }
 
-function securemail_uninstall()
-{
-	Hook::unregister('addon_settings', 'addon/securemail/securemail.php', 'securemail_settings');
-	Hook::unregister('addon_settings_post', 'addon/securemail/securemail.php', 'securemail_settings_post');
-
-	Hook::unregister('emailer_send_prepare', 'addon/securemail/securemail.php', 'securemail_emailer_send_prepare');
-
-	Logger::log('removed securemail');
-}
-
 /**
  * @brief Build user settings form
  *

--- a/showmore/showmore.php
+++ b/showmore/showmore.php
@@ -18,13 +18,6 @@ function showmore_install()
 	Hook::register('addon_settings_post', 'addon/showmore/showmore.php', 'showmore_addon_settings_post');
 }
 
-function showmore_uninstall()
-{
-	Hook::unregister('prepare_body', 'addon/showmore/showmore.php', 'showmore_prepare_body');
-	Hook::unregister('addon_settings', 'addon/showmore/showmore.php', 'showmore_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/showmore/showmore.php', 'showmore_addon_settings_post');
-}
-
 function showmore_addon_settings(&$a, &$s)
 {
 	if (!local_user()) {

--- a/smiley_pack/lang/smiley_pack_es/smiley_pack_es.php
+++ b/smiley_pack/lang/smiley_pack_es/smiley_pack_es.php
@@ -13,12 +13,6 @@ function smiley_pack_es_install() {
 	Hook::register('smilie', 'addon/smiley_pack_es/smiley_pack_es.php', 'smiley_pack_smilies_es');
 }
 
-function smiley_pack_es_uninstall() {
-	Hook::unregister('smilie', 'addon/smiley_pack_es/smiley_pack_es.php', 'smiley_pack_smilies');
-}
-
- 
-
 function smiley_pack_smilies_es(&$a,&$b) {
 
 #Smileys are split into various directories by the intended range of emotions.  This is in case we get too big and need to modularise things.  We can then cut and paste the right lines, move the right directory, and just change the name of the addon to happy_smilies or whatever.

--- a/smiley_pack/lang/smiley_pack_fr/smiley_pack_fr.php
+++ b/smiley_pack/lang/smiley_pack_fr/smiley_pack_fr.php
@@ -15,12 +15,6 @@ function smiley_pack_fr_install() {
 	Hook::register('smilie', 'addon/smiley_pack_fr/smiley_pack_fr.php', 'smiley_pack_fr_smilies');
 }
 
-function smiley_pack_fr_uninstall() {
-	Hook::unregister('smilie', 'addon/smiley_pack_fr/smiley_pack_fr.php', 'smiley_pack_fr_smilies');
-}
-
- 
-
 function smiley_pack_fr_smilies(&$a,&$b) {
 
 #Smileys are split into various directories by the intended range of emotions.  This is in case we get too big and need to modularise things.  We can then cut and paste the right lines, move the right directory, and just change the name of the addon to happy_smilies or whatever.

--- a/smiley_pack/smiley_pack.php
+++ b/smiley_pack/smiley_pack.php
@@ -14,12 +14,6 @@ function smiley_pack_install() {
 	Hook::register('smilie', 'addon/smiley_pack/smiley_pack.php', 'smiley_pack_smilies');
 }
 
-function smiley_pack_uninstall() {
-	Hook::unregister('smilie', 'addon/smiley_pack/smiley_pack.php', 'smiley_pack_smilies');
-}
-
- 
-
 function smiley_pack_smilies(&$a,&$b) {
 
 #Smileys are split into various directories by the intended range of emotions.  This is in case we get too big and need to modularise things.  We can then cut and paste the right lines, move the right directory, and just change the name of the addon to happy_smilies or whatever.

--- a/smileybutton/smileybutton.php
+++ b/smileybutton/smileybutton.php
@@ -16,16 +16,6 @@ function smileybutton_install() {
 	Logger::log("installed smileybutton");
 }
 
-
-function smileybutton_uninstall() {
-	//Delet registered hooks
-	Hook::unregister('jot_tool',    'addon/smileybutton/smileybutton.php', 'show_button');
-
-	Logger::log("removed smileybutton");
-}
-
-
-
 function show_button(Friendica\App $a, &$b) {
 	// Disable if theme is quattro
 	// TODO add style for quattro

--- a/smilies_adult/smilies_adult.php
+++ b/smilies_adult/smilies_adult.php
@@ -15,12 +15,6 @@ function smilies_adult_install() {
 	Hook::register('smilie', 'addon/smilies_adult/smilies_adult.php', 'smilies_adult_smilies');
 }
 
-function smilies_adult_uninstall() {
-	Hook::unregister('smilie', 'addon/smilies_adult/smilies_adult.php', 'smilies_adult_smilies');
-}
-
- 
-
 function smilies_adult_smilies(&$a,&$b) {
 
 	$b['texts'][] = '(o)(o)';

--- a/sniper/sniper.php
+++ b/sniper/sniper.php
@@ -16,11 +16,6 @@ function sniper_install() {
     Hook::register('app_menu', 'addon/sniper/sniper.php', 'sniper_app_menu');
 }
 
-function sniper_uninstall() {
-    Hook::unregister('app_menu', 'addon/sniper/sniper.php', 'sniper_app_menu');
-
-}
-
 function sniper_app_menu($a,&$b) {
     $b['app_menu'][] = '<div class="app-title"><a href="sniper">Hot Shot Sniper</a></div>';
 }

--- a/startpage/startpage.php
+++ b/startpage/startpage.php
@@ -15,13 +15,6 @@ function startpage_install() {
 	Hook::register('addon_settings_post', 'addon/startpage/startpage.php', 'startpage_settings_post');
 }
 
-function startpage_uninstall()
-{
-	Hook::unregister('home_init', 'addon/startpage/startpage.php', 'startpage_home_init');
-	Hook::unregister('addon_settings', 'addon/startpage/startpage.php', 'startpage_settings');
-	Hook::unregister('addon_settings_post', 'addon/startpage/startpage.php', 'startpage_settings_post');
-}
-
 function startpage_home_init($a, $b)
 {
 	if (!local_user()) {

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -74,24 +74,6 @@ function statusnet_install()
 	Logger::log("installed GNU Social");
 }
 
-function statusnet_uninstall()
-{
-	Hook::unregister('connector_settings', 'addon/statusnet/statusnet.php', 'statusnet_settings');
-	Hook::unregister('connector_settings_post', 'addon/statusnet/statusnet.php', 'statusnet_settings_post');
-	Hook::unregister('notifier_normal', 'addon/statusnet/statusnet.php', 'statusnet_post_hook');
-	Hook::unregister('hook_fork', 'addon/statusnet/statusnet.php', 'statusnet_hook_fork');
-	Hook::unregister('post_local', 'addon/statusnet/statusnet.php', 'statusnet_post_local');
-	Hook::unregister('jot_networks', 'addon/statusnet/statusnet.php', 'statusnet_jot_nets');
-	Hook::unregister('cron', 'addon/statusnet/statusnet.php', 'statusnet_cron');
-	Hook::unregister('prepare_body', 'addon/statusnet/statusnet.php', 'statusnet_prepare_body');
-	Hook::unregister('check_item_notification', 'addon/statusnet/statusnet.php', 'statusnet_check_item_notification');
-
-	// old setting - remove only
-	Hook::unregister('post_local_end', 'addon/statusnet/statusnet.php', 'statusnet_post_hook');
-	Hook::unregister('addon_settings', 'addon/statusnet/statusnet.php', 'statusnet_settings');
-	Hook::unregister('addon_settings_post', 'addon/statusnet/statusnet.php', 'statusnet_settings_post');
-}
-
 function statusnet_check_item_notification(App $a, &$notification_data)
 {
 	if (DI::pConfig()->get($notification_data["uid"], 'statusnet', 'post')) {

--- a/superblock/superblock.php
+++ b/superblock/superblock.php
@@ -19,15 +19,6 @@ function superblock_install()
 	Hook::register('enotify_store', 'addon/superblock/superblock.php', 'superblock_enotify_store');
 }
 
-function superblock_uninstall()
-{
-	Hook::unregister('addon_settings', 'addon/superblock/superblock.php', 'superblock_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/superblock/superblock.php', 'superblock_addon_settings_post');
-	Hook::unregister('conversation_start', 'addon/superblock/superblock.php', 'superblock_conversation_start');
-	Hook::unregister('item_photo_menu', 'addon/superblock/superblock.php', 'superblock_item_photo_menu');
-	Hook::unregister('enotify_store', 'addon/superblock/superblock.php', 'superblock_enotify_store');
-}
-
 function superblock_addon_settings(&$a, &$s)
 {
 	if (!local_user()) {

--- a/testdrive/testdrive.php
+++ b/testdrive/testdrive.php
@@ -26,17 +26,6 @@ function testdrive_install() {
 
 }
 
-
-function testdrive_uninstall() {
-
-	Hook::unregister('load_config',      'addon/testdrive/testdrive.php', 'testdrive_load_config');
-	Hook::unregister('register_account', 'addon/testdrive/testdrive.php', 'testdrive_register_account');
-	Hook::unregister('cron', 'addon/testdrive/testdrive.php', 'testdrive_cron');
-	Hook::unregister('enotify','addon/testdrive/testdrive.php', 'testdrive_enotify');
-	Hook::unregister('globaldir_update','addon/testdrive/testdrive.php', 'testdrive_globaldir_update');
-
-}
-
 function testdrive_load_config(App $a, ConfigFileLoader $loader)
 {
 	$a->getConfigCache()->load($loader->loadAddonConfig('testdrive'));

--- a/tictac/tictac.php
+++ b/tictac/tictac.php
@@ -12,11 +12,6 @@ function tictac_install() {
 	Hook::register('app_menu', 'addon/tictac/tictac.php', 'tictac_app_menu');
 }
 
-function tictac_uninstall() {
-	Hook::unregister('app_menu', 'addon/tictac/tictac.php', 'tictac_app_menu');
-
-}
-
 function tictac_app_menu($a,&$b) {
 	$b['app_menu'][] = '<div class="app-title"><a href="tictac">' . DI::l10n()->t('Three Dimensional Tic-Tac-Toe') . '</a></div>';
 }

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -29,16 +29,6 @@ function tumblr_install()
 	Hook::register('connector_settings_post', 'addon/tumblr/tumblr.php', 'tumblr_settings_post');
 }
 
-function tumblr_uninstall()
-{
-	Hook::unregister('hook_fork',               'addon/tumblr/tumblr.php', 'tumblr_hook_fork');
-	Hook::unregister('post_local',              'addon/tumblr/tumblr.php', 'tumblr_post_local');
-	Hook::unregister('notifier_normal',         'addon/tumblr/tumblr.php', 'tumblr_send');
-	Hook::unregister('jot_networks',            'addon/tumblr/tumblr.php', 'tumblr_jot_nets');
-	Hook::unregister('connector_settings',      'addon/tumblr/tumblr.php', 'tumblr_settings');
-	Hook::unregister('connector_settings_post', 'addon/tumblr/tumblr.php', 'tumblr_settings_post');
-}
-
 function tumblr_module()
 {
 }

--- a/unicode_smilies/unicode_smilies.php
+++ b/unicode_smilies/unicode_smilies.php
@@ -13,10 +13,6 @@ function unicode_smilies_install() {
 	Hook::register('smilie', 'addon/unicode_smilies/unicode_smilies.php', 'unicode_smilies_smilies');
 }
 
-function unicode_smilies_uninstall() {
-	Hook::unregister('smilie', 'addon/unicode_smilies/unicode_smilies.php', 'unicode_smilies_smilies');
-}
-
 function unicode_smilies_smilies(&$a,&$b) {
 	Smilies::add($b, ':-)', '&#x1F600;');
 	Smilies::add($b, ':)', '&#x1F600;');

--- a/viewsrc/viewsrc.php
+++ b/viewsrc/viewsrc.php
@@ -16,13 +16,6 @@ function viewsrc_install() {
 	Hook::register('page_end', 'addon/viewsrc/viewsrc.php', 'viewsrc_page_end');
 }
 
-
-function viewsrc_uninstall() {
-	Hook::unregister('item_photo_menu', 'addon/viewsrc/viewsrc.php', 'viewsrc_item_photo_menu');
-	Hook::unregister('page_end', 'addon/viewsrc/viewsrc.php', 'viewsrc_page_end');
-
-}
-
 function viewsrc_page_end(&$a, &$o){
 	DI::page()['htmlhead'] .= <<< EOS
 	<script>

--- a/webrtc/webrtc.php
+++ b/webrtc/webrtc.php
@@ -15,11 +15,6 @@ function webrtc_install() {
         Hook::register('app_menu', 'addon/webrtc/webrtc.php', 'webrtc_app_menu');
 }
 
-function webrtc_uninstall() {
-        Hook::unregister('app_menu', 'addon/webrtc/webrtc.php', 'webrtc_app_menu');
-
-}
-
 function webrtc_app_menu($a,&$b) {
 	$b['app_menu'][] = '<div class="app-title"><a href="webrtc">' . DI::l10n()->t('WebRTC Videochat') . '</a></div>';
 }

--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -20,11 +20,6 @@ function widgets_install() {
 	Logger::log("installed widgets");
 }
 
-function widgets_uninstall() {
-	Hook::unregister('addon_settings', 'addon/widgets/widgets.php', 'widgets_settings');
-	Hook::unregister('addon_settings_post', 'addon/widgets/widgets.php', 'widgets_settings_post');
-}
-
 function widgets_settings_post(){
 	if(! local_user())
 		return;

--- a/windowsphonepush/windowsphonepush.php
+++ b/windowsphonepush/windowsphonepush.php
@@ -55,18 +55,6 @@ function windowsphonepush_install()
 	Logger::log("installed windowsphonepush");
 }
 
-function windowsphonepush_uninstall()
-{
-	/* uninstall unregisters any hooks created with register_hook
-	 * during install. Don't delete data in table `pconfig`.
-	 */
-	Hook::unregister('cron', 'addon/windowsphonepush/windowsphonepush.php', 'windowsphonepush_cron');
-	Hook::unregister('addon_settings', 'addon/windowsphonepush/windowsphonepush.php', 'windowsphonepush_settings');
-	Hook::unregister('addon_settings_post', 'addon/windowsphonepush/windowsphonepush.php', 'windowsphonepush_settings_post');
-
-	Logger::log("removed windowsphonepush");
-}
-
 /* declare the windowsphonepush function so that /windowsphonepush url requests will land here */
 function windowsphonepush_module()
 {

--- a/wppost/wppost.php
+++ b/wppost/wppost.php
@@ -25,22 +25,6 @@ function wppost_install()
 	Hook::register('connector_settings_post', 'addon/wppost/wppost.php', 'wppost_settings_post');
 }
 
-function wppost_uninstall()
-{
-	Hook::unregister('hook_fork',        'addon/wppost/wppost.php', 'wppost_hook_fork');
-	Hook::unregister('post_local',       'addon/wppost/wppost.php', 'wppost_post_local');
-	Hook::unregister('notifier_normal',  'addon/wppost/wppost.php', 'wppost_send');
-	Hook::unregister('jot_networks',     'addon/wppost/wppost.php', 'wppost_jot_nets');
-	Hook::unregister('connector_settings',      'addon/wppost/wppost.php', 'wppost_settings');
-	Hook::unregister('connector_settings_post', 'addon/wppost/wppost.php', 'wppost_settings_post');
-
-	// obsolete - remove
-	Hook::unregister('post_local_end',   'addon/wppost/wppost.php', 'wppost_send');
-	Hook::unregister('addon_settings',  'addon/wppost/wppost.php', 'wppost_settings');
-	Hook::unregister('addon_settings_post',  'addon/wppost/wppost.php', 'wppost_settings_post');
-}
-
-
 function wppost_jot_nets(\Friendica\App &$a, array &$jotnets_fields)
 {
 	if (!local_user()) {

--- a/xmpp/xmpp.php
+++ b/xmpp/xmpp.php
@@ -21,14 +21,6 @@ function xmpp_install()
 	Hook::register('logged_in', 'addon/xmpp/xmpp.php', 'xmpp_login');
 }
 
-function xmpp_uninstall()
-{
-	Hook::unregister('addon_settings', 'addon/xmpp/xmpp.php', 'xmpp_addon_settings');
-	Hook::unregister('addon_settings_post', 'addon/xmpp/xmpp.php', 'xmpp_addon_settings_post');
-	Hook::unregister('page_end', 'addon/xmpp/xmpp.php', 'xmpp_script');
-	Hook::unregister('logged_in', 'addon/xmpp/xmpp.php', 'xmpp_login');
-}
-
 function xmpp_addon_settings_post()
 {
 	if (!local_user() || empty($_POST['xmpp-settings-submit'])) {


### PR DESCRIPTION
Related to https://github.com/friendica/friendica/pull/8931

- All hooks (current and obsolete) are removed automatically during addon uninstall