### PR TITLE
[twitter] Fix direct reshare id source

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -588,11 +588,11 @@ function twitter_post_hook(App $a, array &$b)
 	}
 
 	if ($b['verb'] == Activity::ANNOUNCE) {
-		Logger::info('Retweet', ['uid' => $b['uid'], 'id' => substr($b['thr-parent'], 9)]);
+		Logger::info('Retweet', ['uid' => $b['uid'], 'id' => substr($b['parent-uri'], 9)]);
 		if ($b['deleted']) {
 			twitter_action($a, $b["uid"], substr($orig_post["extid"], 9), "delete");
 		} else {
-			twitter_retweet($b["uid"], substr($b["thr-parent"], 9));
+			twitter_retweet($b['uid'], substr($b['parent-uri'], 9));
 		}
 
 		return;


### PR DESCRIPTION
Addresses https://github.com/friendica/friendica/issues/9250#issuecomment-709238399

I looked into my DB to find the closest field that had the expected format `twitter:XXXXXXXXX`  that the `substr(..., 9)` is looking for, and settled on `parent-uri`, but I'm not sure about it.

Please advise.