### PR TITLE
Twitter: Fix display of reshared posts

### DIFF
--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -1106,11 +1106,13 @@ function statusnet_createpost(App $a, $uid, $post, $self, $create_user, $only_ex
 	if (!empty($content->in_reply_to_status_id)) {
 		$thr_parent = $hostname . "::" . $content->in_reply_to_status_id;
 
-		if (
-			Item::exists(['uri' => $thr_parent, 'uid' => $uid])
-			|| Item::exists(['extid' => $thr_parent, 'uid' => $uid])
-		) {
-			$postarray['thr-parent'] = $thr_parent;
+		$item = Item::selectFirst(['uri'], ['uri' => $thr_parent, 'uid' => $uid]);
+		if (!DBA::isResult($item)) {
+			$item = Item::selectFirst(['uri'], ['extid' => $thr_parent, 'uid' => $uid]);
+		}
+
+		if (DBA::isResult($item)) {
+			$postarray['thr-parent'] = $item['uri'];
 			$postarray['object-type'] = Activity\ObjectType::COMMENT;
 		} else {
 			$postarray['object-type'] = Activity\ObjectType::NOTE;

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1584,11 +1584,13 @@ function twitter_createpost(App $a, $uid, $post, array $self, $create_user, $onl
 	if ($post->in_reply_to_status_id_str != "") {
 		$thr_parent = "twitter::" . $post->in_reply_to_status_id_str;
 
-		if (
-			Item::exists(['uri' => $thr_parent, 'uid' => $uid])
-			|| Item::exists(['extid' => $thr_parent, 'uid' => $uid])
-		) {
-			$postarray['thr-parent'] = $thr_parent;
+		$item = Item::selectFirst(['uri'], ['uri' => $thr_parent, 'uid' => $uid]);
+		if (!DBA::isResult($item)) {
+			$item = Item::selectFirst(['uri'], ['extid' => $thr_parent, 'uid' => $uid]);
+		}
+
+		if (DBA::isResult($item)) {
+			$postarray['thr-parent'] = $item['uri'];
 			$postarray['object-type'] = Activity\ObjectType::COMMENT;
 		} else {
 			$postarray['object-type'] = Activity\ObjectType::NOTE;
@@ -1702,6 +1704,8 @@ function twitter_createpost(App $a, $uid, $post, array $self, $create_user, $onl
 			$postarray['verb'] = Activity::ANNOUNCE;
 			$postarray['gravity'] = GRAVITY_ACTIVITY;
 			$postarray['object-type'] = Activity\ObjectType::NOTE;
+
+			$postarray['thr-parent'] = $retweet['uri'];
 		} else {
 			$retweet['source'] = $postarray['source'];
 			$retweet['private'] = $postarray['private'];
@@ -1919,7 +1923,7 @@ function twitter_fetchhometimeline(App $a, $uid)
 
 			$notify = false;
 
-			if (($postarray['uri'] == $postarray['thr-parent']) && ($postarray['author-link'] == $postarray['owner-link'])) {
+			if (empty($postarray['thr-parent'])) {
 				$contact = DBA::selectFirst('contact', [], ['id' => $postarray['contact-id'], 'self' => false]);
 				if (DBA::isResult($contact)) {
 					$notify = Item::isRemoteSelf($contact, $postarray);


### PR DESCRIPTION
Reshared posts are now marked as this again. This fixes https://github.com/friendica/friendica/issues/9562

Also the handling of the `extid` field had been fixed as well in Twitter and Statusnet.