### PR TITLE
Twitter: Posts are now with links again

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -675,6 +675,11 @@ function twitter_post_hook(App $a, array &$b)
 			$msg = Plaintext::shorten($msgarr["title"], $max_char - 50);
 		}
 
+		// Add the link to the body if the type isn't a photo or there are more than 4 images in the post
+		if (!empty($msgarr['url']) && (($msgarr['type'] != 'photo') || empty($msgarr['images']) || (count($msgarr['images']) > 4))) {
+			$msg .= "\n" . $msgarr['url'];
+		}
+
 		if (empty($msg)) {
 			Logger::notice('Empty message', ['id' => $b['id']]);
 			return;


### PR DESCRIPTION
Posts with links are now working again. Fixes https://github.com/friendica/friendica/issues/9624