### PR TITLE
Pumpio: Fix unknown table field / viewsrc: increase page speed 

### DIFF
--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -1300,7 +1300,7 @@ function pumpio_fetchinbox(App $a, $uid)
 		intval($uid));
 
 	$lastitems = q("SELECT `uri` FROM `post-thread-user`
-			INNER JOIN `post-view` ON `post-view`.`id` = `post-thread-user`.`iid`
+			INNER JOIN `post-view` ON `post-view`.`id` = `post-thread-user`.`id`
 			WHERE `post-thread-user`.`network` = '%s' AND `post-thread-user`.`uid` = %d AND `post-view`.`extid` != ''
 			ORDER BY `post-thread-user`.`commented` DESC LIMIT 10",
 				DBA::escape(Protocol::PUMPIO),

--- a/viewsrc/viewsrc.php
+++ b/viewsrc/viewsrc.php
@@ -8,9 +8,6 @@
  */
 use Friendica\Core\Hook;
 use Friendica\DI;
-use Friendica\Model\Item;
-use Friendica\Database\DBA;
-use Friendica\Model\Post;
 
 function viewsrc_install() {
 	Hook::register('item_photo_menu', 'addon/viewsrc/viewsrc.php', 'viewsrc_item_photo_menu');
@@ -35,21 +32,5 @@ function viewsrc_item_photo_menu(&$a, &$b)
 		return;
 	}
 
-	if (local_user() != $b['item']['uid']) {
-		$item = Post::selectFirstForUser(local_user(), ['id'], ['uid' => local_user(), 'guid' => $b['item']['guid']]);
-		if (!DBA::isResult($item)) {
-			return;
-		}
-
-		$item_id = $item['id'];
-	} else {
-		$item_id = $b['item']['id'];
-	}
-
-	$b['menu'] = array_merge([DI::l10n()->t('View Source') => DI::baseUrl()->get() . '/viewsrc/'. $item_id], $b['menu']);
-
-	//if((! local_user()) || (local_user() != $b['item']['uid']))
-	//	return;
-
-	//$b['menu'] = array_merge(array(DI::l10n()->t('View Source') => $a->getBaseURL() . '/viewsrc/'. $b['item']['id']), $b['menu']);
+	$b['menu'] = array_merge([DI::l10n()->t('View Source') => DI::baseUrl()->get() . '/viewsrc/'. $b['item']['uri-id']], $b['menu']);
 }


### PR DESCRIPTION
This combines two fixes:

1. Pumpio: The query used the non existing field "iid"
2. Viewsrc: The queries aren't needed anymore