### PR TITLE
Twitter: Attachments are stripped from the body / Posting connectors: Add attachments to the body

### DIFF
--- a/diaspora/diaspora.php
+++ b/diaspora/diaspora.php
@@ -18,6 +18,7 @@ use Friendica\Core\Session;
 use Friendica\Database\DBA;
 use Friendica\Core\Worker;
 use Friendica\DI;
+use Friendica\Model\Post;
 
 function diaspora_install()
 {
@@ -196,6 +197,8 @@ function diaspora_send(App $a, array &$b)
 	if ($b['parent'] != $b['id']) {
 		return;
 	}
+
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
 
 	// Dont't post if the post doesn't belong to us.
 	// This is a check for forum postings

--- a/dwpost/dwpost.php
+++ b/dwpost/dwpost.php
@@ -14,6 +14,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\XML;
@@ -158,6 +159,8 @@ function dwpost_send(App $a, array &$b)
 	if ($b['parent'] != $b['id']) {
 		return;
 	}
+
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
 
 	/*
 	 * dreamwidth post in the LJ user's timezone.

--- a/libertree/libertree.php
+++ b/libertree/libertree.php
@@ -12,6 +12,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Post;
 
 function libertree_install()
 {
@@ -190,6 +191,8 @@ function libertree_send(&$a,&$b) {
 	if ($b['contact-id'] != $self['id']) {
 		return;
 	}
+
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
 
 	$ltree_api_token = DI::pConfig()->get($b['uid'],'libertree','libertree_api_token');
 	$ltree_url = DI::pConfig()->get($b['uid'],'libertree','libertree_url');

--- a/ljpost/ljpost.php
+++ b/ljpost/ljpost.php
@@ -12,6 +12,7 @@ use Friendica\Content\Text\BBCode;
 use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\DI;
+use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Util\DateTimeFormat;
 use Friendica\Util\XML;
@@ -152,6 +153,8 @@ function ljpost_send(&$a,&$b) {
 
     if($b['parent'] != $b['id'])
         return;
+
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
 
 	// LiveJournal post in the LJ user's timezone.
 	// Hopefully the person's Friendica account

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -436,6 +436,8 @@ function pumpio_send(App $a, array &$b)
 
 	Logger::log("pumpio_send: parameter ".print_r($b, true), Logger::DATA);
 
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
+
 	if ($b['parent'] != $b['id']) {
 		// Looking if its a reply to a pumpio post
 		$condition = ['id' => $b['parent'], 'network' => Protocol::PUMPIO];

--- a/statusnet/statusnet.php
+++ b/statusnet/statusnet.php
@@ -481,6 +481,8 @@ function statusnet_post_hook(App $a, &$b)
 			return;
 	}
 
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
+
 	$api = DI::pConfig()->get($b["uid"], 'statusnet', 'baseapi');
 	$hostname = preg_replace("=https?://([\w\.]*)/.*=ism", "$1", $api);
 

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -16,6 +16,7 @@ use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
+use Friendica\Model\Post;
 use Friendica\Model\Tag;
 use Friendica\Util\Strings;
 
@@ -365,6 +366,8 @@ function tumblr_send(App $a, array &$b) {
 	if ($b['contact-id'] != $self['id']) {
 		return;
 	}
+
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
 
 	$oauth_token = DI::pConfig()->get($b['uid'], "tumblr", "oauth_token");
 	$oauth_token_secret = DI::pConfig()->get($b['uid'], "tumblr", "oauth_token_secret");

--- a/wppost/wppost.php
+++ b/wppost/wppost.php
@@ -12,7 +12,7 @@ use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Database\DBA;
 use Friendica\DI;
-use Friendica\Util\Strings;
+use Friendica\Model\Post;
 use Friendica\Util\XML;
 
 function wppost_install()
@@ -222,6 +222,8 @@ function wppost_send(&$a, &$b)
 	if ($b['contact-id'] != $self['id']) {
 		return;
 	}
+
+	$b['body'] = Post\Media::addAttachmentsToBody($b['uri-id'], $b['body']);
 
 	$wp_username = XML::escape(DI::pConfig()->get($b['uid'], 'wppost', 'wp_username'));
 	$wp_password = XML::escape(DI::pConfig()->get($b['uid'], 'wppost', 'wp_password'));


### PR DESCRIPTION
We are currently in the process of removing media links from the body. For Twitter this means that we now longer embed the media links directly into the body.

For the posting connectors we have to do the opposite: We add the media links back into the body. In the future we should replace this with a functionality that works with the attachments, but for now this is a good workaround.