### PR TITLE
Enable Drone for Friendica addons

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,39 @@
+---
+kind: pipeline
+type: docker
+name: Check messages.po
+
+clone:
+  disable: true
+
+trigger:
+  event:
+    - pull_request
+
+steps:
+  - name: clone friendica base
+    image: alpine/git
+    commands:
+      - git clone https://github.com/friendica/friendica.git .
+      - git checkout $DRONE_COMMIT_BRANCH
+  - name: clone friendica addon
+    image: alpine/git
+    commands:
+      - git clone $DRONE_REMOTE_URL addon
+      - git checkout $DRONE_COMMIT_REF
+  - name: Run default Xgettext
+    image: friendicaci/transifex
+    commands:
+      - export CHANGED_FILES=($(git diff --name-status ${DRONE_COMMIT_BEFORE}..${DRONE_COMMIT_AFTER} | grep ^A | cut -f2))
+      - export FIND_RESULT=$(printf "%s\n" "$CHANGED_FILES[@]" | sed '/^\./d' | cut -d "/" -f1 | uniq)
+      - for addon in $FIND_RESULT; do ./bin/run_xgettext.sh --addon $addon; done
+  - name: Check update necessary
+    image: alpine/git
+    commands:
+      - cd addon/
+      - if [[ $(git diff -U0 "**/messages.po" | awk '!/index|diff|\-\-\-|\+\+\+|@@|\-"POT-Creation-Date|\+"POT-Creation-Date|\+#|\-#/{print }' | wc -l) > 0 ]]; then
+          echo "::error file=messages.po::messages.po is out of date"
+          exit 1
+        else
+          echo "Nothing to update"
+        fi


### PR DESCRIPTION
This enables the messages.po test inside drone.

We do need a working `.drone.yml` first inside the develop branch, before the integration with Github is working properly, so plz just merge this PR and I'll fix it aferwards in case ;-)