### PR TITLE
Mobile client tokens addon

### DIFF
--- a/mobileclienttokens/README.md
+++ b/mobileclienttokens/README.md
@@ -1,0 +1,28 @@
+Mobile Client Tokens
+====================
+
+Most/all of the mobile clients available for Friendica require the user to
+provide their username and password. This addon allows a user to create
+credentials that can be used to authenticate in lieu of providing their
+username and password. This is primarily useful in situations where one is
+providing some kind of single sign-on mechanism, such as that provided by the
+LDAP and SAML addons. A user providing the password for their SSO account to an
+external client exposes everything bound to that SSO. This addon allows the
+creation of credentials that are limited to accessing Friendica. 
+
+While is *is* meant to be used in conjunction with an SSO addon, it does not
+check with the SSO provider to see if the account is disabled. This is intended
+to keep this addon independent of any particular SSO standard or scheme, and to
+avoid precluding its use in other situations that the author may not have
+foreseen. Completely disabling access for an account has to be done through
+Friendica as well as one's SSO provider when this addon is enabled.
+
+The addon cannot be managed, or credentials created or deleted, from a session
+authenticated through this addon. This is to prevent the possibility of a
+malicious client obtaining indefinite access to a user's account by creating
+new credentials for itself faster than the user can delete them.
+
+Finally, any username and password pair created using this addon can be used to
+authenticate via the login form, just like any other username and password
+pair. This addon's name is more indicative of intent than of any kind of
+constraints.

--- a/mobileclienttokens/mobileclienttokens.php
+++ b/mobileclienttokens/mobileclienttokens.php
@@ -150,9 +150,6 @@ function mobileclienttokens_addon_settings(App $a, &$s)
 
 	$t = Renderer::getMarkupTemplate('settings.tpl', 'addon/mobileclienttokens/');
 	$s .= Renderer::replaceMacros($t, [
-		'$create' => DI::l10n()->t('Create'),
-		'$delete' => DI::l10n()->t('Delete'),
-		'$header' => DI::l10n()->t('Mobile Client Tokens'),
 		'$msg' => DI::session()->get('mobileclienttokens-msg', false),
 		'$newtoken' => DI::session()->get('mobileclienttokens-new', false),
 		'$newtokenid' => [
@@ -168,6 +165,17 @@ function mobileclienttokens_addon_settings(App $a, &$s)
 			empty($tokens) ? null : $tokens[0],
 			DI::l10n()->t('Pick an existing token to delete/revoke.'),
 			array_combine($tokens, $tokens)
+		],
+		'$text' => [
+			'create' => DI::l10n()->t('Create'),
+			'delete' => DI::l10n()->t('Delete'),
+			'header' => DI::l10n()->t('Mobile Client Tokens'),
+			'newtoken1' => DI::l10n()->t('New token created!'),
+			'newtoken2' => DI::l10n()->t('THIS IS THE ONLY TIME YOU WILL BE SHOWN THESE CREDENTIALS!'),
+			'newtoken3' => DI::l10n()->t('Write them down or enter them into your mobile client before navigating away!'),
+			'newtoken4' => DI::l10n()->t('Note: the spaces in the password are only for legibility! Leave them out when entering your password.'),
+			'password' => DI::l10n()->t('Password'),
+			'username' => DI::l10n()->t('Username'),
 		],
 		'$tokens' => empty($tokens) ? false : array_combine($tokens, $tokens),
 	]);

--- a/mobileclienttokens/mobileclienttokens.php
+++ b/mobileclienttokens/mobileclienttokens.php
@@ -39,7 +39,7 @@ function mobileclienttokens_authenticate($a, &$b)
 	}
 	$usertoken = explode('/', $b['username'], 2);
 	$username = $usertoken[0];
-       	$tokenid = $usertoken[1];
+	$tokenid = $usertoken[1];
 
 	$condition = [
 		'nickname' => $username,
@@ -63,7 +63,7 @@ function mobileclienttokens_authenticate($a, &$b)
 	}
 }
 
-function mobileclienttokens_admin_input($key, $label, $description, $default=null)
+function mobileclienttokens_admin_input($key, $label, $description, $default = null)
 {
 	return [
 		'$' . $key => [
@@ -81,7 +81,8 @@ function mobileclienttokens_addon_admin(&$a, &$o)
 	if (DI::session()->get('mobileclienttokens_authed')) {
 		DI::session()->set(
 			'mobileclienttokens-msg',
-			DI::l10n()->t('The Mobile Client Tokens addon cannot be configured in sessions authenticated via the same.'));
+			DI::l10n()->t('The Mobile Client Tokens addon cannot be configured in sessions authenticated via the same.')
+		);
 	}
 
 	$form =
@@ -143,7 +144,8 @@ function mobileclienttokens_addon_settings(App $a, &$s)
 	if (DI::session()->get('mobileclienttokens_authed')) {
 		DI::session()->set(
 			'mobileclienttokens-msg',
-			DI::l10n()->t('Mobile client tokens cannot be added or removed in sessions authenticated via the same.'));
+			DI::l10n()->t('Mobile client tokens cannot be added or removed in sessions authenticated via the same.')
+		);
 	}
 
 	$tokens = mobileclienttokens_gettokens();
@@ -172,8 +174,12 @@ function mobileclienttokens_addon_settings(App $a, &$s)
 			'header' => DI::l10n()->t('Mobile Client Tokens'),
 			'newtoken1' => DI::l10n()->t('New token created!'),
 			'newtoken2' => DI::l10n()->t('THIS IS THE ONLY TIME YOU WILL BE SHOWN THESE CREDENTIALS!'),
-			'newtoken3' => DI::l10n()->t('Write them down or enter them into your mobile client before navigating away!'),
-			'newtoken4' => DI::l10n()->t('Note: the spaces in the password are only for legibility! Leave them out when entering your password.'),
+			'newtoken3' => DI::l10n()->t(
+				'Write them down or enter them into your mobile client before navigating away!'
+			),
+			'newtoken4' => DI::l10n()->t(
+				'Note: the spaces in the password are only for legibility! Leave them out when entering your password.'
+			),
 			'password' => DI::l10n()->t('Password'),
 			'username' => DI::l10n()->t('Username'),
 		],
@@ -192,12 +198,13 @@ function mobileclienttokens_addon_settings_post(App $a, &$s)
 
 	if (!empty($_POST['mobileclienttokens-create'])) {
 		mobileclienttokens_create($_POST['newtokenid']);
-	} else if (!empty($_POST['mobileclienttokens-delete'])) {
+	} elseif (!empty($_POST['mobileclienttokens-delete'])) {
 		mobileclienttokens_delete($_POST['deletetokenid']);
 	}
 }
 
-function mobileclienttokens_create($tokenid) {
+function mobileclienttokens_create($tokenid)
+{
 	if (empty(trim($tokenid))) {
 		DI::session()->set('mobileclienttokens-msg', DI::l10n()->t('Error: No token ID provided!'));
 		return;
@@ -249,7 +256,8 @@ function mobileclienttokens_create($tokenid) {
 	);
 }
 
-function mobileclienttokens_delete($tokenid) {
+function mobileclienttokens_delete($tokenid)
+{
 	$tokens = mobileclienttokens_gettokens();
 
 	if (empty($tokens)) {
@@ -267,7 +275,8 @@ function mobileclienttokens_delete($tokenid) {
 	DI::session()->set('mobileclienttokens-msg', DI::l10n()->t('Token successfully deleted!'));
 }
 
-function mobileclienttokens_gettokens() {
+function mobileclienttokens_gettokens()
+{
 	$tokens = explode('/', DI::pConfig()->get(
 		local_user(),
 		'mobileclienttokens',
@@ -277,7 +286,7 @@ function mobileclienttokens_gettokens() {
 
 	if (!$tokens) {
 		$tokens = [];
-	} else if (is_string($tokens)) {
+	} elseif (is_string($tokens)) {
 		$tokens = [$tokens];
 	}
 	return array_filter($tokens);

--- a/mobileclienttokens/mobileclienttokens.php
+++ b/mobileclienttokens/mobileclienttokens.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Name: Mobile Client Tokens
+ * Description: Allow the creation and revocation of tokens for authentication in lieu of the account password.
+ * Version: 1.0
+ * Author: Ryan <https://verya.pe/profile/ryan>
+ */
+
+use Friendica\App;
+use Friendica\Core\Hook;
+use Friendica\Core\Logger;
+use Friendica\Core\Renderer;
+use Friendica\Database\DBA;
+use Friendica\DI;
+use Friendica\Model\User;
+
+define('DEFAULT_LENGTH', 16);
+define('DEFAULT_GROUPING', 4);
+
+// Base-58 for legibility
+define('DEFAULT_CHARPOOL', '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz');
+
+function mobileclienttokens_install()
+{
+	Hook::register('authenticate', __FILE__, 'mobileclienttokens_authenticate');
+	Hook::register('addon_settings', __FILE__, 'mobileclienttokens_addon_settings');
+	Hook::register('addon_settings_post', __FILE__, 'mobileclienttokens_addon_settings_post');
+}
+
+function mobileclienttokens_authenticate($a, &$b)
+{
+	// Make sure there's a *chance* of authentication.
+	// Authentication via client API token is done by concatenating the user's
+	// nickname with the client token identifier, with a slash between the two.
+	// If there's no slash, there's no way this addon will authenticate.
+	// If there's no password, the same applies.
+	if (!strpos($b['username'], '/') || !$b['password']) {
+		return;
+	}
+	$usertoken = explode('/', $b['username'], 2);
+	$username = $usertoken[0];
+       	$tokenid = $usertoken[1];
+
+	$condition = [
+		'nickname' => $username,
+		'blocked' => false,
+		'account_expired' => false,
+		'account_removed' => false
+	];
+
+	try {
+		$user = DBA::selectFirst('user', ['uid'], $condition);
+	} catch (Exception $e) {
+		return;
+	}
+
+	$token = DI::pConfig()->get($user['uid'], 'mobileclienttokens', 'token/' . $tokenid, false);
+
+	if ($token && password_verify($b['password'], $token)) {
+		$b['user_record'] = User::getById($user['uid']);
+		$b['authenticated'] = 1;
+		DI::session()->set('mobileclienttokens_authed', true);
+	}
+}
+
+function mobileclienttokens_admin_input($key, $label, $description, $default=null)
+{
+	return [
+		'$' . $key => [
+			$key,
+			$label,
+			DI::config()->get('mobileclienttokens', $key, $default),
+			$description,
+			true, // all the fields are required
+		]
+	];
+}
+
+function mobileclienttokens_addon_admin(&$a, &$o)
+{
+	if (DI::session()->get('mobileclienttokens_authed')) {
+		DI::session()->set(
+			'mobileclienttokens-msg',
+			DI::l10n()->t('The Mobile Client Tokens addon cannot be configured in sessions authenticated via the same.'));
+	}
+
+	$form =
+		mobileclienttokens_admin_input(
+			'length',
+			DI::l10n()->t('Token length'),
+			DI::l10n()->t('How long should generated API tokens be?'),
+			DEFAULT_LENGTH
+		) +
+		mobileclienttokens_admin_input(
+			'grouping',
+			DI::l10n()->t('Grouping length'),
+			DI::l10n()->t('For readability, tokens are displayed with spaces between groups of characters. '
+				. 'How long should these groups be?'),
+			DEFAULT_GROUPING
+		) +
+		mobileclienttokens_admin_input(
+			'charpool',
+			DI::l10n()->t('Character pool'),
+			DI::l10n()->t('What characters should be used to generate the API tokens?'),
+			DEFAULT_CHARPOOL
+		) +
+		[
+			'$msg' => DI::session()->get('mobileclienttokens-msg', false),
+			'$submit'  => DI::l10n()->t('Save Settings'),
+		];
+
+	$t = Renderer::getMarkupTemplate('admin.tpl', 'addon/mobileclienttokens/');
+	$o = Renderer::replaceMacros($t, $form);
+
+	DI::session()->remove('mobileclienttokens-msg');
+}
+
+function mobileclienttokens_addon_admin_post(&$a)
+{
+	if (DI::session()->get('mobileclienttokens_authed')) {
+		return;
+	}
+
+	if (!local_user()) {
+		return;
+	}
+
+	$set = function ($key) {
+		$val = (!empty($_POST[$key]) ? trim($_POST[$key]) : '');
+		DI::config()->set('mobileclienttokens', $key, $val);
+	};
+	$set('length');
+	$set('grouping');
+	$set('charpool');
+}
+
+function mobileclienttokens_addon_settings(App $a, &$s)
+{
+	if (!local_user()) {
+		return;
+	}
+
+	if (DI::session()->get('mobileclienttokens_authed')) {
+		DI::session()->set(
+			'mobileclienttokens-msg',
+			DI::l10n()->t('Mobile client tokens cannot be added or removed in sessions authenticated via the same.'));
+	}
+
+	$tokens = mobileclienttokens_gettokens();
+
+	$t = Renderer::getMarkupTemplate('settings.tpl', 'addon/mobileclienttokens/');
+	$s .= Renderer::replaceMacros($t, [
+		'$create' => DI::l10n()->t('Create'),
+		'$delete' => DI::l10n()->t('Delete'),
+		'$header' => DI::l10n()->t('Mobile Client Tokens'),
+		'$msg' => DI::session()->get('mobileclienttokens-msg', false),
+		'$newtoken' => DI::session()->get('mobileclienttokens-new', false),
+		'$newtokenid' => [
+			'newtokenid',
+			DI::l10n()->t('Token ID'),
+			'',
+			DI::l10n()->t('A name for your new mobile client token.'),
+		],
+		'$posted' => !empty($_POST['mobileclienttokens-create']) || !empty($_POST['mobileclienttokens-delete']),
+		'$deletetokenid' => [
+			'deletetokenid',
+			DI::l10n()->t('Tokens'),
+			empty($tokens) ? null : $tokens[0],
+			DI::l10n()->t('Pick an existing token to delete/revoke.'),
+			array_combine($tokens, $tokens)
+		],
+		'$tokens' => empty($tokens) ? false : array_combine($tokens, $tokens),
+	]);
+
+	DI::session()->remove('mobileclienttokens-msg');
+	DI::session()->remove('mobileclienttokens-new');
+}
+
+function mobileclienttokens_addon_settings_post(App $a, &$s)
+{
+	if (!local_user() || DI::session()->get('mobileclienttokens_authed')) {
+		return;
+	}
+
+	if (!empty($_POST['mobileclienttokens-create'])) {
+		mobileclienttokens_create($_POST['newtokenid']);
+	} else if (!empty($_POST['mobileclienttokens-delete'])) {
+		mobileclienttokens_delete($_POST['deletetokenid']);
+	}
+}
+
+function mobileclienttokens_create($tokenid) {
+	if (empty(trim($tokenid))) {
+		DI::session()->set('mobileclienttokens-msg', DI::l10n()->t('Error: No token ID provided!'));
+		return;
+	}
+	$charpool = DI::config()->get('mobileclienttokens', 'charpool', DEFAULT_CHARPOOL);
+	$grouping = DI::config()->get('mobileclienttokens', 'grouping', DEFAULT_GROUPING);
+	$length = DI::config()->get('mobileclienttokens', 'length', DEFAULT_LENGTH);
+
+	$lencharpool = mb_strlen($charpool);
+
+	$password = [];
+
+	for ($i = 0; $i < $length; $i++) {
+		if ($i % $grouping == 0) {
+			$password[] = '';
+		}
+		$password[$i / $grouping] .= $charpool[random_int(0, $lencharpool)];
+	}
+
+	$tokens = mobileclienttokens_gettokens();
+
+	if (in_array($tokenid, $tokens)) {
+		DI::session()->set('mobileclienttokens-msg', DI::l10n()->t('Error: A token with that ID already exists.'));
+		return;
+	}
+	$tokens[] = $tokenid;
+
+	DI::pConfig()->set(
+		local_user(),
+		'mobileclienttokens',
+		'tokens',
+		implode('/', $tokens)
+	);
+
+	DI::pConfig()->set(
+		local_user(),
+		'mobileclienttokens',
+		'token/' . $tokenid,
+		password_hash(implode('', $password), PASSWORD_DEFAULT)
+	);
+
+	$user = DBA::selectFirst('user', ['nickname'], ['uid' => local_user()]);
+	DI::session()->set(
+		'mobileclienttokens-new',
+		[
+			'username' => $user['nickname'] . '/' . $tokenid,
+			'password' => $password
+		]
+	);
+}
+
+function mobileclienttokens_delete($tokenid) {
+	$tokens = mobileclienttokens_gettokens();
+
+	if (empty($tokens)) {
+		return;
+	}
+
+	if (!in_array($tokenid, $tokens)) {
+		DI::session()->set('mobileclienttokens-msg', DI::l10n()->t('Error: Could not find token to delete it!'));
+		return;
+	}
+	$tokens = array_diff($tokens, [$tokenid]);
+
+	DI::pConfig()->set(local_user(), 'mobileclienttokens', 'tokens', implode('/', $tokens));
+	DI::pConfig()->delete(local_user(), 'mobileclienttokens', $tokenid);
+	DI::session()->set('mobileclienttokens-msg', DI::l10n()->t('Token successfully deleted!'));
+}
+
+function mobileclienttokens_gettokens() {
+	$tokens = explode('/', DI::pConfig()->get(
+		local_user(),
+		'mobileclienttokens',
+		'tokens',
+		''
+	));
+
+	if (!$tokens) {
+		$tokens = [];
+	} else if (is_string($tokens)) {
+		$tokens = [$tokens];
+	}
+	return array_filter($tokens);
+}

--- a/mobileclienttokens/templates/admin.tpl
+++ b/mobileclienttokens/templates/admin.tpl
@@ -1,0 +1,7 @@
+{{if $msg }}
+<div class="warning-message">{{$msg}}</div>
+{{/if}}
+{{include file="field_input.tpl" field=$length}}
+{{include file="field_input.tpl" field=$grouping}}
+{{include file="field_textarea.tpl" field=$charpool}}
+<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>

--- a/mobileclienttokens/templates/settings.tpl
+++ b/mobileclienttokens/templates/settings.tpl
@@ -1,0 +1,31 @@
+<style>.mobileclienttokens-chunk { margin-left: 1em; font-family: mono; }</style>
+<span id="settings_mobileclienttokens_inflated" class="settings-block fakelink" 
+	style="{{if $posted}}display: none;{{else}}display: block;{{/if}}" 
+	onclick="openClose('settings_mobileclienttokens_expanded'); openClose('settings_mobileclienttokens_inflated');">
+		<h3>{{$header}}</h3>
+</span>
+<div id="settings_mobileclienttokens_expanded" class="settings-block" 
+	style="{{if $posted}}display: block;{{else}}display: none;{{/if}}">
+	<span class="fakelink" onclick="openClose('settings_mobileclienttokens_expanded'); openClose('settings_mobileclienttokens_inflated');">
+		<h3>{{$header}}</h3>
+	</span>
+	<div class="settings-submit-wrapper" >
+		{{if $msg }}
+		<div class="warning-message">{{$msg}}</div>
+		{{/if}}
+		{{if $newtoken }}
+		<p>New token created!<p>
+		<p><strong>THIS IS THE ONLY TIME YOU WILL BE SHOWN THIS TOKEN!</strong></p>
+		<p>Write it down or enter it into your mobile client before navigating away!</p>
+		<p><em>Note: the spaces in the password are only for legibility! Leave them out when entering your password.</em></p>
+		<p>Username: <span class="mobileclienttokens-chunk">{{$newtoken.username}}</span></p>
+		<p>Password: {{foreach $newtoken.password as $chunk}}<span class="mobileclienttokens-chunk">{{$chunk}}</span>{{/foreach}}</p>
+		{{/if}}
+		<p>{{include file="field_input.tpl" field=$newtokenid}}</p>
+		<div class="submit"><input type="submit" name="mobileclienttokens-create" value="{{$create}}" /></div>
+		{{if $tokens}}
+		<p>{{include file="field_select.tpl" field=$deletetokenid}}</p>
+		<div class="submit"><input type="submit" name="mobileclienttokens-delete" value="{{$delete}}" /></div>
+		{{/if}}
+	</div>
+</div>

--- a/mobileclienttokens/templates/settings.tpl
+++ b/mobileclienttokens/templates/settings.tpl
@@ -2,30 +2,30 @@
 <span id="settings_mobileclienttokens_inflated" class="settings-block fakelink" 
 	style="{{if $posted}}display: none;{{else}}display: block;{{/if}}" 
 	onclick="openClose('settings_mobileclienttokens_expanded'); openClose('settings_mobileclienttokens_inflated');">
-		<h3>{{$header}}</h3>
+		<h3>{{$text.header}}</h3>
 </span>
 <div id="settings_mobileclienttokens_expanded" class="settings-block" 
 	style="{{if $posted}}display: block;{{else}}display: none;{{/if}}">
 	<span class="fakelink" onclick="openClose('settings_mobileclienttokens_expanded'); openClose('settings_mobileclienttokens_inflated');">
-		<h3>{{$header}}</h3>
+		<h3>{{$text.header}}</h3>
 	</span>
 	<div class="settings-submit-wrapper" >
 		{{if $msg }}
 		<div class="warning-message">{{$msg}}</div>
 		{{/if}}
 		{{if $newtoken }}
-		<p>New token created!<p>
-		<p><strong>THIS IS THE ONLY TIME YOU WILL BE SHOWN THIS TOKEN!</strong></p>
-		<p>Write it down or enter it into your mobile client before navigating away!</p>
-		<p><em>Note: the spaces in the password are only for legibility! Leave them out when entering your password.</em></p>
-		<p>Username: <span class="mobileclienttokens-chunk">{{$newtoken.username}}</span></p>
-		<p>Password: {{foreach $newtoken.password as $chunk}}<span class="mobileclienttokens-chunk">{{$chunk}}</span>{{/foreach}}</p>
+		<p>{{$text.newtoken1}}<p>
+		<p><strong>{{$text.newtoken2}}</strong></p>
+		<p>{{$text.newtoken3}}</p>
+		<p><em>{{$text.newtoken4}}</em></p>
+		<p>{{$text.username}}: <span class="mobileclienttokens-chunk">{{$newtoken.username}}</span></p>
+		<p>{{$text.password}}: {{foreach $newtoken.password as $chunk}}<span class="mobileclienttokens-chunk">{{$chunk}}</span>{{/foreach}}</p>
 		{{/if}}
 		<p>{{include file="field_input.tpl" field=$newtokenid}}</p>
-		<div class="submit"><input type="submit" name="mobileclienttokens-create" value="{{$create}}" /></div>
+		<div class="submit"><input type="submit" name="mobileclienttokens-create" value="{{$text.create}}" /></div>
 		{{if $tokens}}
 		<p>{{include file="field_select.tpl" field=$deletetokenid}}</p>
-		<div class="submit"><input type="submit" name="mobileclienttokens-delete" value="{{$delete}}" /></div>
+		<div class="submit"><input type="submit" name="mobileclienttokens-delete" value="{{$text.delete}}" /></div>
 		{{/if}}
 	</div>
 </div>


### PR DESCRIPTION
One of my members tried to use a mobile client yesterday and discovered my SSO scheme didn't play nicely with mobile clients like Fedilab, DiCa, and Friendiqa, as these clients require a username and password. Rather than create an addon to allow them to use their Keycloak credentials with Friendica (as that would compromise their accounts on every service I run in the event of, say, mobile malware), I wrote an addon to allow the issuance and revocation of secondary credentials for Friendica accounts.