### PR TITLE
nitter addon added

### DIFF
--- a/nitter/LICENSE
+++ b/nitter/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2020 Tobias Diekershoff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/nitter/README.md
+++ b/nitter/README.md
@@ -1,0 +1,27 @@
+nitter Addon for Friendica
+==========================
+
+This addon will replace all occurances of the string _https://twitter.com_ with the server address of a nitter installation in all displayed postings on a Friendica node.
+
+Note: If you are using the twitter connector on your server, the links to the contacts profile pages will not be replaced by this addon. Only links in the body of the postings are affected.
+
+Nitter sources can be found on [github.com](https://github.com/zedeus/nitter) it is released unter the AGPLv3 or later.
+
+Why
+---
+
+Excerp from nitters about page.
+
+> It's basically impossible to use Twitter without JavaScript enabled. If you try, you're redirected to the legacy mobile version which is awful both functionally and aesthetically. For privacy-minded folks, preventing JavaScript analytics and potential IP-based tracking is important, but apart from using the legacy mobile version and a VPN, it's impossible.
+>
+> Using an instance of Nitter (hosted on a VPS for example), you can browse Twitter without JavaScript while retaining your privacy. In addition to respecting your privacy, Nitter is on average around 15 times lighter than Twitter, and in some cases serves pages faster.
+>
+> In the future a simple account system will be added that lets you follow Twitter users, allowing you to have a clean chronological timeline without needing a Twitter account.
+
+Changelog
+---------
+
+* **Version 1.1**
+  * Initial localization support with DE translation
+  * Configurable nitter instance address from the admin panel
+* **Version 1.0**: Initial Release

--- a/nitter/lang/C/messages.po
+++ b/nitter/lang/C/messages.po
@@ -1,0 +1,41 @@
+# ADDON nitter
+# Copyright (C) 
+# This file is distributed under the same license as the Friendica nitter addon package.
+# 
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-08 07:44+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: nitter.php:51
+#, php-format
+msgid ""
+"Which nitter server shall be used for the replacements in the post bodies? "
+"Use the URL with servername and protocol.  See %s for a list of available "
+"public Nitter servers."
+msgstr ""
+
+#: nitter.php:52
+msgid "Nitter server"
+msgstr ""
+
+#: nitter.php:53
+msgid "Save Settings"
+msgstr ""
+
+#: nitter.php:65
+#, php-format
+msgid ""
+"Links to Twitter in this posting were replaced by links to the Nitter "
+"instance at %s"
+msgstr ""

--- a/nitter/lang/de/messages.po
+++ b/nitter/lang/de/messages.po
@@ -1,0 +1,41 @@
+# ADDON nitter
+# Copyright (C) 
+# This file is distributed under the same license as the Friendica nitter addon package.
+# 
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-08 07:44+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: nitter.php:51
+#, php-format
+msgid ""
+"Which nitter server shall be used for the replacements in the post bodies? "
+"Use the URL with servername and protocol.  See %s for a list of available "
+"public Nitter servers."
+msgstr "Welcher Nitter server soll für die Ersetzungen verwendet werden? Gib die URL mit Servername und Protokoll an. Eine Liste von öffentlichen Nitter servern findest du unter %s."
+
+#: nitter.php:52
+msgid "Nitter server"
+msgstr "Nitter Server"
+
+#: nitter.php:53
+msgid "Save Settings"
+msgstr "Einstellungen Speichern"
+
+#: nitter.php:65
+#, php-format
+msgid ""
+"Links to Twitter in this posting were replaced by links to the Nitter "
+"instance at %s"
+msgstr "In diesem Beitrag wurden Links nach twitter.com durch die Nitter Instanz auf %s ersetzt."

--- a/nitter/lang/de/strings.php
+++ b/nitter/lang/de/strings.php
@@ -1,0 +1,7 @@
+<?php
+
+;
+$a->strings["Which nitter server shall be used for the replacements in the post bodies? Use the URL with servername and protocol.  See %s for a list of available public Nitter servers."] = "Welcher Nitter server soll für die Ersetzungen verwendet werden? Gib die URL mit Servername und Protokoll an. Eine Liste von öffentlichen Nitter servern findest du unter %s.";
+$a->strings["Nitter server"] = "Nitter Server";
+$a->strings["Save Settings"] = "Einstellungen Speichern";
+$a->strings["Links to Twitter in this posting were replaced by links to the Nitter instance at %s"] = "In diesem Beitrag wurden Links nach twitter.com durch die Nitter Instanz auf %s ersetzt.";

--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Name: nitter
+ * Description: Replaces links to twitter.com to a nitter server in all displays of postings on a node.
+ * Version: 1.1
+ * Author: Tobias Diekershoff <tobias@social.diekershoff.de>
+ *
+ * Copyright (c) 2020 Tobias Diekershoff
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+ * associated documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+use Friendica\App;
+use Friendica\Core\Addon;
+use Friendica\Core\Renderer;
+use Friendica\DI;
+
+function nitter_install() {
+    Addon::registerHook ('prepare_body', 'addon/nitter/nitter.php', 'nitter_render');
+}
+
+/* Handle the send data from the admin settings
+ */
+function nitter_addon_admin_post(App $a)
+{
+    $nitterserver = trim($_POST['nitterserver']);
+    DI::config()->set('nitter', 'server', $nitterserver);
+}
+
+/* Hook into the admin settings to let the admin choose a
+ * nitter server to use for the replacement.
+ */
+function nitter_addon_admin(App $a, &$o)
+{
+    $nitterserver = DI::config()->get('nitter', 'server');
+    $t = Renderer::getMarkupTemplate("admin.tpl", "addon/nitter/");
+    $o = Renderer::replaceMacros($t, [
+        '$settingdescription' => DI::l10n()->t('Which nitter server shall be used for the replacements in the post bodies? Use the URL with servername and protocol.  See %s for a list of available public Nitter servers.', "https://github.com/zedeus/nitter/wiki/Instances"),
+        '$nitterserver' => ["nitterserver", DI::l10n()->t('Nitter server'), $nitterserver, 'http://example.com'], 
+        '$submit' => DI::l10n()->t('Save Settings'),
+    ]);
+}
+
+/*
+ *  replace "twitter.com" with "nitter.net"
+ */
+function nitter_render(&$a, &$o) {
+    // this needs to be a system setting
+    $nitter = DI::config()->get('nitter', 'server', 'https://nitter.net');
+    if (strstr($o['html'],'https://twitter.com')) {
+        $o['html'] = str_replace('https://twitter.com', $nitter, $o['html']);
+        $o['html'] .= '<hr><p>'.DI::l10n()->t('Links to Twitter in this posting were replaced by links to the Nitter instance at %s', $nitter).'</p>';
+    }
+}

--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -28,16 +28,17 @@ use Friendica\Core\Addon;
 use Friendica\Core\Renderer;
 use Friendica\DI;
 
-function nitter_install() {
-    Addon::registerHook ('prepare_body', 'addon/nitter/nitter.php', 'nitter_render');
+function nitter_install()
+{
+	Addon::registerHook ('prepare_body', 'addon/nitter/nitter.php', 'nitter_render');
 }
 
 /* Handle the send data from the admin settings
  */
 function nitter_addon_admin_post(App $a)
 {
-    $nitterserver = trim($_POST['nitterserver']);
-    DI::config()->set('nitter', 'server', $nitterserver);
+	$nitterserver = trim($_POST['nitterserver']);
+	DI::config()->set('nitter', 'server', $nitterserver);
 }
 
 /* Hook into the admin settings to let the admin choose a
@@ -45,23 +46,24 @@ function nitter_addon_admin_post(App $a)
  */
 function nitter_addon_admin(App $a, &$o)
 {
-    $nitterserver = DI::config()->get('nitter', 'server');
-    $t = Renderer::getMarkupTemplate("admin.tpl", "addon/nitter/");
-    $o = Renderer::replaceMacros($t, [
-        '$settingdescription' => DI::l10n()->t('Which nitter server shall be used for the replacements in the post bodies? Use the URL with servername and protocol.  See %s for a list of available public Nitter servers.', "https://github.com/zedeus/nitter/wiki/Instances"),
-        '$nitterserver' => ["nitterserver", DI::l10n()->t('Nitter server'), $nitterserver, 'http://example.com'], 
-        '$submit' => DI::l10n()->t('Save Settings'),
-    ]);
+	$nitterserver = DI::config()->get('nitter', 'server');
+	$t = Renderer::getMarkupTemplate('admin.tpl', 'addon/nitter/');
+	$o = Renderer::replaceMacros($t, [
+		'$settingdescription' => DI::l10n()->t('Which nitter server shall be used for the replacements in the post bodies? Use the URL with servername and protocol.  See %s for a list of available public Nitter servers.', 'https://github.com/zedeus/nitter/wiki/Instances'),
+		'$nitterserver' => ['nitterserver', DI::l10n()->t('Nitter server'), $nitterserver, 'http://example.com'], 
+		'$submit' => DI::l10n()->t('Save Settings'),
+	]);
 }
 
 /*
  *  replace "twitter.com" with "nitter.net"
  */
-function nitter_render(&$a, &$o) {
-    // this needs to be a system setting
-    $nitter = DI::config()->get('nitter', 'server', 'https://nitter.net');
-    if (strstr($o['html'],'https://twitter.com')) {
-        $o['html'] = str_replace('https://twitter.com', $nitter, $o['html']);
-        $o['html'] .= '<hr><p>'.DI::l10n()->t('Links to Twitter in this posting were replaced by links to the Nitter instance at %s', $nitter).'</p>';
-    }
+function nitter_render(&$a, &$o)
+{
+	// this needs to be a system setting
+	$nitter = DI::config()->get('nitter', 'server', 'https://nitter.net');
+	if (strstr($o['html'], 'https://twitter.com')) {
+		$o['html'] = str_replace('https://twitter.com', $nitter, $o['html']);
+		$o['html'] .= '<hr><p>' . DI::l10n()->t('Links to Twitter in this posting were replaced by links to the Nitter instance at %s', $nitter) . '</p>';
+	}
 }

--- a/nitter/templates/admin.tpl
+++ b/nitter/templates/admin.tpl
@@ -1,0 +1,5 @@
+<p>{{$settingdescription}}</p>
+
+{{include file="field_input.tpl" field=$nitterserver}}
+
+<div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>


### PR DESCRIPTION
Treansfering the addon from the separate repository into the projects addon collection.

This addon is meant to replace links to Twitter in the body of postings with a nitter [1] instance of the admins choice. It is not meant to change links to contact prociles.

In addition to the change, a note about the changed links is placed at the bottom of the posting.

1: https://github.com/zedeus/nitter