### PR TITLE
[securemail,phpmailer] Increase priority for securemail over phpmailer

### DIFF
--- a/phpmailer/phpmailer.php
+++ b/phpmailer/phpmailer.php
@@ -20,7 +20,7 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'a
 function phpmailer_install()
 {
 	Hook::register('load_config'         , __FILE__, 'phpmailer_load_config');
-	Hook::register('emailer_send_prepare', __FILE__, 'phpmailer_emailer_send_prepare');
+	Hook::register('emailer_send_prepare', __FILE__, 'phpmailer_emailer_send_prepare', 5);
 }
 
 function phpmailer_load_config(App $a, ConfigFileLoader $loader)

--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -19,9 +19,9 @@ require_once __DIR__ . '/vendor/autoload.php';
 function securemail_install()
 {
 	Hook::register('addon_settings', 'addon/securemail/securemail.php', 'securemail_settings');
-	Hook::register('addon_settings_post', 'addon/securemail/securemail.php', 'securemail_settings_post');
+	Hook::register('addon_settings_post', 'addon/securemail/securemail.php', 'securemail_settings_post', 10);
 
-	Hook::register('emailer_send_prepare', 'addon/securemail/securemail.php', 'securemail_emailer_send_prepare');
+	Hook::register('emailer_send_prepare', 'addon/securemail/securemail.php', 'securemail_emailer_send_prepare', 10);
 
 	Logger::log('installed securemail');
 }


### PR DESCRIPTION
This should close https://github.com/friendica/friendica/issues/10312

=> There was no priority, so the hooks are sorted by their filenames and directories
=> "phpmailer" is sorted over "securemail", so the SMTP mailer already sent the mail before the "securemail" addon could encrypt it
=> this lead to the null-pointer exception :)