### PR TITLE
Fill the header field of the contact with the twitter banner

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1217,6 +1217,7 @@ function twitter_user_to_contact($data)
 		'location' => $data->location,
 		'about'    => $data->description,
 		'photo'    => twitter_fix_avatar($data->profile_image_url_https),
+		'header'   => $data->profile_banner_url ?? $data->profile_background_image_url_https,
 	];
 
 	return $fields;


### PR DESCRIPTION
If the header is not filled we use the background image that seems to be filled all the time.