### PR TITLE
[securemail] Remove wrong 5th argument

### DIFF
--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -52,7 +52,7 @@ function securemail_settings(App &$a, &$s)
 		'$submit' => DI::l10n()->t('Save Settings'),
 		'$test' => DI::l10n()->t('Save and send test'), //NOTE: update also in 'post'
 		'$enable' => ['securemail-enable', DI::l10n()->t('Enable Secure Mail'), $enable, ''],
-		'$publickey' => ['securemail-pkey', DI::l10n()->t('Public key'), $publickey, DI::l10n()->t('Your public PGP key, ascii armored format'), 'rows="10"']
+		'$publickey' => ['securemail-pkey', DI::l10n()->t('Public key'), $publickey, DI::l10n()->t('Your public PGP key, ascii armored format')]
 	]);
 }
 


### PR DESCRIPTION
The 5th argument for the field publickey was intended to set the row-count. But in fact the 5th argument is boolean field to enable/disable a required field.

Resolving https://github.com/friendica/friendica/issues/10314