### PR TITLE
nitter: mobile links and config enhancements

### DIFF
--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -38,6 +38,9 @@ function nitter_install()
 function nitter_addon_admin_post(App $a)
 {
 	$nitterserver = trim($_POST['nitterserver']);
+	if ((substr($apiurl, -1) == '/')) {
+		$apiurl = substr($apiurl, 0, -1);
+	}
 	DI::config()->set('nitter', 'server', $nitterserver);
 }
 

--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -37,10 +37,7 @@ function nitter_install()
  */
 function nitter_addon_admin_post(App $a)
 {
-	$nitterserver = trim($_POST['nitterserver']);
-	if ((substr($apiurl, -1) == '/')) {
-		$apiurl = substr($apiurl, 0, -1);
-	}
+	$nitterserver = rtrim(trim($_POST['nitterserver']),'/');
 	DI::config()->set('nitter', 'server', $nitterserver);
 }
 

--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -61,9 +61,17 @@ function nitter_addon_admin(App $a, &$o)
 function nitter_render(&$a, &$o)
 {
 	// this needs to be a system setting
+	$replaced = false;
 	$nitter = DI::config()->get('nitter', 'server', 'https://nitter.net');
+	if (strstr($o['html'], 'https://mobile.twitter.com')) {
+		$o['html'] = str_replace('https://mobile.twitter.com', $nitter, $o['html']);
+		$replace = true;
+	}
 	if (strstr($o['html'], 'https://twitter.com')) {
 		$o['html'] = str_replace('https://twitter.com', $nitter, $o['html']);
+		$replace = true;
+	}
+	if ($replace) {
 		$o['html'] .= '<hr><p>' . DI::l10n()->t('Links to Twitter in this posting were replaced by links to the Nitter instance at %s', $nitter) . '</p>';
 	}
 }


### PR DESCRIPTION
It was mentioned by community members, that it would be nice to also replace links to `mobile.twitter.com`. Also the generated URL can contain a double `/` if the nitter instance was given with the trailing `/`, so there is now a check to remove it.