### PR TITLE
[nitter] addon version update - reload of the addon required

### DIFF
--- a/nitter/lang/C/messages.po
+++ b/nitter/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-08 07:44+0100\n"
+"POT-Creation-Date: 2021-10-01 16:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: nitter.php:51
+#: nitter.php:52
 #, php-format
 msgid ""
 "Which nitter server shall be used for the replacements in the post bodies? "
@@ -25,17 +25,17 @@ msgid ""
 "public Nitter servers."
 msgstr ""
 
-#: nitter.php:52
+#: nitter.php:53
 msgid "Nitter server"
 msgstr ""
 
-#: nitter.php:53
+#: nitter.php:54
 msgid "Save Settings"
 msgstr ""
 
-#: nitter.php:65
+#: nitter.php:99
 #, php-format
 msgid ""
-"Links to Twitter in this posting were replaced by links to the Nitter "
-"instance at %s"
+"In an attempt to protect your privacy, links to Twitter in this posting were "
+"replaced by links to the Nitter instance at %s"
 msgstr ""

--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -72,6 +72,6 @@ function nitter_render(&$a, &$o)
 		$replaced = true;
 	}
 	if ($replaced) {
-		$o['html'] .= '<hr><p>' . DI::l10n()->t('Links to Twitter in this posting were replaced by links to the Nitter instance at %s', $nitter) . '</p>';
+		$o['html'] .= '<hr><p>' . DI::l10n()->t('In an attempt to protect your privacy, links to Twitter in this posting were replaced by links to the Nitter instance at %s', $nitter) . '</p>';
 	}
 }

--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -30,7 +30,7 @@ use Friendica\DI;
 
 function nitter_install()
 {
-	Addon::registerHook ('prepare_body', 'addon/nitter/nitter.php', 'nitter_render');
+	Addon::registerHook ('prepare_body_final', 'addon/nitter/nitter.php', 'nitter_render');
 }
 
 /* Handle the send data from the admin settings

--- a/nitter/nitter.php
+++ b/nitter/nitter.php
@@ -2,7 +2,7 @@
 /*
  * Name: nitter
  * Description: Replaces links to twitter.com to a nitter server in all displays of postings on a node.
- * Version: 1.1
+ * Version: 2.0
  * Author: Tobias Diekershoff <tobias@social.diekershoff.de>
  *
  * Copyright (c) 2020 Tobias Diekershoff


### PR DESCRIPTION
With this patch the used hook by the addon changes, so that links in the preview of postings will be replaced as well. This requires node admins to manually reload the addon.

Additionally the added text about the replaced links was updated to explain the reasoning of the replacement a bit.