### PR TITLE
[twitter] Add support for block and unblock hooks

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -107,6 +107,8 @@ function twitter_install()
 	Hook::register('support_follow'         , __FILE__, 'twitter_support_follow');
 	Hook::register('follow'                 , __FILE__, 'twitter_follow');
 	Hook::register('unfollow'               , __FILE__, 'twitter_unfollow');
+	Hook::register('block'                  , __FILE__, 'twitter_block');
+	Hook::register('unblock'                , __FILE__, 'twitter_unblock');
 	Hook::register('expire'                 , __FILE__, 'twitter_expire');
 	Hook::register('prepare_body'           , __FILE__, 'twitter_prepare_body');
 	Hook::register('check_item_notification', __FILE__, 'twitter_check_item_notification');
@@ -173,6 +175,16 @@ function twitter_follow(App $a, array &$contact)
 function twitter_unfollow(App $a, array &$hook_data)
 {
 	$hook_data['result'] = twitter_api_contact('friendship/destroy', $hook_data['contact'], $hook_data['uid']);
+}
+
+function twitter_block(App $a, array &$hook_data)
+{
+	$hook_data['result'] = twitter_api_contact('blocks/create', $hook_data['contact'], $hook_data['uid']);
+}
+
+function twitter_unblock(App $a, array &$hook_data)
+{
+	$hook_data['result'] = twitter_api_contact('blocks/destroy', $hook_data['contact'], $hook_data['uid']);
 }
 
 function twitter_api_contact(string $apiPath, array $contact, int $uid): ?bool


### PR DESCRIPTION
Closes https://github.com/friendica/friendica/issues/10739
Depends on https://github.com/friendica/friendica/pull/10800

Additionally, it reactivates `statuses/destroy` API calls that had been deactivated in September 2015.

Let's see how it goes now.