### PR TITLE
[markdown] Escape HTML characters before running Markdown::toBBCode()

### DIFF
--- a/markdown/markdown.php
+++ b/markdown/markdown.php
@@ -56,6 +56,10 @@ function markdown_post_local_start(App $a, &$request) {
 			// Escape mentions which username can contain Markdown-like characters
 			// See https://github.com/friendica/friendica/issues/9486
 			return \Friendica\Util\Strings::performWithEscapedBlocks($body, '/[@!][^@\s]+@[^\s]+\w/', function ($text) {
+				// Markdown accepts literal HTML but we do not in post body, so we need to escape all chevrons
+				// See https://github.com/friendica/friendica/issues/10634
+				$text = \Friendica\Util\Strings::escapeHtml($text);
+
 				return Markdown::toBBCode($text);
 			});
 		}


### PR DESCRIPTION
Fixes https://github.com/friendica/friendica/issues/10634
Replaces https://github.com/friendica/friendica/pull/10866

- This prevents HTML tag looking text to be purified in the Markdown to BBCode process