### PR TITLE
"escapeTags" is removed from the addons

### DIFF
--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -73,8 +73,8 @@ function buffer_addon_admin(App $a, &$o)
 
 function buffer_addon_admin_post(App $a)
 {
-	$client_id     = (!empty($_POST['client_id'])     ? trim($_POST['client_id'])     : '');
-	$client_secret = (!empty($_POST['client_secret']) ? trim($_POST['client_secret']) : '');
+	$client_id     = trim($_POST['client_id'] ?? '');
+	$client_secret = trim($_POST['client_secret'] ?? '');
 
 	DI::config()->set('buffer', 'client_id'    , $client_id);
 	DI::config()->set('buffer', 'client_secret', $client_secret);

--- a/buffer/buffer.php
+++ b/buffer/buffer.php
@@ -17,7 +17,6 @@ use Friendica\Core\Renderer;
 use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Util\Proxy as ProxyUtils;
-use Friendica\Util\Strings;
 
 function buffer_install()
 {
@@ -74,8 +73,8 @@ function buffer_addon_admin(App $a, &$o)
 
 function buffer_addon_admin_post(App $a)
 {
-	$client_id     = (!empty($_POST['client_id'])     ? Strings::escapeTags(trim($_POST['client_id']))     : '');
-	$client_secret = (!empty($_POST['client_secret']) ? Strings::escapeTags(trim($_POST['client_secret'])) : '');
+	$client_id     = (!empty($_POST['client_id'])     ? trim($_POST['client_id'])     : '');
+	$client_secret = (!empty($_POST['client_secret']) ? trim($_POST['client_secret']) : '');
 
 	DI::config()->set('buffer', 'client_id'    , $client_id);
 	DI::config()->set('buffer', 'client_secret', $client_secret);

--- a/forumdirectory/forumdirectory.php
+++ b/forumdirectory/forumdirectory.php
@@ -66,9 +66,9 @@ function forumdirectory_content(App $a)
 	Nav::setSelected('directory');
 
 	if (!empty($forumdirectory_search)) {
-		$search = Strings::escapeTags(trim($forumdirectory_search));
+		$search = trim($forumdirectory_search);
 	} else {
-		$search = (!empty($_GET['search']) ? Strings::escapeTags(trim(rawurldecode($_GET['search']))) : '');
+		$search = (!empty($_GET['search']) ? trim(rawurldecode($_GET['search'])) : '');
 	}
 
 	$gdirpath = '';

--- a/geocoordinates/geocoordinates.php
+++ b/geocoordinates/geocoordinates.php
@@ -90,9 +90,9 @@ function geocoordinates_addon_admin(&$a, &$o)
 
 function geocoordinates_addon_admin_post(&$a)
 {
-	$api_key  = (!empty($_POST['api_key']) ? trim($_POST['api_key']) : '');
+	$api_key  = trim($_POST['api_key'] ?? '');
 	DI::config()->set('geocoordinates', 'api_key', $api_key);
 
-	$language  = (!empty($_POST['language']) ? trim($_POST['language']) : '');
+	$language  = trim($_POST['language'] ?? '');
 	DI::config()->set('geocoordinates', 'language', $language);
 }

--- a/geocoordinates/geocoordinates.php
+++ b/geocoordinates/geocoordinates.php
@@ -10,7 +10,6 @@ use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\DI;
-use Friendica\Util\Strings;
 
 function geocoordinates_install()
 {
@@ -91,9 +90,9 @@ function geocoordinates_addon_admin(&$a, &$o)
 
 function geocoordinates_addon_admin_post(&$a)
 {
-	$api_key  = (!empty($_POST['api_key']) ? Strings::escapeTags(trim($_POST['api_key']))   : '');
+	$api_key  = (!empty($_POST['api_key']) ? trim($_POST['api_key']) : '');
 	DI::config()->set('geocoordinates', 'api_key', $api_key);
 
-	$language  = (!empty($_POST['language']) ? Strings::escapeTags(trim($_POST['language']))   : '');
+	$language  = (!empty($_POST['language']) ? trim($_POST['language']) : '');
 	DI::config()->set('geocoordinates', 'language', $language);
 }

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -108,8 +108,8 @@ function gravatar_addon_admin (&$a, &$o) {
 function gravatar_addon_admin_post (&$a) {
 	BaseModule::checkFormSecurityToken('gravatarsave');
 
-	$default_avatar = (!empty($_POST['avatar']) ? trim($_POST['avatar']) : 'identicon');
-	$rating = (!empty($_POST['rating']) ? trim($_POST['rating']) : 'g');
+	$default_avatar = trim($_POST['avatar'] ?? 'identicon');
+	$rating = trim($_POST['rating'] ?? 'g');
 	DI::config()->set('gravatar', 'default_avatar', $default_avatar);
 	DI::config()->set('gravatar', 'rating', $rating);
 }

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -108,8 +108,8 @@ function gravatar_addon_admin (&$a, &$o) {
 function gravatar_addon_admin_post (&$a) {
 	BaseModule::checkFormSecurityToken('gravatarsave');
 
-	$default_avatar = (!empty($_POST['avatar']) ? Strings::escapeTags(trim($_POST['avatar'])) : 'identicon');
-	$rating = (!empty($_POST['rating']) ? Strings::escapeTags(trim($_POST['rating'])) : 'g');
+	$default_avatar = (!empty($_POST['avatar']) ? trim($_POST['avatar']) : 'identicon');
+	$rating = (!empty($_POST['rating']) ? trim($_POST['rating']) : 'g');
 	DI::config()->set('gravatar', 'default_avatar', $default_avatar);
 	DI::config()->set('gravatar', 'rating', $rating);
 }

--- a/impressum/impressum.php
+++ b/impressum/impressum.php
@@ -14,7 +14,6 @@ use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Core\Config\Util\ConfigFileLoader;
 use Friendica\Util\Proxy as ProxyUtils;
-use Friendica\Util\Strings;
 
 function impressum_install() {
 	Hook::register('load_config', 'addon/impressum/impressum.php', 'impressum_load_config');
@@ -79,11 +78,11 @@ function impressum_show($a,&$b) {
 }
 
 function impressum_addon_admin_post (&$a) {
-    $owner = (!empty($_POST['owner']) ? Strings::escapeTags(trim($_POST['owner'])) : '');
-    $ownerprofile = (!empty($_POST['ownerprofile']) ? Strings::escapeTags(trim($_POST['ownerprofile'])) : '');
+    $owner = (!empty($_POST['owner']) ? trim($_POST['owner']) : '');
+    $ownerprofile = (!empty($_POST['ownerprofile']) ? trim($_POST['ownerprofile']) : '');
     $postal = (!empty($_POST['postal']) ? (trim($_POST['postal'])) : '');
     $notes = (!empty($_POST['notes']) ? (trim($_POST['notes'])) : '');
-    $email = (!empty($_POST['email']) ? Strings::escapeTags(trim($_POST['email'])) : '');
+    $email = (!empty($_POST['email']) ? trim($_POST['email']) : '');
     $footer_text = (!empty($_POST['footer_text']) ? (trim($_POST['footer_text'])) : '');
     DI::config()->set('impressum','owner',strip_tags($owner));
     DI::config()->set('impressum','ownerprofile',strip_tags($ownerprofile));

--- a/impressum/impressum.php
+++ b/impressum/impressum.php
@@ -78,12 +78,12 @@ function impressum_show($a,&$b) {
 }
 
 function impressum_addon_admin_post (&$a) {
-    $owner = (!empty($_POST['owner']) ? trim($_POST['owner']) : '');
-    $ownerprofile = (!empty($_POST['ownerprofile']) ? trim($_POST['ownerprofile']) : '');
-    $postal = (!empty($_POST['postal']) ? (trim($_POST['postal'])) : '');
-    $notes = (!empty($_POST['notes']) ? (trim($_POST['notes'])) : '');
-    $email = (!empty($_POST['email']) ? trim($_POST['email']) : '');
-    $footer_text = (!empty($_POST['footer_text']) ? (trim($_POST['footer_text'])) : '');
+    $owner = trim($_POST['owner'] ?? '');
+    $ownerprofile = trim($_POST['ownerprofile'] ?? '');
+    $postal = trim($_POST['postal'] ?? '');
+    $notes = trim($_POST['notes'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $footer_text = trim($_POST['footer_text'] ?? '');
     DI::config()->set('impressum','owner',strip_tags($owner));
     DI::config()->set('impressum','ownerprofile',strip_tags($ownerprofile));
     DI::config()->set('impressum','postal',strip_tags($postal));

--- a/libravatar/libravatar.php
+++ b/libravatar/libravatar.php
@@ -89,6 +89,6 @@ function libravatar_addon_admin(&$a, &$o)
  */
 function libravatar_addon_admin_post(&$a)
 {
-	$default_avatar = (!empty($_POST['avatar']) ? trim($_POST['avatar']) : 'identicon');
+	$default_avatar = trim($_POST['avatar'] ?? 'identicon');
 	DI::config()->set('libravatar', 'default_avatar', $default_avatar);
 }

--- a/libravatar/libravatar.php
+++ b/libravatar/libravatar.php
@@ -13,7 +13,6 @@ use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Core\Config\Util\ConfigFileLoader;
-use Friendica\Util\Strings;
 
 /**
  * Installs the addon hook
@@ -90,6 +89,6 @@ function libravatar_addon_admin(&$a, &$o)
  */
 function libravatar_addon_admin_post(&$a)
 {
-	$default_avatar = (!empty($_POST['avatar']) ? Strings::escapeTags(trim($_POST['avatar'])) : 'identicon');
+	$default_avatar = (!empty($_POST['avatar']) ? trim($_POST['avatar']) : 'identicon');
 	DI::config()->set('libravatar', 'default_avatar', $default_avatar);
 }

--- a/newmemberwidget/newmemberwidget.php
+++ b/newmemberwidget/newmemberwidget.php
@@ -11,7 +11,6 @@ use Friendica\Core\Hook;
 use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\DI;
-use Friendica\Util\Strings;
 
 function newmemberwidget_install()
 {
@@ -49,7 +48,7 @@ function newmemberwidget_network_mod_init ($a, $b)
 function newmemberwidget_addon_admin_post(&$a)
 {
 	$ft = (!empty($_POST['freetext']) ? trim($_POST['freetext']) : "");
-	$lsn = (!empty($_POST['localsupportname']) ? Strings::escapeTags(trim($_POST['localsupportname'])) : "");
+	$lsn = (!empty($_POST['localsupportname']) ? trim($_POST['localsupportname']) : "");
 	$gs = intval($_POST['linkglobalsupport']);
 	$ls = intval($_POST['linklocalsupport']);
 	DI::config()->set('newmemberwidget', 'freetext',           trim($ft));

--- a/newmemberwidget/newmemberwidget.php
+++ b/newmemberwidget/newmemberwidget.php
@@ -48,7 +48,7 @@ function newmemberwidget_network_mod_init ($a, $b)
 function newmemberwidget_addon_admin_post(&$a)
 {
 	$ft = (!empty($_POST['freetext']) ? trim($_POST['freetext']) : "");
-	$lsn = (!empty($_POST['localsupportname']) ? trim($_POST['localsupportname']) : "");
+	$lsn = trim($_POST['localsupportname'] ?? '');
 	$gs = intval($_POST['linkglobalsupport']);
 	$ls = intval($_POST['linklocalsupport']);
 	DI::config()->set('newmemberwidget', 'freetext',           trim($ft));

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -36,7 +36,6 @@ use Friendica\Core\Logger;
 use Friendica\Core\Renderer;
 use Friendica\DI;
 use Friendica\Core\Config\Util\ConfigFileLoader;
-use Friendica\Util\Strings;
 
 function piwik_install() {
 	Hook::register('load_config', 'addon/piwik/piwik.php', 'piwik_load_config');
@@ -102,7 +101,7 @@ function piwik_addon_admin (&$a, &$o) {
 	]);
 }
 function piwik_addon_admin_post (&$a) {
-	$url = (!empty($_POST['baseurl']) ? Strings::escapeTags(trim($_POST['baseurl'])) : '');
+	$url = (!empty($_POST['baseurl']) ? trim($_POST['baseurl']) : '');
 	$id = (!empty($_POST['siteid']) ? trim($_POST['siteid']) : '');
 	$optout = (!empty($_POST['optout']) ? trim($_POST['optout']) : '');
 	$async = (!empty($_POST['async']) ? trim($_POST['async']) : '');

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -101,10 +101,10 @@ function piwik_addon_admin (&$a, &$o) {
 	]);
 }
 function piwik_addon_admin_post (&$a) {
-	$url = (!empty($_POST['baseurl']) ? trim($_POST['baseurl']) : '');
-	$id = (!empty($_POST['siteid']) ? trim($_POST['siteid']) : '');
-	$optout = (!empty($_POST['optout']) ? trim($_POST['optout']) : '');
-	$async = (!empty($_POST['async']) ? trim($_POST['async']) : '');
+	$url = trim($_POST['baseurl'] ?? '');
+	$id = trim($_POST['siteid'] ?? '');
+	$optout = trim($_POST['optout'] ?? '');
+	$async = trim($_POST['async'] ?? '');
 	DI::config()->set('piwik', 'baseurl', $url);
 	DI::config()->set('piwik', 'siteid', $id);
 	DI::config()->set('piwik', 'optout', $optout);

--- a/public_server/public_server.php
+++ b/public_server/public_server.php
@@ -17,7 +17,6 @@ use Friendica\Model\Notification;
 use Friendica\Model\User;
 use Friendica\Core\Config\Util\ConfigFileLoader;
 use Friendica\Util\DateTimeFormat;
-use Friendica\Util\Strings;
 
 function public_server_install()
 {
@@ -126,12 +125,12 @@ function public_server_login($a, $b)
 function public_server_addon_admin_post(&$a)
 {
 	BaseModule::checkFormSecurityTokenRedirectOnError('/admin/addons/publicserver', 'publicserver');
-	$expiredays = (!empty($_POST['expiredays']) ? Strings::escapeTags(trim($_POST['expiredays'])) : '');
-	$expireposts = (!empty($_POST['expireposts']) ? Strings::escapeTags(trim($_POST['expireposts'])) : '');
-	$nologin = (!empty($_POST['nologin']) ? Strings::escapeTags(trim($_POST['nologin'])) : '');
-	$flagusers = (!empty($_POST['flagusers']) ? Strings::escapeTags(trim($_POST['flagusers'])) : '');
-	$flagposts = (!empty($_POST['flagposts']) ? Strings::escapeTags(trim($_POST['flagposts'])) : '');
-	$flagpostsexpire = (!empty($_POST['flagpostsexpire']) ? Strings::escapeTags(trim($_POST['flagpostsexpire'])) : '');
+	$expiredays = (!empty($_POST['expiredays']) ? trim($_POST['expiredays']) : '');
+	$expireposts = (!empty($_POST['expireposts']) ? trim($_POST['expireposts']) : '');
+	$nologin = (!empty($_POST['nologin']) ? trim($_POST['nologin']) : '');
+	$flagusers = (!empty($_POST['flagusers']) ? trim($_POST['flagusers']) : '');
+	$flagposts = (!empty($_POST['flagposts']) ? trim($_POST['flagposts']) : '');
+	$flagpostsexpire = (!empty($_POST['flagpostsexpire']) ? trim($_POST['flagpostsexpire']) : '');
 	DI::config()->set('public_server', 'expiredays', $expiredays);
 	DI::config()->set('public_server', 'expireposts', $expireposts);
 	DI::config()->set('public_server', 'nologin', $nologin);

--- a/public_server/public_server.php
+++ b/public_server/public_server.php
@@ -125,12 +125,12 @@ function public_server_login($a, $b)
 function public_server_addon_admin_post(&$a)
 {
 	BaseModule::checkFormSecurityTokenRedirectOnError('/admin/addons/publicserver', 'publicserver');
-	$expiredays = (!empty($_POST['expiredays']) ? trim($_POST['expiredays']) : '');
-	$expireposts = (!empty($_POST['expireposts']) ? trim($_POST['expireposts']) : '');
-	$nologin = (!empty($_POST['nologin']) ? trim($_POST['nologin']) : '');
-	$flagusers = (!empty($_POST['flagusers']) ? trim($_POST['flagusers']) : '');
-	$flagposts = (!empty($_POST['flagposts']) ? trim($_POST['flagposts']) : '');
-	$flagpostsexpire = (!empty($_POST['flagpostsexpire']) ? trim($_POST['flagpostsexpire']) : '');
+	$expiredays = trim($_POST['expiredays'] ?? '');
+	$expireposts = trim($_POST['expireposts'] ?? '');
+	$nologin = trim($_POST['nologin'] ?? '');
+	$flagusers = trim($_POST['flagusers'] ?? '');
+	$flagposts = trim($_POST['flagposts'] ?? '');
+	$flagpostsexpire = trim($_POST['flagpostsexpire'] ?? '');
 	DI::config()->set('public_server', 'expiredays', $expiredays);
 	DI::config()->set('public_server', 'expireposts', $expireposts);
 	DI::config()->set('public_server', 'nologin', $nologin);

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -75,8 +75,8 @@ function tumblr_addon_admin(App $a, &$o)
 
 function tumblr_addon_admin_post(App $a)
 {
-	$consumer_key    = (!empty($_POST['consumer_key'])    ? trim($_POST['consumer_key'])   : '');
-	$consumer_secret = (!empty($_POST['consumer_secret']) ? trim($_POST['consumer_secret']): '');
+	$consumer_key    = trim($_POST['consumer_key'] ?? : '');
+	$consumer_secret = trim($_POST['consumer_secret'] ?? '');
 
 	DI::config()->set('tumblr', 'consumer_key',$consumer_key);
 	DI::config()->set('tumblr', 'consumer_secret',$consumer_secret);

--- a/tumblr/tumblr.php
+++ b/tumblr/tumblr.php
@@ -18,7 +18,6 @@ use Friendica\Database\DBA;
 use Friendica\DI;
 use Friendica\Model\Post;
 use Friendica\Model\Tag;
-use Friendica\Util\Strings;
 
 function tumblr_install()
 {
@@ -76,8 +75,8 @@ function tumblr_addon_admin(App $a, &$o)
 
 function tumblr_addon_admin_post(App $a)
 {
-	$consumer_key    =       (!empty($_POST['consumer_key'])      ? Strings::escapeTags(trim($_POST['consumer_key']))   : '');
-	$consumer_secret =       (!empty($_POST['consumer_secret'])   ? Strings::escapeTags(trim($_POST['consumer_secret'])): '');
+	$consumer_key    = (!empty($_POST['consumer_key'])    ? trim($_POST['consumer_key'])   : '');
+	$consumer_secret = (!empty($_POST['consumer_secret']) ? trim($_POST['consumer_secret']): '');
 
 	DI::config()->set('tumblr', 'consumer_key',$consumer_key);
 	DI::config()->set('tumblr', 'consumer_secret',$consumer_secret);

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -791,8 +791,8 @@ function twitter_post_hook(App $a, array &$b)
 
 function twitter_addon_admin_post(App $a)
 {
-	$consumerkey    = !empty($_POST['consumerkey'])    ? Strings::escapeTags(trim($_POST['consumerkey']))    : '';
-	$consumersecret = !empty($_POST['consumersecret']) ? Strings::escapeTags(trim($_POST['consumersecret'])) : '';
+	$consumerkey    = !empty($_POST['consumerkey'])    ? trim($_POST['consumerkey'])    : '';
+	$consumersecret = !empty($_POST['consumersecret']) ? trim($_POST['consumersecret']) : '';
 	DI::config()->set('twitter', 'consumerkey', $consumerkey);
 	DI::config()->set('twitter', 'consumersecret', $consumersecret);
 }

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -791,8 +791,8 @@ function twitter_post_hook(App $a, array &$b)
 
 function twitter_addon_admin_post(App $a)
 {
-	$consumerkey    = !empty($_POST['consumerkey'])    ? trim($_POST['consumerkey'])    : '';
-	$consumersecret = !empty($_POST['consumersecret']) ? trim($_POST['consumersecret']) : '';
+	$consumerkey    = trim($_POST['consumerkey'] ?? : '');
+	$consumersecret = trim($_POST['consumersecret'] ?? '');
 	DI::config()->set('twitter', 'consumerkey', $consumerkey);
 	DI::config()->set('twitter', 'consumersecret', $consumersecret);
 }

--- a/webrtc/webrtc.php
+++ b/webrtc/webrtc.php
@@ -26,7 +26,7 @@ function webrtc_addon_admin (&$a, &$o) {
 	]);
 }
 function webrtc_addon_admin_post (&$a) {
-        $url = (!empty($_POST['webrtcurl']) ? trim($_POST['webrtcurl']) : '');
+        $url = trim($_POST['webrtcurl'] ?? '');
 	    DI::config()->set('webrtc', 'webrtcurl', $url);
 }
 

--- a/webrtc/webrtc.php
+++ b/webrtc/webrtc.php
@@ -9,7 +9,6 @@
 use Friendica\Core\Hook;
 use Friendica\Core\Renderer;
 use Friendica\DI;
-use Friendica\Util\Strings;
 
 function webrtc_install() {
         Hook::register('app_menu', 'addon/webrtc/webrtc.php', 'webrtc_app_menu');
@@ -27,7 +26,7 @@ function webrtc_addon_admin (&$a, &$o) {
 	]);
 }
 function webrtc_addon_admin_post (&$a) {
-        $url = (!empty($_POST['webrtcurl']) ? Strings::escapeTags(trim($_POST['webrtcurl'])) : '');
+        $url = (!empty($_POST['webrtcurl']) ? trim($_POST['webrtcurl']) : '');
 	    DI::config()->set('webrtc', 'webrtcurl', $url);
 }
 


### PR DESCRIPTION
They had been used mostly for content that isn't displayed at all or that only an admin is allowed to enter, like in the impressum. So it was safe to remove the call.