### PR TITLE
[twitter] Abort follow process on API call failure

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -157,7 +157,10 @@ function twitter_follow(App $a, array &$contact)
 
 	$uid = $a->getLoggedInUserId();
 
-	twitter_api_contact('friendships/create', ['network' => Protocol::TWITTER, 'nick' => $nickname], $uid);
+	if (!twitter_api_contact('friendships/create', ['network' => Protocol::TWITTER, 'nick' => $nickname], $uid)) {
+		$contact = null;
+		return;
+	}
 
 	$user = twitter_fetchuser($nickname);
 


### PR DESCRIPTION
- Prevents users without a connected Twitter account from visibly following a Twitter contact

Fixes https://github.com/friendica/friendica/issues/11139