### PR TITLE
Twitter: Assign contacts via their twitter id - not via their url

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1886,13 +1886,14 @@ function twitter_createpost(App $a, $uid, $post, array $self, $create_user, $onl
 
 			$postarray['thr-parent'] = $retweet['uri'];
 		} else {
-			$retweet['source'] = $postarray['source'];
-			$retweet['direction'] = $postarray['direction'];
-			$retweet['private'] = $postarray['private'];
-			$retweet['allow_cid'] = $postarray['allow_cid'];
-			$retweet['contact-id'] = $postarray['contact-id'];
-			$retweet['owner-name'] = $postarray['owner-name'];
-			$retweet['owner-link'] = $postarray['owner-link'];
+			$retweet['source']       = $postarray['source'];
+			$retweet['direction']    = $postarray['direction'];
+			$retweet['private']      = $postarray['private'];
+			$retweet['allow_cid']    = $postarray['allow_cid'];
+			$retweet['contact-id']   = $postarray['contact-id'];
+			$retweet['owner-id']     = $postarray['owner-id'];
+			$retweet['owner-name']   = $postarray['owner-name'];
+			$retweet['owner-link']   = $postarray['owner-link'];
 			$retweet['owner-avatar'] = $postarray['owner-avatar'];
 
 			$postarray = $retweet;


### PR DESCRIPTION
Twitter contacts should be assigned via their Twitter id, not via their URL. I experienced problems with Twitter contact entries that had a change in their nick which resulted in incomplete Twitter contact entries.

Now we address the contacts via their Twitter id - which should help.