### PR TITLE
Update browser support notes for WebRTC

### DIFF
--- a/webrtc/README.md
+++ b/webrtc/README.md
@@ -10,12 +10,10 @@ really a person 2 person communication, using the server to only signal who
 wants to talk to who, the actual transfer of the audio and video is directly
 between the participants.
 
-If you would like to try this addon please download one of the following
-either Chrome/Chromium 25 or higher or Firefox 21 or higher. Then test it by
-visiting a known webrtc instance (i.e. [live.mayfirst.org](https://live.mayfirst.org)) create a
-room, you should be asked to share your camera and microphone (firefox will let
-you choose one or the other, whereas chrome/chromium asks for both in one
-question).
+You can test it by visiting a known webrtc instance (i.e. [live.mayfirst.org](https://live.mayfirst.org))
+create a room, you should be asked to share your camera and microphone (firefox
+will let you choose one or the other, whereas chrome/chromium asks for both in
+one question).
 
 If the test is successful then proceed with copying the webrtc instance you
 would like to use and place it in the config window and save. Now when you

--- a/webrtc/webrtc.php
+++ b/webrtc/webrtc.php
@@ -42,7 +42,7 @@ function webrtc_content(&$a) {
 
         /* embedd the landing page in an iframe */
         $o .= '<h2>'.DI::l10n()->t('Video Chat').'</h2>';
-        $o .= '<p>'.DI::l10n()->t('WebRTC is a video and audio conferencing tool that works with Firefox (version 21 and above) and Chrome/Chromium (version 25 and above). Just create a new chat room and send the link to someone you want to chat with.').'</p>';
+        $o .= '<p>'.DI::l10n()->t('WebRTC is a video and audio conferencing tool that works in all modern browsers. Just create a new chat room and send the link to someone you want to chat with.').'</p>';
 	if ($webrtcurl == '') {
 	    $o .= '<p>'.DI::l10n()->t('Please contact your friendica admin and send a reminder to configure the WebRTC addon.').'</p>';
 	} else {


### PR DESCRIPTION
A quick update; WebRTC has been supported in all major browsers for quite a while now ([source](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#browser_compatibility)), there is no need to mention specific versions.