### PR TITLE
Twitter: Only search for comments with extid to avoid problems with mirrored posts

### DIFF
--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -1761,7 +1761,7 @@ function twitter_createpost(App $a, $uid, $post, array $self, $create_user, $onl
 
 		$item = Post::selectFirst(['uri'], ['uri' => $thr_parent, 'uid' => $uid]);
 		if (!DBA::isResult($item)) {
-			$item = Post::selectFirst(['uri'], ['extid' => $thr_parent, 'uid' => $uid]);
+			$item = Post::selectFirst(['uri'], ['extid' => $thr_parent, 'uid' => $uid, 'gravity' => GRAVITY_COMMENT]);
 		}
 
 		if (DBA::isResult($item)) {


### PR DESCRIPTION
Twitter comments had been falsely assigned to the Friendica post if the post had been created via the mirror function. This should solve the problem.