### PR TITLE
mark the whindowsphonepush as unsupported

### DIFF
--- a/windowsphonepush/windowsphonepush.php
+++ b/windowsphonepush/windowsphonepush.php
@@ -5,6 +5,7 @@
  * Description: Enable push notification to send information to Friendica Mobile app on Windows phone (count of unread timeline entries, text of last posting - if wished by user)
  * Version: 2.0
  * Author: Gerhard Seeber <http://friendica.seeber.at/profile/admin>
+ * Status: Unsupported
  *
  *
  * Pre-requisite: Windows Phone mobile device (at least WP 7.0)


### PR DESCRIPTION
The Windows Phone app for Friendica does not seem to exist anymore (see https://www.microsoft.com/store/p/friendica-mobile/9nblggh0fhmn) which was linked from a promo video as store location. So lets set it to unsupported and deprecate it once 2022.09 was released.