### PR TITLE
[impressum] notes and email field were exchanged

### DIFF
--- a/impressum/impressum.php
+++ b/impressum/impressum.php
@@ -98,8 +98,8 @@ function impressum_addon_admin_post (App $a)
 	DI::config()->set('impressum', 'owner', strip_tags(trim($_POST['owner'] ?? '')));
 	DI::config()->set('impressum', 'ownerprofile', strip_tags(trim($_POST['ownerprofile'] ?? '')));
 	DI::config()->set('impressum', 'postal', strip_tags(trim($_POST['postal'] ?? '')));
-	DI::config()->set('impressum', 'email', strip_tags(trim($_POST['notes'] ?? '')));
-	DI::config()->set('impressum', 'notes', strip_tags(trim($_POST['email'] ?? '')));
+	DI::config()->set('impressum', 'email', strip_tags(trim($_POST['email'] ?? '')));
+	DI::config()->set('impressum', 'notes', strip_tags(trim($_POST['notes'] ?? '')));
 	DI::config()->set('impressum', 'footer_text', strip_tags(trim($_POST['footer_text'] ?? '')));
 }
 


### PR DESCRIPTION
The `notes` and `email` field of the admin form got mixed up when the send form information was processed.

fixes https://github.com/friendica/friendica/issues/11998