### PR TITLE
Revert "Fix CI pipeline"

### DIFF
--- a/.woodpecker/.continuous-deployment.yml
+++ b/.woodpecker/.continuous-deployment.yml
@@ -1,3 +1,8 @@
+# This prevents executing this pipeline at other servers than ci.friendi.ca
+labels:
+  location: friendica
+  type: releaser
+
 skip_clone: true
 
 pipeline:
@@ -10,7 +15,6 @@ pipeline:
       repo: friendica/friendica-addons
       branch: [ develop, '*-rc' ]
       event: push
-      instance: releaser.ci.friendi.ca
   clone_friendica_addon:
     image: alpine/git
     commands:
@@ -25,7 +29,6 @@ pipeline:
       repo: friendica/friendica-addons
       branch: [ develop, '*-rc' ]
       event: push
-      instance: releaser.ci.friendi.ca
   restore_cache:
     image: meltwater/drone-cache:dev
     settings:
@@ -41,7 +44,6 @@ pipeline:
       repo: friendica/friendica-addons
       branch: [ develop, '*-rc' ]
       event: push
-      instance: releaser.ci.friendi.ca
   composer_install:
     image: friendicaci/php7.4:php7.4.18
     commands:
@@ -54,7 +56,6 @@ pipeline:
       repo: friendica/friendica-addons
       branch: [ develop, '*-rc' ]
       event: push
-      instance: releaser.ci.friendi.ca
   create_artifacts:
     image: debian
     commands:
@@ -83,7 +84,6 @@ pipeline:
       repo: friendica/friendica-addons
       branch: [ develop, '*-rc' ]
       event: push
-      instance: releaser.ci.friendi.ca
   sign_artifacts:
     image: plugins/gpgsign
     settings:
@@ -100,7 +100,6 @@ pipeline:
       repo: friendica/friendica-addons
       branch: [ develop, '*-rc' ]
       event: push
-      instance: releaser.ci.friendi.ca
   publish_artifacts:
     image: alpine
     commands:
@@ -111,4 +110,3 @@ pipeline:
       repo: friendica/friendica-addons
       branch: [ develop, '*-rc' ]
       event: push
-      instance: releaser.ci.friendi.ca

--- a/.woodpecker/.releaser.yml
+++ b/.woodpecker/.releaser.yml
@@ -1,3 +1,8 @@
+# This prevents executing this pipeline at other servers than ci.friendi.ca
+labels:
+  location: friendica
+  type: releaser
+
 skip_clone: true
 
 pipeline:
@@ -9,7 +14,6 @@ pipeline:
     when:
       repo: friendica/friendica-addons
       event: tag
-      instance: releaser.ci.friendi.ca
   clone_friendica_addon:
     image: alpine/git
     commands:
@@ -23,7 +27,6 @@ pipeline:
     when:
       repo: friendica/friendica-addons
       event: tag
-      instance: releaser.ci.friendi.ca
   restore_cache:
     image: meltwater/drone-cache:dev
     settings:
@@ -38,7 +41,6 @@ pipeline:
     when:
       repo: friendica/friendica-addons
       event: tag
-      instance: releaser.ci.friendi.ca
   composer_install:
     image: friendicaci/php7.4:php7.4.18
     commands:
@@ -48,7 +50,6 @@ pipeline:
     when:
       repo: friendica/friendica-addons
       event: tag
-      instance: releaser.ci.friendi.ca
     volumes:
       - /etc/hosts:/etc/hosts
   create_artifacts:
@@ -78,7 +79,6 @@ pipeline:
     when:
       repo: friendica/friendica-addons
       event: tag
-      instance: releaser.ci.friendi.ca
   sign_artifacts:
     image: plugins/gpgsign
     settings:
@@ -94,7 +94,6 @@ pipeline:
     when:
       repo: friendica/friendica-addons
       event: tag
-      instance: releaser.ci.friendi.ca
   publish_artifacts:
     image: alpine
     commands:
@@ -104,4 +103,3 @@ pipeline:
     when:
       repo: friendica/friendica-addons
       event: tag
-      instance: releaser.ci.friendi.ca


### PR DESCRIPTION
Reverts friendica/friendica-addons#1297

@MrPetovan  - I revert both this and the other PR because the `label`-filtering wasn't supported at Woodpecker stable (which I completely oversaw..). But because of the unexpected behavior of the "stable" method (=> `instance`-filtering), I pulled the nightly build of Woodpecker, where `label` is now included :)