### PR TITLE
Twitter: automatically follow fediverse accounts in profile

### DIFF
--- a/twitter/lang/C/messages.po
+++ b/twitter/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-02 23:56+0000\n"
+"POT-Creation-Date: 2022-11-13 10:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,19 +21,19 @@ msgstr ""
 msgid "Post to Twitter"
 msgstr ""
 
-#: twitter.php:262
+#: twitter.php:263
 msgid ""
 "You submitted an empty PIN, please Sign In with Twitter again to get a new "
 "one."
 msgstr ""
 
-#: twitter.php:327
+#: twitter.php:330
 msgid ""
 "No consumer key pair for Twitter found. Please contact your site "
 "administrator."
 msgstr ""
 
-#: twitter.php:340
+#: twitter.php:343
 msgid ""
 "At this Friendica instance the Twitter addon was enabled but you have not "
 "yet connected your account to your Twitter account. To do so click the "
@@ -42,26 +42,26 @@ msgid ""
 "be posted to Twitter."
 msgstr ""
 
-#: twitter.php:341
+#: twitter.php:344
 msgid "Log in with Twitter"
 msgstr ""
 
-#: twitter.php:343
+#: twitter.php:346
 msgid "Copy the PIN from Twitter here"
 msgstr ""
 
-#: twitter.php:351 twitter.php:395
+#: twitter.php:354 twitter.php:399
 msgid "An error occured: "
 msgstr ""
 
-#: twitter.php:365
+#: twitter.php:368
 #, php-format
 msgid ""
 "Currently connected to: <a href=\"https://twitter.com/%1$s\" target="
 "\"_twitter\">%1$s</a>"
 msgstr ""
 
-#: twitter.php:371
+#: twitter.php:374
 msgid ""
 "<strong>Note</strong>: Due to your privacy settings (<em>Hide your profile "
 "details from unknown viewers?</em>) the link potentially included in public "
@@ -69,46 +69,46 @@ msgid ""
 "the visitor that the access to your profile has been restricted."
 msgstr ""
 
-#: twitter.php:378
+#: twitter.php:381
 msgid "Invalid Twitter info"
 msgstr ""
 
-#: twitter.php:379
+#: twitter.php:382
 msgid "Disconnect"
 msgstr ""
 
-#: twitter.php:384
+#: twitter.php:387
 msgid "Allow posting to Twitter"
 msgstr ""
 
-#: twitter.php:384
+#: twitter.php:387
 msgid ""
 "If enabled all your <strong>public</strong> postings can be posted to the "
 "associated Twitter account. You can choose to do so by default (here) or for "
 "every posting separately in the posting options when writing the entry."
 msgstr ""
 
-#: twitter.php:385
+#: twitter.php:388
 msgid "Send public postings to Twitter by default"
 msgstr ""
 
-#: twitter.php:386
+#: twitter.php:389
 msgid "Use threads instead of truncating the content"
 msgstr ""
 
-#: twitter.php:387
+#: twitter.php:390
 msgid "Mirror all posts from twitter that are no replies"
 msgstr ""
 
-#: twitter.php:388
+#: twitter.php:391
 msgid "Import the remote timeline"
 msgstr ""
 
-#: twitter.php:389
+#: twitter.php:392
 msgid "Automatically create contacts"
 msgstr ""
 
-#: twitter.php:389
+#: twitter.php:392
 msgid ""
 "This will automatically create a contact in Friendica as soon as you receive "
 "a message from an existing contact via the Twitter network. If you do not "
@@ -116,33 +116,44 @@ msgid ""
 "from whom you would like to see posts here."
 msgstr ""
 
-#: twitter.php:402
+#: twitter.php:393
+msgid "Follow in fediverse"
+msgstr ""
+
+#: twitter.php:393
+msgid ""
+"Automatically subscribe to the contact in the fediverse, when a fediverse "
+"account is mentioned in name or description and we are following the Twitter "
+"contact."
+msgstr ""
+
+#: twitter.php:406
 msgid "Twitter Import/Export/Mirror"
 msgstr ""
 
-#: twitter.php:554
+#: twitter.php:558
 msgid ""
 "Please connect a Twitter account in your Social Network settings to import "
 "Twitter posts."
 msgstr ""
 
-#: twitter.php:561
+#: twitter.php:565
 msgid "Twitter post not found."
 msgstr ""
 
-#: twitter.php:961
+#: twitter.php:965
 msgid "Save Settings"
 msgstr ""
 
-#: twitter.php:963
+#: twitter.php:967
 msgid "Consumer key"
 msgstr ""
 
-#: twitter.php:964
+#: twitter.php:968
 msgid "Consumer secret"
 msgstr ""
 
-#: twitter.php:1163
+#: twitter.php:1167
 #, php-format
 msgid "%s on Twitter"
 msgstr ""

--- a/twitter/templates/connector_settings.tpl
+++ b/twitter/templates/connector_settings.tpl
@@ -22,3 +22,4 @@
 {{include file="field_checkbox.tpl" field=$mirror}}
 {{include file="field_checkbox.tpl" field=$import}}
 {{include file="field_checkbox.tpl" field=$create_user}}
+{{include file="field_checkbox.tpl" field=$auto_follow}}


### PR DESCRIPTION
Many Twitter users who moved to the Fediverse are providing their Fediverse address in their Twitter name and/or their profile description.

We now check for this and automatically follow these accounts if the user followed the Twitter account as well.

The check is performed each time that the contact has published a tweet, so it can take some time for the system to detect them all.