### PR TITLE
[nsfw] Match regular words with case sensitivity

### DIFF
--- a/nsfw/lang/C/messages.po
+++ b/nsfw/lang/C/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-21 19:15-0500\n"
+"POT-Creation-Date: 2022-11-18 11:57-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,7 +34,9 @@ msgid "Comma separated list of keywords to hide"
 msgstr ""
 
 #: nsfw.php:67
-msgid "Use /expression/ to provide regular expressions"
+msgid ""
+"Use /expression/ to provide regular expressions, #tag to specfically match "
+"hashtags (case-insensitive), or regular words (case-sensitive)"
 msgstr ""
 
 #: nsfw.php:72

--- a/nsfw/nsfw.php
+++ b/nsfw/nsfw.php
@@ -64,7 +64,7 @@ function nsfw_addon_settings(App &$a, array &$data)
 	$html = Renderer::replaceMacros($t, [
 		'$info'    => DI::l10n()->t('This addon searches for specified words/text in posts and collapses them. It can be used to filter content tagged with for instance #NSFW that may be deemed inappropriate at certain times or places, such as being at work. It is also useful for hiding irrelevant or annoying content from direct view.'),
 		'$enabled' => ['nsfw-enable', DI::l10n()->t('Enable Content filter'), $enabled],
-		'$words'   => ['nsfw-words', DI::l10n()->t('Comma separated list of keywords to hide'), $words, DI::l10n()->t('Use /expression/ to provide regular expressions')],
+		'$words'   => ['nsfw-words', DI::l10n()->t('Comma separated list of keywords to hide'), $words, DI::l10n()->t('Use /expression/ to provide regular expressions, #tag to specfically match hashtags (case-insensitive), or regular words (case-sensitive)')],
 	]);
 
 	$data = [
@@ -125,7 +125,7 @@ function nsfw_prepare_body_content_filter(App $a, &$hook_data)
 					$found = nsfw_find_word_in_item_tags($hook_data['item']['hashtags'], substr($word, 1));
 					break;
 				default:
-					$found = stripos($body, $word) !== false || nsfw_find_word_in_item_tags($hook_data['item']['tags'], $word);
+					$found = strpos($body, $word) !== false || nsfw_find_word_in_item_tags($hook_data['item']['tags'], $word);
 					break;
 			}
 


### PR DESCRIPTION
I've been trying to filter my timeline after the recent influx of users coming mostly from Twitter, and I've tried to filter the word "Mastodon", but it started filtering any post mentioning a user on a domain including "mastodon" in the domain name, which wasn't what I expected. While it makes sense to match hashtags no matter their case, regular words should be sensitive to case.