### PR TITLE
[various] Set config loaded from default values to SOURCE_STATIC

### DIFF
--- a/geonames/README.md
+++ b/geonames/README.md
@@ -7,10 +7,12 @@ Use [Geonames service](https://www.geonames.org) to resolve nearest populated lo
 
 ## Installation
 
-Pre-requisite: Register a username at https://www.geonames.org/login and set it in `config/addon.config.php`
+Pre-requisite: Register a username at https://www.geonames.org/login and set it in `config/geonames.config.php`:
 
-    'geonames' => [
-        'username' => 'your_username'
-    ],
+	return [
+		'geonames' => [
+			'username' => 'your_username'
+		],
+	];
 
 Also visit https://geonames.org/manageaccount and enable access to the free web services.

--- a/geonames/config/geonames.config.php
+++ b/geonames/config/geonames.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/geonames.config.php in your Friendica directory and set the correct values there
 
 return [
 	'geonames' => [

--- a/geonames/geonames.php
+++ b/geonames/geonames.php
@@ -35,7 +35,7 @@ function geonames_install()
 
 function geonames_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('geonames'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('geonames'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function geonames_post_hook(App $a, array &$item)

--- a/gravatar/README.md
+++ b/gravatar/README.md
@@ -38,11 +38,13 @@ Open the `config/local.config.php` file and add "gravatar" to the list of activa
 		...
 	]
 
-You can add two configuration variables for the addon to the `config/addon.config.php` file:
+You can add two configuration variables for the addon to the `config/gravatar.config.php` file:
 
-    'gravatar' => [
-        'default_avatar' => 'identicon',
-        'rating' => 'g',
-    ],
+	return [
+		'gravatar' => [
+			'default_avatar' => 'identicon',
+			'rating' => 'g',
+		],
+	];
 
 [1]: http://www.gravatar.com/site/implement/images/ "See documentation at Gravatar for more information"

--- a/gravatar/config/gravatar.config.php
+++ b/gravatar/config/gravatar.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/gravatar.config.php in your Friendica directory and set the correct values there
 
 return [
 	'gravatar' => [

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -28,7 +28,7 @@ function gravatar_install() {
 
 function gravatar_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('gravatar'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('gravatar'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 /**

--- a/impressum/README.md
+++ b/impressum/README.md
@@ -16,14 +16,16 @@ Simply fill in the fields in the impressium settings page in the addons area of 
 
 Manual Configuration
 --------------------
-If you for any reason you prefer to use a configuration file instead, you can set the following variables in the `config/addon.config.php` file
+If you for any reason you prefer to use a configuration file instead, you can set the following variables in the `config/impressum.config.php` file
 
-	'impressum' => [
-        'owner' => '',           This is the Name of the Operator
-        'ownerprofile' => '',    This is an optional Friendica account where the above owner name will link to
-        'email' => '',           A contact email address (optional)
-                                 Will be displayed slightly obfuscated as name(at)example(dot)com
-        'postal' => '',          Should contain a postal address where you can be reached at (optional)
-        'notes' => '',           Additional informations that should be displayed in the Impressum block
-        'footer_text' => '',     Text that will be displayed at the bottom of the pages.
-    ],
+	return [
+		'impressum' => [
+			'owner' => '',           // This is the Name of the Operator
+			'ownerprofile' => '',    // This is an optional Friendica account where the above owner name will link to
+			'email' => '',           // A contact email address (optional)
+									 // Will be displayed slightly obfuscated as name(at)example(dot)com
+			'postal' => '',          // Should contain a postal address where you can be reached at (optional)
+			'notes' => '',           // Additional informations that should be displayed in the Impressum block
+			'footer_text' => '',     // Text that will be displayed at the bottom of the pages.
+		],
+	];

--- a/impressum/config/impressum.config.php
+++ b/impressum/config/impressum.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/impressum.config.php in your Friendica directory and set the correct values there
 
 return [
 	'impressum' => [

--- a/impressum/impressum.php
+++ b/impressum/impressum.php
@@ -56,7 +56,7 @@ function impressum_footer(App $a, string &$body)
 
 function impressum_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('impressum'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('impressum'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function impressum_show(App $a, string &$body)

--- a/ldapauth/README.md
+++ b/ldapauth/README.md
@@ -12,38 +12,4 @@ However, it's possible with an option to automate the creation of a Friendica ba
 Note when using with Windows Active Directory: you may need to set TLS_CACERT in your site
 ldap.conf file to the signing cert for your LDAP server.
 
-The configuration options for this module may be set in the `config/addon.config.php` file
-e.g.:
-
-	'ldapauth' => [
-        // ldap hostname server - required
-        'ldap_server' => '',
-
-        // admin dn - optional - only if ldap server dont have anonymous access
-        'ldap_binddn' => '',
-
-        // admin password - optional - only if ldap server dont have anonymous access
-        'ldap_bindpw' => '',
-
-        // dn to search users - required
-        'ldap_searchdn' => '',
-
-        // attribute to find username - required
-        'ldap_userattr' => '',
-
-        // DN of the group whose member can auth on Friendica - optional
-        'ldap_group' => '',
-
-        // To create Friendica account if user exists in ldap
-        // Requires an email and a simple (beautiful) nickname on user ldap object
-        // active account creation - optional - default true
-        'ldap_autocreateaccount' => true,
-
-        // attribute to get email - optional - default : 'mail'
-        'ldap_autocreateaccount_emailattribute' => 'mail',
-
-        // attribute to get nickname - optional - default : 'givenName'
-        'ldap_autocreateaccount_nameattribute' => 'givenName',
-    ],
-
-...etc.
+The configuration options for this module are described in the `config/ldapauth.config.php` file.

--- a/ldapauth/config/ldapauth.config.php
+++ b/ldapauth/config/ldapauth.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/ldapauth.config.php in your Friendica directory and set the correct values there
 
 return [
 	'ldapauth' => [

--- a/ldapauth/ldapauth.php
+++ b/ldapauth/ldapauth.php
@@ -45,7 +45,7 @@ function ldapauth_install()
 
 function ldapauth_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('ldapauth'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('ldapauth'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function ldapauth_hook_authenticate(App $a, array &$b)

--- a/ldapauth/ldapauth.php
+++ b/ldapauth/ldapauth.php
@@ -26,32 +26,7 @@
  * Note when using with Windows Active Directory: you may need to set TLS_CACERT in your site
  * ldap.conf file to the signing cert for your LDAP server.
  *
- * The configuration options for this module may be set in the config/addon.config.php file
- * e.g.:
- *
- * [ldapauth]
- * ; ldap hostname server - required
- * ldap_server = host.example.com
- * ; dn to search users - required
- * ldap_searchdn = ou=users,dc=example,dc=com
- * ; attribute to find username - required
- * ldap_userattr = uid
- *
- * ; admin dn - optional - only if ldap server dont have anonymous access
- * ldap_binddn = cn=admin,dc=example,dc=com
- * ; admin password - optional - only if ldap server dont have anonymous access
- * ldap_bindpw = password
- *
- * ; for create Friendica account if user exist in ldap
- * ;     required an email and a simple (beautiful) nickname on user ldap object
- * ;   active account creation - optional - default none
- * ldap_autocreateaccount = true
- * ;   attribute to get email - optional - default : 'mail'
- * ldap_autocreateaccount_emailattribute = mail
- * ;   attribute to get nickname - optional - default : 'givenName'
- * ldap_autocreateaccount_nameattribute = cn
- *
- * ...etc.
+ * The configuration options for this module are described in the config/ldapauth.config.php file
  */
 
 use Friendica\App;

--- a/leistungsschutzrecht/README.md
+++ b/leistungsschutzrecht/README.md
@@ -1,16 +1,17 @@
 Leistungsschutzrecht Addon
 ==========================
 
-Main author Michael Vogel
+Main author: Michael Vogel
 
 This addon handles legal problems with the German link tax, named "Leistungsschutzrecht" by shortening preview texts.
-Additionally it is possibly to suppress preview pictures completely to avoid any legal problems.
+Additionally, it is possibly to suppress preview pictures completely to avoid any legal problems.
 
-## configuration
+## Configuration
 
-If you want to suppress pictures in previews, add this to your global `config/addon.config.php`:
+If you want to suppress pictures in previews, add this to your global `config/leistungsschutzrecht.config.php`:
 
-	'leistungsschutzrecht' => [
-		'suppress_photos' => true,
-	],
-
+	return [
+		'leistungsschutzrecht' => [
+			'suppress_photos' => true,
+		],
+	];

--- a/libravatar/README.md
+++ b/libravatar/README.md
@@ -31,10 +31,12 @@ Open the `config/local.config.php` file and add "libravatar" to the list of acti
         ...
     ]
 
-You can add one configuration variables for the addon to the `config/addon.config.php` file:
+You can add one configuration variables for the addon to the `config/libravatar.config.php` file:
 
-    'libravatar' => [
-        'default_avatar' => 'identicon',
-    ],
+	return [
+		'libravatar' => [
+			'default_avatar' => 'identicon',
+		],
+	];
 
 [1]: http://wiki.libravatar.org/api/ "See API documentation at Libravatar for more information"

--- a/libravatar/config/libravatar.config.php
+++ b/libravatar/config/libravatar.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/libravatar.config.php in your Friendica directory and set the correct values there
 
 return [
 	'libravatar' => [

--- a/libravatar/libravatar.php
+++ b/libravatar/libravatar.php
@@ -26,7 +26,7 @@ function libravatar_install()
 
 function libravatar_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('libravatar'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('libravatar'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 /**

--- a/mathjax/README.md
+++ b/mathjax/README.md
@@ -29,11 +29,13 @@ the addon by adding _mathjax_ to the list in your `config/local.config.php` file
         ...
     ]
 
-and then providing the base URL after that in the `config/addon.config.php` file
+and then providing the base URL after that in the `config/mathjax.config.php` file
 
-	'mathjax' => [
-		'baseurl' => '[the URL to your MathJax installation]',
-	],
+	return [
+		'mathjax' => [
+			'baseurl' => '[the URL to your MathJax installation]',
+		],
+	];
 
 Usage
 =====

--- a/openstreetmap/README.md
+++ b/openstreetmap/README.md
@@ -42,14 +42,16 @@ Open the `config/local.config.php` file and add "openstreetmap" to the list of a
          ...
      ]
 
-You can set configuration variables for the addon in the `config/addon.config.php` file:
+You can set configuration variables for the addon in the `config/openstreetmap.config.php` file:
 
-	'openstreetmap' => [
-		'tmsserver' => 'https://www.openstreetmap.org',
-		'nomserver' => 'https://nominatim.openstreetmap.org/search.php',
-		'zoom' => 16,
-		'marker' => 0,
-	],
+	return [
+		'openstreetmap' => [
+			'tmsserver' => 'https://www.openstreetmap.org',
+			'nomserver' => 'https://nominatim.openstreetmap.org/search.php',
+			'zoom' => 16,
+			'marker' => 0,
+		],
+	];
 
 The *tmsserver* points to the tile server you want to use. Use the full URL,
 with protocol (http/s) and trailing slash. You can configure the default zoom

--- a/openstreetmap/config/openstreetmap.config.php
+++ b/openstreetmap/config/openstreetmap.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/openstreetmap.config.php in your Friendica directory and set the correct values there
 
 return [
 	'openstreetmap' => [

--- a/openstreetmap/openstreetmap.php
+++ b/openstreetmap/openstreetmap.php
@@ -37,7 +37,7 @@ function openstreetmap_install()
 
 function openstreetmap_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('openstreetmap'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('openstreetmap'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function openstreetmap_alterheader(App $a, &$navHtml)

--- a/phpmailer/README.md
+++ b/phpmailer/README.md
@@ -8,45 +8,7 @@ This addon replaces the default `mail()` function by the `PHPMailer` library, al
 Configuration
 -------------
 
-You can override the default value of the following config keys in your base Friendica install `config/addon.config.php` file:
-
-	'phpmailer' => [
-        // smtp (Boolean)
-        // Enables SMTP relaying for outbound emails
-        'smtp' => false,
-
-        // smtp_server (String)
-        // SMTP server host name
-        'smtp_server' => 'smtp.example.com',
-
-        // smtp_port (Integer)
-        // SMTP server port number
-        'smtp_port' => 25,
-
-        // smtp_secure (String)
-        // What kind of encryption to use on the SMTP connection.
-        // Options: '', 'ssl' or 'tls'.
-        'smtp_secure' => '',
-
-        // smtp_port_s (Integer)
-        // Secure SMTP server port number
-        'smtp_port_s' => 465,
-
-        // smtp_username (String)
-        // SMTP server authentication user name
-        // Empty string disables authentication
-        'smtp_username' => '',
-
-        // smtp_password (String)
-        // SMTP server authentication password
-        // Empty string disables authentication
-        'smtp_password' => '',
-
-        // smtp_from (String)
-        // From address used when using the SMTP server
-        // Example: no-reply@example.com
-        'smtp_from' => '',
-    ],
+The configuration options for this module are described in the `config/phpmailer.config.php` file.
 
 License
 =======

--- a/phpmailer/config/phpmailer.config.php
+++ b/phpmailer/config/phpmailer.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/phpmailer.config.php in your Friendica directory and set the correct values there
 
 return [
 	'phpmailer' => [

--- a/phpmailer/phpmailer.php
+++ b/phpmailer/phpmailer.php
@@ -25,7 +25,7 @@ function phpmailer_install()
 
 function phpmailer_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('phpmailer'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('phpmailer'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 /**

--- a/piwik/README.md
+++ b/piwik/README.md
@@ -30,14 +30,16 @@ Open the `config/local.config.php` file and add "piwik" to the list of activated
         ...
     ]
 
-You can change 4 more configuration variables for the addon in the `config/addon.config.php` file:
+You can change 4 more configuration variables for the addon in the `config/piwik.config.php` file:
 
-	'piwik' => [
-        'baseurl' => 'example.com/piwik/',
-        'sideid' => 1,
-        'optout' => true,
-        'async' => false,
-    ],
+	return [
+		'piwik' => [
+			'baseurl' => 'example.com/piwik/',
+			'sideid' => 1,
+			'optout' => true,
+			'async' => false,
+		],
+	];
 
 Configuration fields
 ---------------------

--- a/piwik/config/piwik.config.php
+++ b/piwik/config/piwik.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/piwik.config.php in your Friendica directory and set the correct values there
 
 return [
 	'piwik' => [

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -50,7 +50,7 @@ function piwik_install() {
 
 function piwik_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('piwik'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('piwik'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function piwik_analytics(App $a, string &$b)

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -16,14 +16,17 @@
  *
  *   Configuration:
  *     Use the administration panel to configure the Piwik tracking addon, or
- *     in case you don't use this add the following lines to your config/addon.config.php
+ *     in case you don't use this, add the following lines to your config/piwik.config.php
  *     file:
  *
- *     [piwik]
- *     baseurl = example.com/piwik/
- *     sideid = 1
- *     optout = true ;set to false to disable
- *     async = false ;set to true to enable
+ *      return [
+ *          'piwik' => [
+ *              'baseurl' => '',
+ *              'sideid' => '',
+ *              'optout' => true,
+ *              'async' => false,
+ *          ],
+ *      ];
  *
  *     Change the siteid to the ID that the Piwik tracker for your Friendica
  *     installation has. Alter the baseurl to fit your needs, don't care
@@ -60,7 +63,7 @@ function piwik_analytics(App $a, string &$b)
 	DI::page()['htmlhead'] .= '<link rel="stylesheet"  type="text/css" href="' . DI::baseUrl()->get() . '/addon/piwik/piwik.css' . '" media="all" />';
 
 	/*
-	 *   Get the configuration variables from the config/addon.config.php file.
+	 *   Get the configuration values.
 	 */
 	$baseurl = DI::config()->get('piwik', 'baseurl');
 	$siteid  = DI::config()->get('piwik', 'siteid');

--- a/public_server/README.md
+++ b/public_server/README.md
@@ -6,21 +6,23 @@ Public Server is a Friendica addon which implements automatic account & post exp
 
 This is a modified version of the testdrive addon, DO NOT ACTIVATE AT THE SAME TIME AS THE TESTDRIVE ADDON.
 
-    'public_server' => [
-        // When an account is created on the site, it is given a hard expiration date of. 0 to disable.
-        'expiredays' => 0,
-        // Set the default days for posts to expire here. 0 to disable.
-        'expireposts' => 0,
-        // Remove users who have never logged in after nologin days. 0 to disable.
-        'nologin' => 0,
-        // Remove users who last logged in over flagusers days ago. 0 to disable.
-        'flagusers' => 0,
-        // For users who last logged in over flagposts days ago set post expiry days to flagpostsexpire. 0 to disable.
-        'flagposts' => 0,
-        'flagpostsexpire' => 0,
-    ],
+	return [
+		'public_server' => [
+			// When an account is created on the site, it is given a hard expiration date of. 0 to disable.
+			'expiredays' => 0,
+			// Set the default days for posts to expire here. 0 to disable.
+			'expireposts' => 0,
+			// Remove users who have never logged in after nologin days. 0 to disable.
+			'nologin' => 0,
+			// Remove users who last logged in over flagusers days ago. 0 to disable.
+			'flagusers' => 0,
+			// For users who last logged in over flagposts days ago set post expiry days to flagpostsexpire. 0 to disable.
+			'flagposts' => 0,
+			'flagpostsexpire' => 0,
+		],
+	];
 
-Set these in your `config/addon.config.php` file. By default nothing is defined in case the addon is activated accidentally.
+Set these in your `config/public_server.config.php` file. By default, nothing is defined in case the addon is activated accidentally.
 They can be ommitted or set to 0 to disable each option.
 The default values are those used by friendica.eu, change these as desired.
 

--- a/public_server/config/public_server.config.php
+++ b/public_server/config/public_server.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/public_server.config.php in your Friendica directory and set the correct values there
 
 return [
 	'public_server' => [

--- a/public_server/public_server.php
+++ b/public_server/public_server.php
@@ -29,7 +29,7 @@ function public_server_install()
 
 function public_server_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('public_server'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('public_server'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function public_server_register_account(App $a, $b)

--- a/pumpio/README.md
+++ b/pumpio/README.md
@@ -1,11 +1,13 @@
-To let the connector work properly you should define an application name in `config/addon.config.php`:
+To let the connector work properly you should define an application name in `config/pumpio.config.php`:
 
-	'pumpio' => [
-		'application_name' => '',
-		// Displays forwarded posts like "wall-to-wall" posts.
-		'wall-to-wall_share' => false,
-		// Given in minutes
-		'poll_interval' => 5,
-	],
+	return [
+		'pumpio' => [
+			'application_name' => '',
+			// Displays forwarded posts like "wall-to-wall" posts.
+			'wall-to-wall_share' => false,
+			// Given in minutes
+			'poll_interval' => 5,
+		],
+	];
 
 This name appears at pump.io and is important for not mirroring back posts that came from Friendica.

--- a/pumpio/config/pumpio.config.php
+++ b/pumpio/config/pumpio.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/pumpio.config.php in your Friendica directory and set the correct values there
 
 return [
 	'pumpio' => [

--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -320,7 +320,7 @@ function pumpio_settings_post(App $a, array &$b)
 
 function pumpio_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('pumpio'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('pumpio'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function pumpio_hook_fork(App $a, array &$b)

--- a/testdrive/README.md
+++ b/testdrive/README.md
@@ -6,12 +6,14 @@ Testdrive is a Friendica addon which implements automatic account expiration so 
 
 When an account is created on the site, it is given a hard expiration date of
 
-	'testdrive' => [
-		'expiredays' => 30,
-	],
+	return [
+		'testdrive' => [
+			'expiredays' => 30,
+		],
+	];
 
-Set this in your `config/addon.config.php` file to allow a 30 day test drive period.
-By default no expiration period is defined in case the addon is activated accidentally.
+Set this in your `config/testdrive.config.php` file to allow a 30-day test drive period.
+By default, no expiration period is defined in case the addon is activated accidentally.
 
 There is no opportunity to extend an expired account using this addon.
 Expiration is final.

--- a/testdrive/config/testdrive.config.php
+++ b/testdrive/config/testdrive.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/testdrive.config.php in your Friendica directory and set the correct values there
 
 return [
 	'testdrive' => [

--- a/testdrive/testdrive.php
+++ b/testdrive/testdrive.php
@@ -27,7 +27,7 @@ function testdrive_install()
 
 function testdrive_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('testdrive'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('testdrive'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function testdrive_globaldir_update(App $a, array &$b)

--- a/twitter/README.md
+++ b/twitter/README.md
@@ -24,12 +24,14 @@ Open the `config/local.config.php` file and add "twitter" to the list of activat
         ...
     ]
 
-Add your key pair to your global `config/addon.config.php`.
+Add your key pair to your `config/twitter.config.php` file.
 
-	'twitter' => [
-		'consumerkey' => 'your consumer_key here',
-		'consumersecret' => 'your consumer_secret here',
-	],
+	return [
+		'twitter' => [
+			'consumerkey' => 'your consumer_key here',
+			'consumersecret' => 'your consumer_secret here',
+		],
+	];
 
 After this, users can configure their Twitter account settings from "Settings -> Addon Settings".
 

--- a/twitter/config/twitter.config.php
+++ b/twitter/config/twitter.config.php
@@ -1,7 +1,7 @@
 <?php
 
 // Warning: Don't change this file! It only holds the default config values for this addon.
-// Instead overwrite these config values in config/addon.config.php in your Friendica directory
+// Instead, copy this file to config/twitter.config.php in your Friendica directory and set the correct values there
 
 return [
 	'twitter' => [

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -48,12 +48,14 @@
  *     we do not need "Twitter as login". When you've registered the app you get the
  *     OAuth Consumer key and secret pair for your application/site.
  *
- *     Add this key pair to your global config/addon.config.php or use the admin panel.
+ *     Add this key pair to your config/twitter.config.php file or use the admin panel.
  *
- *     	'twitter' => [
- * 		    'consumerkey' => '',
- *  		'consumersecret' => '',
- *      ],
+ *     	return [
+ *          'twitter' => [
+ * 		        'consumerkey' => '',
+ *  		    'consumersecret' => '',
+ *          ],
+ *      ];
  *
  *     To activate the addon itself add it to the system.addon
  *     setting. After this, your user can configure their Twitter account settings

--- a/twitter/twitter.php
+++ b/twitter/twitter.php
@@ -125,7 +125,7 @@ function twitter_install()
 
 function twitter_load_config(App $a, ConfigFileLoader $loader)
 {
-	$a->getConfigCache()->load($loader->loadAddonConfig('twitter'));
+	$a->getConfigCache()->load($loader->loadAddonConfig('twitter'), \Friendica\Core\Config\ValueObject\Cache::SOURCE_STATIC);
 }
 
 function twitter_check_item_notification(App $a, array &$notification_data)


### PR DESCRIPTION
Fix https://github.com/friendica/friendica/issues/10188

Related to https://github.com/friendica/friendica/pull/12225

This PR adds the correct source to the `load_config` hooks. This should prevent defaults values clobbering custom values. Thanks to @nupplaphil for the hint.

Additionally, it enacts the move to per-addon configuration files in the documentation of individual addons. It is independent from the core PR.