### PR TITLE
fancybox addon v.1.03

### DIFF
--- a/fancybox/CHANGELOG.md
+++ b/fancybox/CHANGELOG.md
@@ -1,3 +1,13 @@
+### Version 1.03
+
+* imgages in body-attach with title / alt attribute get them removed while adding fancy attributes
+* Added fancybox to image inlined in posts. Un-hooked the old lightbox from frio and vier and excahnged that with fancybox hooks.
+* Excluded images in "type-link" divs from being "fancied" as they have no images but pages linked to. 
+
+### Version 1.02
+
+* [MrPetovan](https://github.com/MrPetovan) optimized my noob regular expression code. 
+
 ### Version 1.01
 
 * One gallery for each post

--- a/fancybox/asset/fancybox/fancybox.config.js
+++ b/fancybox/asset/fancybox/fancybox.config.js
@@ -1,3 +1,4 @@
 $(document).ready(function() {
     $.fancybox.defaults.loop = "true";
+    $("body").off("click", ".wall-item-body a img");
 });

--- a/fancybox/asset/fancybox/fancybox.config.js
+++ b/fancybox/asset/fancybox/fancybox.config.js
@@ -1,4 +1,5 @@
 $(document).ready(function() {
     $.fancybox.defaults.loop = "true";
+    // this disables the colorbox hook found in frio/js/modal.js:34
     $("body").off("click", ".wall-item-body a img");
 });

--- a/fancybox/createrelease
+++ b/fancybox/createrelease
@@ -11,7 +11,7 @@ rm $MODULE/dist/*
 # create release for actual version
 zip -r9 $MODULE/dist/release.zip $MODULE/* -x $MODULE/dist/\* -x $MODULE/test/\* $MODULE/createrelease
 
-echo release/release.zip created.
+echo dist/release.zip created.
 
 cd $MODULE
 


### PR DESCRIPTION
This PR removes the lightbox hook out of the addon and replaces all URLs on images inlined in posts with the fancybox hook.
URLs in divs class="type-link" won't be touched, as these URLs have pages not images linked to.

Fix https://github.com/friendica/friendica/issues/12331