### PR TITLE
[pumpio] Cast variable as array before being passed to Logger::info

### DIFF
--- a/pumpio/pumpio.php
+++ b/pumpio/pumpio.php
@@ -123,7 +123,7 @@ function pumpio_registerclient(App $a, $host)
 
 	if ($curl_info['http_code'] == '200') {
 		$values = json_decode($s);
-		Logger::info('pumpio_registerclient: success ', $values);
+		Logger::info('pumpio_registerclient: success ', (array)$values);
 		return $values;
 	}
 	Logger::info('pumpio_registerclient: failed: ', $curl_info);


### PR DESCRIPTION
Fix https://github.com/friendica/friendica/issues/12405