### PR TITLE
Added ALT and TITLE of original IMG to fancybox popup.

### DIFF
--- a/fancybox/CHANGELOG.md
+++ b/fancybox/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Version 1.05
+
+* Added ALT and TITLE of original IMG to fancybox popup.
+
+### Version 1.04
+
+* Update supporting upcoming imnagegrid in posts
+ 
 ### Version 1.03
 
 * imgages in body-attach with title / alt attribute get them removed while adding fancy attributes

--- a/fancybox/asset/fancybox/fancybox.config.js
+++ b/fancybox/asset/fancybox/fancybox.config.js
@@ -2,4 +2,12 @@ $(document).ready(function() {
     $.fancybox.defaults.loop = "true";
     // this disables the colorbox hook found in frio/js/modal.js:34
     $("body").off("click", ".wall-item-body a img");
+
+    // Adds ALT/TITLE text to fancybox
+    $('a[data-fancybox').fancybox({
+        afterLoad : function(instance, current) {
+            current.$image.attr('alt', current.opts.$orig.find('img').attr('alt') );
+            current.$image.attr('title', current.opts.$orig.find('img').attr('title') );
+        }
+    });
 });

--- a/fancybox/fancybox.php
+++ b/fancybox/fancybox.php
@@ -2,7 +2,7 @@
 /**
  * Name: Fancybox
  * Description: Open media attachments of posts into a fancybox overlay.
- * Version: 1.04
+ * Version: 1.05
  * Author: Grischa Brockhaus <grischa@brockha.us>
  */
 


### PR DESCRIPTION
Images having a title and/or alt attribute did not have them anymore when opened in fancybox. Now these attributes are copied to the big version of the image loaded in the popup.

See: https://friendica.mbbit.de/display/b25b9f4f-1763-9f50-4653-fe3097934697
