### PR TITLE
Blockem: set to unsupported

### DIFF
--- a/blockem/blockem.php
+++ b/blockem/blockem.php
@@ -5,6 +5,7 @@
  * Version: 1.0
  * Author: Mike Macgirvin <http://macgirvin.com/profile/mike>
  * Author: Roland Haeder <https://f.haeder.net/roland>
+ * Status: unsupported
  */
 
 use Friendica\App;


### PR DESCRIPTION
Blockem is set to unsupported since there is now a native funcationality to collapse contact content, see PR https://github.com/friendica/friendica/pull/12638