### PR TITLE
[piwik] Short Endpoint option

### DIFF
--- a/piwik/README.md
+++ b/piwik/README.md
@@ -31,7 +31,7 @@ Open the `config/node.config.php` file and add "piwik" to the list of activated 
 		],
 	]
 
-You can change 4 more configuration variables for the addon in the `config/piwik.config.php` file:
+You can change 5 more configuration variables for the addon in the `config/piwik.config.php` file:
 
 	return [
 		'piwik' => [
@@ -39,6 +39,7 @@ You can change 4 more configuration variables for the addon in the `config/piwik
 			'sideid' => 1,
 			'optout' => true,
 			'async' => false,
+			'shortendpoint' => false,
 		],
 	];
 
@@ -50,7 +51,7 @@ Configuration fields
 * The *optout* parameter (true|false) defines whether or not a short notice about the utilization of Piwik will be displayed on every page of your Friendica site (at the bottom of the page with some spacing to the
 other content). Part of the note is a link that allows the visitor to set an _opt-out_ cookie which will prevent visits from that user be tracked by piwik.
 * The *async* parameter (true|false) defines whether or not to use asynchronous tracking so pages load (or appear to load) faster.
-
+* The *shortendpoint* parameter (true|false) defines whether or not to use a short path to the tracking script: "/js/" instead of "/piwik.js".
 Currently the optional notice states the following:
 
 >    This website is tracked using the Piwik analytics tool. If you do not want that your visits are logged this way you can set a cookie to prevent Piwik from tracking further visits of the site (opt-out).

--- a/piwik/config/piwik.config.php
+++ b/piwik/config/piwik.config.php
@@ -25,5 +25,9 @@ return [
 		// async (Boolean)
 		// This defines whether or not to use asynchronous tracking so pages load (or appear to load) faster.
 		'async' => false,
+
+		// shortendpoint (Boolean)
+		// This defines whether or not to use a short path to the tracking script: "/js/" instead of "/piwik.js".
+		'shortendpoint' => false,
 	],
 ];

--- a/piwik/lang/en-gb/messages.po
+++ b/piwik/lang/en-gb/messages.po
@@ -20,13 +20,13 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: piwik.php:94
+#: piwik.php:95
 msgid ""
 "This website is tracked using the <a href='http://www.matomo.org'>Matomo</a>"
 " analytics tool."
 msgstr "This website is tracking, using the <a href='http://www.matomo.org'>Matomo</a> analytics tool."
 
-#: piwik.php:97
+#: piwik.php:98
 #, php-format
 msgid ""
 "If you do not want that your visits are logged in this way you <a "
@@ -34,31 +34,35 @@ msgid ""
 "visits of the site</a> (opt-out)."
 msgstr "If you do not want that your visits logged in this way you <a href='%s'>can set a cookie to prevent Matomo / Piwik from tracking further visits of the site</a> (opt-out)."
 
-#: piwik.php:104
+#: piwik.php:107
 msgid "Save Settings"
 msgstr "Save settings"
 
-#: piwik.php:105
+#: piwik.php:108
 msgid "Matomo (Piwik) Base URL"
 msgstr "Matomo (Piwik) Base URL"
 
-#: piwik.php:105
+#: piwik.php:108
 msgid ""
 "Absolute path to your Matomo (Piwik) installation. (without protocol "
 "(http/s), with trailing slash)"
 msgstr "Absolute path to your Matomo (Piwik) installation. (without protocol (http/s), with trailing slash)"
 
-#: piwik.php:106
+#: piwik.php:109
 msgid "Site ID"
 msgstr "Site ID"
 
-#: piwik.php:107
+#: piwik.php:110
 msgid "Show opt-out cookie link?"
 msgstr "Show opt-out cookie link?"
 
-#: piwik.php:108
+#: piwik.php:111
 msgid "Asynchronous tracking"
 msgstr "Asynchronous tracking"
+
+#: piwik.php:112
+msgid "Shortcut path to the script ('/js/' instead of '/piwik.js')"
+msgstr "Shortcut path to the script ('/js/' instead of '/piwik.js')"
 
 #: piwik.php:120
 msgid "Settings updated."

--- a/piwik/lang/en-gb/strings.php
+++ b/piwik/lang/en-gb/strings.php
@@ -14,3 +14,4 @@ $a->strings['Site ID'] = 'Site ID';
 $a->strings['Show opt-out cookie link?'] = 'Show opt-out cookie link?';
 $a->strings['Asynchronous tracking'] = 'Asynchronous tracking';
 $a->strings['Settings updated.'] = 'Settings updated.';
+$a->strings["Shortcut path to the script ('/js/' instead of '/piwik.js')"] = "Shortcut path to the script ('/js/' instead of '/piwik.js')";

--- a/piwik/lang/ru/strings.php
+++ b/piwik/lang/ru/strings.php
@@ -9,3 +9,4 @@ $a->strings["Site ID"] = "ID сайта";
 $a->strings["Show opt-out cookie link?"] = "Показать ссылку opt-out cookie?";
 $a->strings["Asynchronous tracking"] = "Асинхронное отслеживание";
 $a->strings["Settings updated."] = "Настройки обновлены.";
+$a->strings["Shortcut path to the script ('/js/' instead of '/piwik.js')"] = "Сокращенный путь к скрипту ('/js/' вместо '/piwik.js')";

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -84,7 +84,7 @@ function piwik_analytics(string &$b)
 	$b .= "<!-- Piwik --> <script type=\"text/javascript\"> var _paq = _paq || []; _paq.push(['trackPageView']); _paq.push(['enableLinkTracking']); (function() { var u=((\"https:\" == document.location.protocol) ? \"https\" : \"http\") + \"://$baseurl\"; _paq.push(['setTrackerUrl', u+'$scriptPhpEndpoint']); _paq.push(['setSiteId', $siteid]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=$scriptAsyncValue; g.src=u+'$scriptJsEndpoint'; s.parentNode.insertBefore(g,s); })(); </script> <!-- End Piwik Code -->\r\n";
 
 	if ($async) {
-		$b .= "<div id='piwik-code-block'> <!-- Piwik -->\r\n<noscript><p><img src=\"//".$baseurl."$scriptPhpEndpoint?idsite=".$siteid."\" style=\"border:0\" alt=\"\" /></p></noscript>\r\n <!-- End Piwik Tracking Tag --> </div>";
+		$b .= "<div id='piwik-code-block'> <!-- Piwik -->\r\n<noscript><p><img src=\"//$baseurl$scriptPhpEndpoint?idsite=$siteid\" style=\"border:0\" alt=\"\" /></p></noscript>\r\n <!-- End Piwik Tracking Tag --> </div>";
 	}
 
 	/*

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -81,7 +81,7 @@ function piwik_analytics(string &$b)
 	$scriptPhpEndpoint = $shortendpoint ? 'js/' : 'piwik.php';
 	$scriptJsEndpoint = $shortendpoint ? 'js/' : 'piwik.js';
 
-	$b .= "<!-- Piwik --> <script type=\"text/javascript\"> var _paq = _paq || []; _paq.push(['trackPageView']); _paq.push(['enableLinkTracking']); (function() { var u=((\"https:\" == document.location.protocol) ? \"https\" : \"http\") + \"://".$baseurl."\"; _paq.push(['setTrackerUrl', u+'$scriptPhpEndpoint']); _paq.push(['setSiteId', ".$siteid."]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=$scriptAsyncValue; g.src=u+'$scriptJsEndpoint'; s.parentNode.insertBefore(g,s); })(); </script> <!-- End Piwik Code -->\r\n";
+	$b .= "<!-- Piwik --> <script type=\"text/javascript\"> var _paq = _paq || []; _paq.push(['trackPageView']); _paq.push(['enableLinkTracking']); (function() { var u=((\"https:\" == document.location.protocol) ? \"https\" : \"http\") + \"://$baseurl\"; _paq.push(['setTrackerUrl', u+'$scriptPhpEndpoint']); _paq.push(['setSiteId', $siteid]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=$scriptAsyncValue; g.src=u+'$scriptJsEndpoint'; s.parentNode.insertBefore(g,s); })(); </script> <!-- End Piwik Code -->\r\n";
 
 	if ($async) {
 		$b .= "<div id='piwik-code-block'> <!-- Piwik -->\r\n<noscript><p><img src=\"//".$baseurl."$scriptPhpEndpoint?idsite=".$siteid."\" style=\"border:0\" alt=\"\" /></p></noscript>\r\n <!-- End Piwik Tracking Tag --> </div>";

--- a/piwik/piwik.php
+++ b/piwik/piwik.php
@@ -25,6 +25,7 @@
  *              'sideid' => '',
  *              'optout' => true,
  *              'async' => false,
+ *				'shortendpoint' => false,
  *          ],
  *      ];
  *
@@ -69,16 +70,21 @@ function piwik_analytics(string &$b)
 	$siteid  = DI::config()->get('piwik', 'siteid');
 	$optout  = DI::config()->get('piwik', 'optout');
 	$async   = DI::config()->get('piwik', 'async');
+	$shortendpoint = DI::config()->get('piwik', 'shortendpoint');
 
 	/*
 	 *   Add the Piwik tracking code for the site.
 	 *   If async is set to true use asynchronous tracking
 	 */
+	
+	$scriptAsyncValue = $async ? 'true' : 'false';
+	$scriptPhpEndpoint = $shortendpoint ? 'js/' : 'piwik.php';
+	$scriptJsEndpoint = $shortendpoint ? 'js/' : 'piwik.js';
+
+	$b .= "<!-- Piwik --> <script type=\"text/javascript\"> var _paq = _paq || []; _paq.push(['trackPageView']); _paq.push(['enableLinkTracking']); (function() { var u=((\"https:\" == document.location.protocol) ? \"https\" : \"http\") + \"://".$baseurl."\"; _paq.push(['setTrackerUrl', u+'$scriptPhpEndpoint']); _paq.push(['setSiteId', ".$siteid."]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=$scriptAsyncValue; g.src=u+'$scriptJsEndpoint'; s.parentNode.insertBefore(g,s); })(); </script> <!-- End Piwik Code -->\r\n";
+
 	if ($async) {
-	  $b .= "<!-- Piwik --> <script type=\"text/javascript\"> var _paq = _paq || []; _paq.push(['trackPageView']); _paq.push(['enableLinkTracking']); (function() { var u=((\"https:\" == document.location.protocol) ? \"https\" : \"http\") + \"://".$baseurl."\"; _paq.push(['setTrackerUrl', u+'piwik.php']); _paq.push(['setSiteId', ".$siteid."]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s); })(); </script> <!-- End Piwik Code -->\r\n";
-	  $b .= "<div id='piwik-code-block'> <!-- Piwik -->\r\n<noscript><p><img src=\"//".$baseurl."piwik.php?idsite=".$siteid."\" style=\"border:0\" alt=\"\" /></p></noscript>\r\n <!-- End Piwik Tracking Tag --> </div>";
-	} else {
-	  $b .= "<!-- Piwik --> <script type=\"text/javascript\"> var _paq = _paq || []; _paq.push(['trackPageView']); _paq.push(['enableLinkTracking']); (function() { var u=((\"https:\" == document.location.protocol) ? \"https\" : \"http\") + \"://".$baseurl."\"; _paq.push(['setTrackerUrl', u+'piwik.php']); _paq.push(['setSiteId', ".$siteid."]); var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.defer=true; g.async=false; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s); })(); </script> <!-- End Piwik Code -->\r\n";
+		$b .= "<div id='piwik-code-block'> <!-- Piwik -->\r\n<noscript><p><img src=\"//".$baseurl."$scriptPhpEndpoint?idsite=".$siteid."\" style=\"border:0\" alt=\"\" /></p></noscript>\r\n <!-- End Piwik Tracking Tag --> </div>";
 	}
 
 	/*
@@ -104,6 +110,7 @@ function piwik_addon_admin (string &$o)
 		'$siteid' => ['siteid', DI::l10n()->t('Site ID'), DI::config()->get('piwik','siteid' ), ''],
 		'$optout' => ['optout', DI::l10n()->t('Show opt-out cookie link?'), DI::config()->get('piwik','optout' ), ''],
 		'$async' => ['async', DI::l10n()->t('Asynchronous tracking'), DI::config()->get('piwik','async' ), ''],
+		'$shortendpoint' => ['shortendpoint', DI::l10n()->t("Shortcut path to the script ('/js/' instead of '/piwik.js')"), DI::config()->get('piwik','shortendpoint' ), ''],
 	]);
 }
 
@@ -113,4 +120,5 @@ function piwik_addon_admin_post()
 	DI::config()->set('piwik', 'siteid', trim($_POST['siteid'] ?? ''));
 	DI::config()->set('piwik', 'optout', trim($_POST['optout'] ?? ''));
 	DI::config()->set('piwik', 'async', trim($_POST['async'] ?? ''));
+	DI::config()->set('piwik', 'shortendpoint', trim($_POST['shortendpoint'] ?? ''));
 }

--- a/piwik/templates/admin.tpl
+++ b/piwik/templates/admin.tpl
@@ -2,4 +2,5 @@
 {{include file="field_input.tpl" field=$siteid}}
 {{include file="field_checkbox.tpl" field=$optout}}
 {{include file="field_checkbox.tpl" field=$async}}
+{{include file="field_checkbox.tpl" field=$shortendpoint}}
 <div class="submit"><input type="submit" name="page_site" value="{{$submit}}" /></div>


### PR DESCRIPTION
Added setting for short endpoint.
If you are concerned about the impact of browser-based privacy filters which attempt to block tracking, you can change your tracking code to use "js/" instead of "piwik.js" and "piwik.php", respectively.

link to the description of this functionality:
https://github.com/lipis/piwik/blob/master/js/README.md

Support for this option exists in current versions of piwik and matomo.