### PR TITLE
fix: tweak z-index to not clash with sidebar on mobile

### DIFF
--- a/showmore_dyn/showmore_dyn.css
+++ b/showmore_dyn/showmore_dyn.css
@@ -7,7 +7,7 @@
 	position: absolute;
 	top: auto;
 	bottom: 0;
-	z-index: 11;
+	z-index: 9;
 	left: 0;
 	display: none;
 }


### PR DESCRIPTION
By default, the z-index of the toggle button is above the z-index of the sidebar on mobile devices. This fix tweaks the z-index so that it remains below the sidebar while it's open.