### PR TITLE
Add relatica user agent type to blockbot

### DIFF
--- a/blockbot/blockbot.php
+++ b/blockbot/blockbot.php
@@ -466,6 +466,7 @@ function blockbot_is_fediverse_client(array $parts): bool
 		'megalodonandroid', 'fedilab', 'mastodonapp', 'toot!', 'intravnews',
 		'pixeldroid', 'greatnews', 'protopage', 'newsfox', 'vienna', 'wp-urldetails', 'husky',
 		'activitypub-go-http-client', 'mobilesafari', 'mastodon-ios', 'mastodonpy', 'techniverse',
+		'relatica',
 	];
 
 	foreach ($parts as $part) {


### PR DESCRIPTION
Adds a user agent string for Relatica to allow access when blockbot is enabled: 'relatica'