### PR TITLE
Remove unused App parameter in securemail addon

### DIFF
--- a/securemail/securemail.php
+++ b/securemail/securemail.php
@@ -82,7 +82,7 @@ function securemail_settings_post(array &$b)
 		DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'securemail', 'enable', $enable);
 
 		if (!empty($_POST['securemail-test'])) {
-			$res = DI::emailer()->send(new SecureTestEmail(DI::app(), DI::config(), DI::pConfig(), DI::baseUrl()));
+			$res = DI::emailer()->send(new SecureTestEmail(DI::config(), DI::pConfig(), DI::baseUrl()));
 
 			// revert to saved value
 			DI::pConfig()->set(DI::userSession()->getLocalUserId(), 'securemail', 'enable', $enable);


### PR DESCRIPTION
In #1351 https://github.com/friendica/friendica-addons/commit/39c654da00e63a58b6a930e7d0e555bfb248b44b in `securemail/SecureTestEmail.php` the requirement for `Friendica\App` in parameter 1 was removed, but this calls was left over.

I noticed while working on https://github.com/friendica/friendica/pull/14570.