### PR TITLE
Remove unused parameter in saml addon

### DIFF
--- a/saml/saml.php
+++ b/saml/saml.php
@@ -161,7 +161,7 @@ function saml_sso_reply()
 	}
 
 	if (!empty($user['uid'])) {
-		DI::auth()->setForUser(DI::app(), $user);
+		DI::auth()->setForUser($user);
 	}
 
 	if (isset($_POST['RelayState']) && Utils::getSelfURL() != $_POST['RelayState']) {


### PR DESCRIPTION
The requirement for `Friendica\App` as first parameter in `Friendica\Security\Authentication::setForUser()` was removed in https://github.com/friendica/friendica/pull/14542 and must be removed in the saml addond as well.