### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in irc addon

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Unsanitized User Input in Heredoc Output (XSS)
+**Vulnerability:** Found unescaped user input `$_GET['channels']` embedded directly into a string literal representing HTML via Heredoc (`<<< EOT`) in `irc/irc.php`.
+**Learning:** Even simple variable concatenation in Heredoc strings bypasses template engine auto-escaping protections, leaving the application vulnerable to XSS if input comes from external sources like query parameters.
+**Prevention:** Always use appropriate sanitization functions (like `htmlspecialchars` for HTML attributes and `urlencode` for URLs) when generating HTML natively without a template engine.

--- a/irc/irc.php
+++ b/irc/irc.php
@@ -82,7 +82,7 @@ function irc_content()
 		if (!$sitechats) {
 			$sitechats = DI::config()->get('irc', 'sitechats');
 		}
-		$usernick = "nick=" . DI::userSession()->getLocalUserNickname() . "&";
+		$usernick = "nick=" . urlencode(DI::userSession()->getLocalUserNickname()) . "&";
 	} else {
 		$sitechats = DI::config()->get('irc','sitechats');
 	}
@@ -96,7 +96,7 @@ function irc_content()
 
 	DI::page()['aside'] .= '<div class="widget"><h3>' . DI::l10n()->t('Popular Channels') . '</h3><ul>';
 	foreach ($chats as $chat) {
-		DI::page()['aside'] .= '<li><a href="' . DI::baseUrl() . '/irc?channels=' . $chat . '" >' . '#' . $chat . '</a></li>';
+		DI::page()['aside'] .= '<li><a href="' . DI::baseUrl() . '/irc?channels=' . urlencode($chat) . '" >' . '#' . htmlspecialchars($chat, ENT_QUOTES, 'UTF-8') . '</a></li>';
 	}
 	DI::page()['aside'] .= '</ul></div>';
 
@@ -114,6 +114,8 @@ function irc_content()
 	} else {
 		$channels = ($_GET['channels'] ?? '') ?: 'friendica';
 	}
+
+	$channels = htmlspecialchars($channels, ENT_QUOTES, 'UTF-8');
 
 /* add the chatroom frame and some html */
   $o .= <<< EOT


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unsanitized user input $_GET['channels'] was directly embedded into the src attribute of an iframe, allowing attackers to escape the attribute and inject malicious HTML/JavaScript (XSS).
🎯 Impact: Attackers could execute arbitrary scripts in the context of the user's browser, potentially leading to session hijacking or unauthorized actions.
🔧 Fix: Sanitized $channels using htmlspecialchars(..., ENT_QUOTES, 'UTF-8') before using it in the HTML. Additionally applied urlencode to $usernick and popular channels to ensure properly formatted URLs.
✅ Verification: The channel query parameter is now correctly encoded in the HTML output, preventing attribute injection.

Generated by jules.google.com