### PR TITLE
Fix path traversal vulnerability in js_upload file name processing

### DIFF
--- a/js_upload/js_upload.php
+++ b/js_upload/js_upload.php
@@ -138,7 +138,7 @@ class js_upload_qqUploadedFileXhr
 
 	function getName()
 	{
-		return $_GET['qqfile'];
+		return basename($_GET['qqfile']);
 	}
 
 	function getSize()
@@ -173,7 +173,7 @@ class js_upload_qqUploadedFileForm
 
 	function getName()
 	{
-		return $_FILES['qqfile']['name'];
+		return basename($_FILES['qqfile']['name']);
 	}
 
 	function getSize()


### PR DESCRIPTION
Replaced direct use of `$_GET['qqfile']` and `$_FILES['qqfile']['name']` with `basename()` in `js_upload_qqUploadedFileXhr` and `js_upload_qqUploadedFileForm` to prevent directory traversal payloads.